### PR TITLE
Add resource requests and limits to Utility Cluster deployments

### DIFF
--- a/assets/manifests/utility/gitea.yaml
+++ b/assets/manifests/utility/gitea.yaml
@@ -23,7 +23,6 @@ spec:
                 name: stuart-gitea-http
                 port:
                   number: 3000
-
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -51,7 +50,7 @@ spec:
         server:
           DISABLE_SSH: true
           OFFLINE_MODE: true
-        database: 
+        database:
           DB_TYPE: sqlite3
           # Note that the init script checks to see if the IP & port of the database service is accessible, so make sure you set those to something that resolves as successful (since sqlite uses files on disk setting the port & ip won't affect the running of gitea).
           HOST: kevin-docker-registry.registry.svc.cluster.local:5000
@@ -62,8 +61,14 @@ spec:
         repository:
           ENABLE_PUSH_CREATE_USER: true
           FORCE_PRIVATE: true
-
       database:
         builtIn:
           postgresql:
             enabled: false
+    resources:
+      requests:
+        cpu: "200m"
+        memory: "512Mi"
+      limits:
+        cpu: "1"
+        memory: "2Gi"

--- a/assets/manifests/utility/registry.yaml
+++ b/assets/manifests/utility/registry.yaml
@@ -38,3 +38,10 @@ spec:
     image:
       repository: registry1.dso.mil/ironbank/opensource/docker/registry-v2
       pullPolicy: Never
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "512Mi"
+      limits:
+        cpu: "1"
+        memory: "2Gi"


### PR DESCRIPTION
## What/Why

- Add resource requests and limits to Gitea and the private docker registry because not having them is a finding in `kubescape` and other k8s security tools