### PR TITLE
Add repo mirroring

### DIFF
--- a/assets/misc/registries.yaml
+++ b/assets/misc/registries.yaml
@@ -1,0 +1,10 @@
+mirrors:
+  registry1.dso.mil:
+    endpoint:
+      - "http://zarf.localhost"
+  docker.io:
+    endpoint:
+      - "http://zarf.localhost"
+  registry-1.docker.io:
+    endpoint:
+      - "http://zarf.localhost"

--- a/assets/misc/registries.yaml
+++ b/assets/misc/registries.yaml
@@ -1,10 +1,13 @@
 mirrors:
+  registry.dso.mil:
+    endpoint:
+      - "https://zarf.localhost"
   registry1.dso.mil:
     endpoint:
-      - "http://zarf.localhost"
+      - "https://zarf.localhost"
   docker.io:
     endpoint:
-      - "http://zarf.localhost"
+      - "https://zarf.localhost"
   registry-1.docker.io:
     endpoint:
-      - "http://zarf.localhost"
+      - "https://zarf.localhost"

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -13,6 +13,8 @@ local:
       executable: true
     - source: assets/scripts/k3s.service
       target: "/etc/systemd/system/k3s.service"
+    - source: assets/misc/registries.yaml
+      target: "/etc/rancher/k3s/registries.yaml"
 
   images:
     # K3s images


### PR DESCRIPTION
Add file /etc/rancher/k3s/registries.yaml to init package which will tell k3s to automatically use `zarf.localhost` as a registry mirror for various remote registries