### PR TITLE
Implement SHA256SUM validation

### DIFF
--- a/cli/cmd/prepare.go
+++ b/cli/cmd/prepare.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"repo1.dso.mil/platform-one/big-bang/apps/product-tools/zarf/cli/internal/git"
+	"repo1.dso.mil/platform-one/big-bang/apps/product-tools/zarf/cli/internal/utils"
 )
 
 var prepareCmd = &cobra.Command{
@@ -49,7 +51,23 @@ var prepareTransformGitLinks = &cobra.Command{
 	},
 }
 
+var prepareComputeFileSha256sum = &cobra.Command{
+	Use:   "sha256sum FILE",
+	Short: "Generate a SHA256SUM for the given file",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		fileName := args[0]
+		hash, err := utils.GetSha256Sum(fileName)
+		if err != nil {
+			logrus.Fatal("Unable to compute the hash")
+		} else {
+			fmt.Println(hash)
+		}
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(prepareCmd)
 	prepareCmd.AddCommand(prepareTransformGitLinks)
+	prepareCmd.AddCommand(prepareComputeFileSha256sum)
 }

--- a/cli/internal/packager/create.go
+++ b/cli/internal/packager/create.go
@@ -112,6 +112,12 @@ func addLocalAssets(tempPath tempPaths, assets config.ZarfFeature) {
 			} else {
 				utils.CreatePathAndCopy(file.Source, destinationFile)
 			}
+
+			// Abort packaging on invalid shasum (if one is specified)
+			if file.Shasum != "" {
+				utils.ValidateSha256Sum(file.Shasum, destinationFile)
+			}
+
 			if file.Executable {
 				_ = os.Chmod(destinationFile, 0700)
 			} else {

--- a/cli/internal/packager/deploy.go
+++ b/cli/internal/packager/deploy.go
@@ -149,6 +149,10 @@ func deployLocalAssets(tempPath tempPaths, assets config.ZarfFeature) {
 		logrus.Info("Loading files for local install")
 		for index, file := range assets.Files {
 			sourceFile := tempPath.localFiles + "/" + strconv.Itoa(index)
+			// If a shasum is specified check it again on deployment as well
+			if file.Shasum != "" {
+				utils.ValidateSha256Sum(file.Shasum, sourceFile)
+			}
 			err := copy.Copy(sourceFile, file.Target)
 			if err != nil {
 				logrus.WithField("file", file.Target).Fatal("Unable to copy the contents of the asset")

--- a/cli/internal/utils/shasum.go
+++ b/cli/internal/utils/shasum.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+func ValidateSha256Sum(expectedChecksum string, path string) {
+	actualChecksum, _ := GetSha256Sum(path)
+	if expectedChecksum != actualChecksum {
+		logrus.WithFields(logrus.Fields{
+			"Source":   path,
+			"Expected": expectedChecksum,
+			"Actual":   actualChecksum,
+		}).Fatal("Invalid or mismatched file checksum")
+	}
+}
+
+// GetSha256Sum returns the computed SHA256 Sum of a given file
+func GetSha256Sum(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	_, err = io.Copy(hash, file)
+
+	if err != nil {
+		return "", err
+	} else {
+		computedHash := hex.EncodeToString(hash.Sum(nil))
+		return computedHash, nil
+	}
+}

--- a/e2e.sh
+++ b/e2e.sh
@@ -72,6 +72,17 @@ loadZarfCA() {
     _run "sudo cat zarf-pki/zarf-ca.crt" > zarf-ca.crt
 }
 
+testPrepareCommands() {
+    # Validate working SHASUM computation
+    EXPECTED_SHASUM="61b50898f982d015ed87093ba822de0fe011cec6dd67db39f99d8c56391a6109"
+    _run "echo 'random test data 🦄' > shasum-test-file"
+    ZARF_SHASUM=$(_run "zarf prepare sha256sum shasum-test-file")
+    if [ $EXPECTED_SHASUM != $ZARF_SHASUM ]; then
+        echo -e "${RED}zarf prepare sha256sum failed${NOCOLOR}"
+        exit 1
+    fi
+}
+
 testAPIEndpoints() {
     # Update the CA first
     loadZarfCA
@@ -116,6 +127,8 @@ testGitBasedHelmChart() {
 }
 
 beforeAll
+
+testPrepareCommands
 
 # Get the admin credentials 
 ZARF_PWD=$(_run "sudo zarf tools get-admin-password")


### PR DESCRIPTION
Finally closes #11.  This PR adds a new `zarf prepare sha256sum` command for internally generating hashes.  On package create/deploy the operation will fail if a SHASUM is specified but does not match the computed result.  Added a single E2E for the prepare command, the other code is already covered by other E2E tests.

<img width="1687" alt="Screen Shot 2021-09-26 at 7 33 28 PM" src="https://user-images.githubusercontent.com/882485/134832761-e6114ce0-cce3-4c3a-bc7f-d60d4d4c9a6c.png">

<img width="1009" alt="Screen Shot 2021-09-26 at 8 03 42 PM" src="https://user-images.githubusercontent.com/882485/134831412-362a984f-671e-495e-8cbe-d7b1f1bc395a.png">
  