### PR TITLE
Upgrade Big Bang Core example to BB v1.17.0

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -16,8 +16,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.network "forwarded_port", guest: 443, host: 8443
-  config.vm.network "forwarded_port", guest: 8080, host: 9080
-  config.vm.network "forwarded_port", guest: 8443, host: 9443
+  config.vm.network "forwarded_port", guest: 9080, host: 9080
+  config.vm.network "forwarded_port", guest: 9443, host: 9443
 
   config.ssh.insert_key = false
 

--- a/examples/big-bang/README.md
+++ b/examples/big-bang/README.md
@@ -29,6 +29,14 @@ This example adds the `kubescape` binary, which can scan clusters for compliance
 kubescape scan framework nsa --use-from /usr/local/bin/kubescape-framework-nsa.json
 ```
 
-## To-Do
+## Services
 
-1. Re-enable the NetworkPolicies - They got disabled to resolve an issue connecting to the k8s cluster API server, which is fine for a demo but unacceptable in production
+| URL                                                   | Username  | Password                                                                                                                                                                                   | Notes                                                               |
+| ----------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| [AlertManager](https://alertmanager.bigbang.dev:9443) | n/a       | n/a                                                                                                                                                                                        | Unauthenticated                                                     |
+| [Grafana](https://grafana.bigbang.dev:9443)           | `admin`   | `prom-operator`                                                                                                                                                                            |                                                                     |
+| [Kiali](https://kiali.bigbang.dev:9443)               | n/a       | `kubectl get secret -n kiali -o=json \| jq -r '.items[] \| select(.metadata.annotations."kubernetes.io/service-account.name"=="kiali-service-account") \| .data.token' \| base64 -d; echo` |                                                                     |
+| [Kibana](https://kibana.bigbang.dev:9443)             | `elastic` | `kubectl get secret -n logging logging-ek-es-elastic-user -o=jsonpath='{.data.elastic}' \| base64 -d; echo`                                                                                |                                                                     |
+| [Prometheus](https://prometheus.bigbang.dev:9443)     | n/a       | n/a                                                                                                                                                                                        | Unauthenticated                                                     |
+| [Jaeger](https://tracing.bigbang.dev:9443)            | n/a       | n/a                                                                                                                                                                                        | Unauthenticated                                                     |
+| [Twistlock](https://twistlock.bigbang.dev:9443)       | n/a       | n/a                                                                                                                                                                                        | Twistlock has you create an admin account the first time you log in |

--- a/examples/big-bang/README.md
+++ b/examples/big-bang/README.md
@@ -18,8 +18,9 @@ Because the same cluster will be running both Traefik and Istio, Istio's Virtual
 8. Wait a bit, run `k9s` to see pods come up. Don't move on until everything is running
 9. Run: `./zarf package deploy zarf-package-big-bang-core-demo.tar.zst --confirm` - Deploy Big Bang Core
 10. Wait several minutes. Run `k9s` to watch progress
-11. Use a browser to visit the various services, available at https://*.bigbang.dev:9443
-12. When you're done, run `make vm-destroy` to bring everything down
+11. :warning: `kubectl delete -n istio-system envoyfilter/misdirected-request` (due to [this bug](https://repo1.dso.mil/platform-one/big-bang/bigbang/-/issues/802))
+12. Use a browser to visit the various services, available at https://*.bigbang.dev:9443
+13. When you're done, run `make vm-destroy` to bring everything down
 
 ## Kubescape scan
 

--- a/examples/big-bang/template/bigbang/kustomization.yaml
+++ b/examples/big-bang/template/bigbang/kustomization.yaml
@@ -1,5 +1,4 @@
 bases:
-#  - git::https://repo1.dso.mil/platform-one/big-bang/bigbang.git/base?ref=1.14.1
   - git::https://repo1.dso.mil/platform-one/big-bang/bigbang.git/base?ref=1.17.0
 
 configMapGenerator:

--- a/examples/big-bang/template/bigbang/kustomization.yaml
+++ b/examples/big-bang/template/bigbang/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
-  - git::https://repo1.dso.mil/platform-one/big-bang/bigbang.git/base?ref=1.14.1
+  - git::https://repo1.dso.mil/platform-one/big-bang/bigbang.git/base?ref=1.17.0
 
 configMapGenerator:
   - name: common

--- a/examples/big-bang/template/bigbang/kustomization.yaml
+++ b/examples/big-bang/template/bigbang/kustomization.yaml
@@ -1,4 +1,5 @@
 bases:
+#  - git::https://repo1.dso.mil/platform-one/big-bang/bigbang.git/base?ref=1.14.1
   - git::https://repo1.dso.mil/platform-one/big-bang/bigbang.git/base?ref=1.17.0
 
 configMapGenerator:

--- a/examples/big-bang/template/bigbang/values.yaml
+++ b/examples/big-bang/template/bigbang/values.yaml
@@ -1,4 +1,4 @@
-hostname: bigbang.dev
+domain: bigbang.dev
 
 git:
   existingSecret: "zarf-git-secret"
@@ -10,98 +10,13 @@ flux:
 
 networkPolicies:
   enabled: true
-  # TODO: Fix this insecure CIDR
-  controlPlaneCidr: 0.0.0.0/0
-
-logging:
-  enabled: true
-  git:
-    repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__elasticsearch-kibana.git
-  values:
-    elasticsearch:
-      master:
-        count: 1
-        persistence:
-          size: "5Gi"
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "2Gi"
-          limits:
-            cpu: "500m"
-            memory: "2Gi"
-      data:
-        count: 1
-        persistence:
-          size: 5Gi
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "2Gi"
-          limits:
-            cpu: "500m"
-            memory: "2Gi"
-    kibana:
-      count: 1
-      resources:
-        requests:
-          memory: "1Gi"
-          cpu: "100m"
-        limits:
-          memory: "1Gi"
-          cpu: "500m"
-
-eckoperator:
-  enabled: true
-  git:
-    repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__eck-operator.git
-
-fluentbit:
-  enabled: true
-  git:
-    repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__fluentbit.git
-  values:
-    securityContext:
-      privileged: true
-    resources:
-      requests:
-        cpu: "100m"
-        memory: "128Mi"
-      limits:
-        cpu: "500m"
-        memory: "128Mi"
-
-istiooperator:
-  enabled: true
-  git:
-    repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__istio-operator.git
-  values:
-    operator:
-      resources:
-        requests:
-          cpu: "100m"
-          memory: "256Mi"
-        limits:
-          cpu: "500m"
-          memory: "256Mi"
+  controlPlaneCidr: "10.0.2.15/32"
+  nodeCidr: "10.0.2.15/32"
 
 istio:
   enabled: true
   git:
     repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__istio-controlplane.git
-  values:
-    istiod:
-      resources:
-        requests:
-          cpu: "100m"
-          memory: "1Gi"
-        limits:
-          cpu: "500m"
-          memory: "1Gi"
-    kiali:
-      dashboard:
-        auth:
-          strategy: "anonymous"
   ingressGateways:
     public-ingressgateway:
       type: "LoadBalancer"
@@ -259,6 +174,90 @@ istio:
           he8Y4IWS6wY7bCkjCWDcRQJMEhg76fsO3txE+FiYruq9RUWhiF1myv4Q6W+CyBFC
           Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5
           -----END CERTIFICATE-----
+  values:
+    istiod:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "1Gi"
+        limits:
+          cpu: "500m"
+          memory: "1Gi"
+    kiali:
+      dashboard:
+        auth:
+          strategy: "anonymous"
+
+istiooperator:
+  enabled: true
+  git:
+    repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__istio-operator.git
+  values:
+    operator:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "256Mi"
+        limits:
+          cpu: "500m"
+          memory: "256Mi"
+
+jaeger:
+  enabled: true
+  git:
+    repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__jaeger.git
+  values:
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "500m"
+        memory: "128Mi"
+    jaeger:
+      spec:
+        allInOne:
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "128Mi"
+        collector:
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "128Mi"
+        ingester:
+          # TODO: Remove this once the upstream bug is fixed (https://repo1.dso.mil/platform-one/big-bang/apps/core/jaeger/-/issues/15)
+          image: registry1.dso.mil/ironbank/opensource/jaegertracing/jaeger-ingester:1.24.0
+
+kiali:
+  enabled: true
+  git:
+    repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__kiali.git
+  values:
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "256Mi"
+      limits:
+        cpu: "500m"
+        memory: "256Mi"
+    cr:
+      spec:
+        deployment:
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "368Mi"
+            limits:
+              cpu: "500m"
+              memory: "368Mi"
 
 clusterAuditor:
   enabled: true
@@ -272,6 +271,87 @@ clusterAuditor:
       limits:
         cpu: "500m"
         memory: "512Mi"
+
+gatekeeper:
+  enabled: true
+  git:
+    repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__policy.git
+  values:
+    replicas: 1
+    controllerManager:
+      resources:
+        requests:
+          cpu: "175m"
+          memory: "512Mi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+    audit:
+      resources:
+        requests:
+          cpu: "200m"
+          memory: "768Mi"
+        limits:
+          cpu: "1.2"
+          memory: "2Gi"
+
+logging:
+  enabled: true
+  git:
+    repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__elasticsearch-kibana.git
+  values:
+    elasticsearch:
+      master:
+        count: 1
+        persistence:
+          size: "5Gi"
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "3Gi"
+          limits:
+            cpu: "500m"
+            memory: "3Gi"
+      data:
+        count: 1
+        persistence:
+          size: 5Gi
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "3Gi"
+          limits:
+            cpu: "500m"
+            memory: "3Gi"
+    kibana:
+      count: 1
+      resources:
+        requests:
+          memory: "1Gi"
+          cpu: "100m"
+        limits:
+          memory: "1Gi"
+          cpu: "500m"
+
+eckoperator:
+  enabled: true
+  git:
+    repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__eck-operator.git
+
+fluentbit:
+  enabled: true
+  git:
+    repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__fluentbit.git
+  values:
+    securityContext:
+      privileged: true
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "500m"
+        memory: "128Mi"
 
 monitoring:
   enabled: true
@@ -337,20 +417,6 @@ monitoring:
           cpu: "500m"
           memory: "128Mi"
 
-gatekeeper:
-  enabled: true
-  git:
-    repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__policy.git
-  values:
-    replicas: 1
-    resources:
-      requests:
-        cpu: "100m"
-        memory: "256Mi"
-      limits:
-        cpu: "500m"
-        memory: "256Mi"
-
 twistlock:
   enabled: true
   git:
@@ -366,60 +432,6 @@ twistlock:
       limits:
         cpu: "500m"
         memory: "256Mi"
-
-jaeger:
-  enabled: true
-  git:
-    repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__jaeger.git
-  values:
-    resources:
-      requests:
-        cpu: "100m"
-        memory: "128Mi"
-      limits:
-        cpu: "500m"
-        memory: "128Mi"
-    jaeger:
-      spec:
-        allInOne:
-          resources:
-            requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
-              cpu: "500m"
-              memory: "128Mi"
-        collector:
-          resources:
-            requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
-              cpu: "500m"
-              memory: "128Mi"
-
-kiali:
-  enabled: true
-  git:
-    repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__kiali.git
-  values:
-    resources:
-      requests:
-        cpu: "100m"
-        memory: "256Mi"
-      limits:
-        cpu: "500m"
-        memory: "256Mi"
-    cr:
-      spec:
-        deployment:
-          resources:
-            requests:
-              cpu: "100m"
-              memory: "368Mi"
-            limits:
-              cpu: "500m"
-              memory: "368Mi"
 
 addons:
   argocd:

--- a/examples/big-bang/template/bigbang/values.yaml
+++ b/examples/big-bang/template/bigbang/values.yaml
@@ -13,8 +13,6 @@ networkPolicies:
   enabled: true
   controlPlaneCidr: "0.0.0.0/0"
   nodeCidr: "0.0.0.0/0"
-#  controlPlaneCidr: "10.0.2.15/32"
-#  nodeCidr: "10.0.2.15/32"
 
 istio:
   enabled: true
@@ -34,22 +32,18 @@ istio:
         service:
           ports:
             - name: status-port
-#              nodePort: 31027
               port: 15021
               protocol: TCP
               targetPort: 15021
             - name: http2
-#              nodePort: 30635
               port: 9080
               protocol: TCP
               targetPort: 8080
             - name: https
-#              nodePort: 31821
               port: 9443
               protocol: TCP
               targetPort: 8443
             - name: tls
-#              nodePort: 30889
               port: 15443
               protocol: TCP
               targetPort: 15443

--- a/examples/big-bang/template/bigbang/values.yaml
+++ b/examples/big-bang/template/bigbang/values.yaml
@@ -42,12 +42,12 @@ istio:
 #              nodePort: 30635
               port: 9080
               protocol: TCP
-              targetPort: 9080
+              targetPort: 8080
             - name: https
 #              nodePort: 31821
               port: 9443
               protocol: TCP
-              targetPort: 9443
+              targetPort: 8443
             - name: tls
 #              nodePort: 30889
               port: 15443
@@ -55,10 +55,6 @@ istio:
               targetPort: 15443
   gateways:
     public:
-      port:
-        name: https
-        number: 9443
-        protocol: HTTPS
       tls:
         key: |
           -----BEGIN PRIVATE KEY-----

--- a/examples/big-bang/template/bigbang/values.yaml
+++ b/examples/big-bang/template/bigbang/values.yaml
@@ -1,4 +1,5 @@
 domain: bigbang.dev
+hostname: bigbang.dev
 
 git:
   existingSecret: "zarf-git-secret"
@@ -10,8 +11,10 @@ flux:
 
 networkPolicies:
   enabled: true
-  controlPlaneCidr: "10.0.2.15/32"
-  nodeCidr: "10.0.2.15/32"
+  controlPlaneCidr: "0.0.0.0/0"
+  nodeCidr: "0.0.0.0/0"
+#  controlPlaneCidr: "10.0.2.15/32"
+#  nodeCidr: "10.0.2.15/32"
 
 istio:
   enabled: true
@@ -31,27 +34,31 @@ istio:
         service:
           ports:
             - name: status-port
-              nodePort: 31027
+#              nodePort: 31027
               port: 15021
               protocol: TCP
               targetPort: 15021
             - name: http2
-              nodePort: 30635
-              port: 8080
+#              nodePort: 30635
+              port: 9080
               protocol: TCP
-              targetPort: 8080
+              targetPort: 9080
             - name: https
-              nodePort: 31821
-              port: 8443
+#              nodePort: 31821
+              port: 9443
               protocol: TCP
-              targetPort: 8443
+              targetPort: 9443
             - name: tls
-              nodePort: 30889
+#              nodePort: 30889
               port: 15443
               protocol: TCP
               targetPort: 15443
   gateways:
     public:
+      port:
+        name: https
+        number: 9443
+        protocol: HTTPS
       tls:
         key: |
           -----BEGIN PRIVATE KEY-----
@@ -273,7 +280,7 @@ clusterAuditor:
         memory: "512Mi"
 
 gatekeeper:
-  enabled: true
+  enabled: false
   git:
     repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__policy.git
   values:
@@ -294,6 +301,38 @@ gatekeeper:
         limits:
           cpu: "1.2"
           memory: "2Gi"
+    violations:
+      allowedDockerRegistries:
+        parameters:
+          excludedResources:
+            # K3s kube-system stuff, better than excluding the whole namespace
+            - "kube-system/coredns-.*"
+            - "kube-system/local-path-provisioner-.*"
+            - "kube-system/metrics-server-.*"
+            - "kube-system/svclb-.*"
+            - "kube-system/traefik-.*"
+            # K3s needs these due to how it creates services of type "LoadBalancer"
+            - "istio-system/lb-port-.*"
+            - "istio-system/svclb-.*"
+            # K3s needs this if you are doing K3s-specific "HelmRelease"-type CRDs
+            - ".*/helm-install-.*"
+            - ".*/helm"
+            # TODO: Get Gitea in Iron Bank
+            - "git/stuart-gitea-.*"
+            - "git/gitea"
+            - "git/init"
+      hostNetworking:
+        parameters:
+          excludedResources:
+            # K3s needs these due to how it creates services of type "LoadBalancer"
+            - "istio-system/svclb-.*"
+            - "istio-system/lb-port-.*"
+      httpsOnly:
+        parameters:
+          excludedResources:
+            # TODO: Fix these ingresses
+            - "git/git-ingress"
+            - "registry/registry-ingress"
 
 logging:
   enabled: true

--- a/examples/big-bang/template/bigbang/values.yaml
+++ b/examples/big-bang/template/bigbang/values.yaml
@@ -412,10 +412,10 @@ monitoring:
         resources:
           requests:
             cpu: "100m"
-            memory: "256Mi"
+            memory: "512Mi"
           limits:
             cpu: "500m"
-            memory: "256Mi"
+            memory: "2Gi"
     grafana:
       sidecar:
         resources:

--- a/examples/big-bang/template/bigbang/values.yaml
+++ b/examples/big-bang/template/bigbang/values.yaml
@@ -1,5 +1,4 @@
 domain: bigbang.dev
-hostname: bigbang.dev
 
 git:
   existingSecret: "zarf-git-secret"
@@ -11,8 +10,8 @@ flux:
 
 networkPolicies:
   enabled: true
-  controlPlaneCidr: "0.0.0.0/0"
-  nodeCidr: "0.0.0.0/0"
+  controlPlaneCidr: "10.0.2.15/32"
+  nodeCidr: "10.0.2.15/32"
 
 istio:
   enabled: true
@@ -52,63 +51,63 @@ istio:
       tls:
         key: |
           -----BEGIN PRIVATE KEY-----
-          MIIEwAIBADANBgkqhkiG9w0BAQEFAASCBKowggSmAgEAAoIBAQD1ahjVSH4A+inh
-          YyeVfOMQJhzrtt7OXpcGbSeepDY0lz+opc29BWafqcwZKef12aYMU7CzoyPJCL13
-          gOjn6FbU3h8FNkDZQ0kiZfGWQxHGYoJLB8MdXKyYgcynDCczMFNR/mc7YwF0IMVp
-          iApW/XYg2sv4ouuaBAZI/F7jQVYl1SB18gkk180YxZK9mzetie8V9dCEMkodH1tq
-          +BRzCYbrh3oSX/dL/CXYq/x29nFYTZmMctMc7T9ligS7n/JCBVTsLLGL/BL7E/Ba
-          8g54qDGR78FEW1kgr0dsWVcOWJQdb8JpwCRUUFXYHL5liFGS1IozD+bpFfUvUxNH
-          1sjPo18JAgMBAAECggEBAJRaQ5LC1LDAiQqfhvE94oEDmR4AmOWFlqQi3f1vZPkb
-          qTbIq/skxamk2iUoCPm8TT1MZhfheaNwLiCMg76U29CoSXY8Gq17mD08BPOBrcAQ
-          EpVKpu8b85XpeQ5OMXAnOWbqc/sZWWqa2Nt3ilCVvZAU05KE4gljf20lajLUb0BE
-          S+EOHgiPgbL9Upgb2HvsYjaBkgy6dMIJhH9ybyQqRJPaLceEbu53Krrv4iuZjzLD
-          CIdePYRge9DfvIff0UBlAFPVgahrwJNzZoqhEv9KlvSshE51tfaNv7zzMpoEnq7z
-          XqbisXXq/Pn6MaWiyF/6sYxYZDrAIHI5exmoJAYs4tECgYEA/V9eNpdh70Vzv19l
-          TkpjEklaAgDzSda68TSb5hYLtINI3m3+vVN+rlth5gZN7n8hKjxIBuUI8yERMY8B
-          is5g+qgIqK1jDeRHUJTKo7x+fRgM2vCTcYQgxCC4x2czkG86AifsNaGZ6j2P9y2v
-          lpaozs+ONkADpGwnOu0lsCBxbVUCgYEA9/WaPrhOO/ImKlyFbXnXHZsoRXKuWVKm
-          DRcs7z8LZmPH7n3ikiMZW7CUbKHB3mreL6Xv5gQ/nait2tjYRPT2OfBA+WTQi/kO
-          MwHyuq92J1965WCld3hzGYeJHtB12rVjheRQ3TBeBCFFu3pgEVsgqnVV1gqceBL7
-          edXnu85KSuUCgYEAxbhURvmfPR7PknmZDp1R7oU7LfEb6XUd8PiC5+wwOi9w/9KK
-          RagQZXN+VAh7bC/c656a/nZgo4ocZrYYF/+xAil6iFa1w7NuS12xPFDtzCSmc3vl
-          M2JOR37ZcxH/1ShW9jO9SqTO/VIJNHR8X2E2Xhzt9zvBG+AiRQOms2i92vkCgYEA
-          pZ2AiZXWg0mIXlDvuaBgouCoNEKV2wlN6X5qP94PAjNxLYUdWNhirpAxgqFD+QfO
-          IWsm4a5Cw04P2RVu1hf7gdVLwIeql2MhLcaGVlStiTzHu/8iZbqovgt99Xvsy8jN
-          kXde323XzdBfYAorskv4dIHsdAsgWT7sgoLxxcnSa1UCgYEAh0SDR9xTdNnCRTL8
-          Fz+YyN8EWm4XaiYv4fDu7mBEiAYJFQjfez/ZammSASwfv+sFcE4rCEMED2InlLin
-          73hJO8bDRMI7BEtaYKyEFcCgdNXOyDRfYhLtJllaIiJNbC8m4dW8H7Hq4Av2pTc0
-          dbfd2CfWKgXWqJNl2RCGWIoqDIU=
+          MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDbaLWaC86eG74Z
+          D5JxLJ0X4DpOTZgGeP3oY+oS5S1pE+nZq30LrC6YMQeBLSvJDWpBtvV5x9F88gMz
+          yhU94HgrWH26LBUQIBti+ip6IbS0sAKc6bicw6NBtR2F4BnLGw+mrUniVT8WNrRL
+          C1NkN5shexmTE6XAY9Ak6UpApHVmTiB8xz6hypr4JwqnqQfxDO0+AfaGSHheKo5h
+          xTSgUYULhyA9UaImHU+S/SekwGLRLX1KfcTpnz1+TZiQqShG9vqUB4dAge+imwAs
+          ZTCnI9H3tmz6jWekXQYRUraJUwjEaqqLoSQT5VQmEl518ueeRKKNB/8mi1pylWqN
+          UjedV4A5AgMBAAECggEBAM56xORaljBO9WAKOotNK+1rNBO6jAYTWQeY95CeolSP
+          y/PvobcZa6QICAL16o3DlSqQroTTmf7WllLnq4PWueA43+ETWSMaxAsqWE0laTTd
+          qyfV/8lvhzTv5/+z/TIZnmoCDFT2Wm9iPdudpfXbKp+ghFnYFJVwmVITRbB91InX
+          38LaEvLWFnJ3/DPYursaXerwwrm50d0PCdpa/ceqBCVHlpT3Zc0lT0rYpDVtc9BG
+          3gjbvKwhVUQBDfD3FGEobxhbc5eEH6JEf0PUWKnsU5F0qRKjQnfM19XKbczP+9gY
+          71BDL1sALSZxxJXW865+7GeXKCtxObkcCwYbf8UrS30CgYEA+HSH4ZpuHZ8IKIbs
+          vFaAjsEMkRfZPao8b/g4/JCg4TuOpAdFZUTSPWmdUq3i/J8o9b+e8/bznn9HLHIT
+          qyreSyiRUQRtcniSL1ZUHSzzW9QefYKzPghGYHXQLIBAWt50PDaMfPQ6Sj1NaEPH
+          h3hq4YNYNMQP/QVmfFdiT4xVA6cCgYEA4hJgSc17hh/u84uYAKhg2zSlFG5LlYKc
+          Yb2aFQJhFz2QqGxMeOXyIVDFD6btGcOLtPt4RdsBuCLZZzFBDUlWL7rY9qlL+/+P
+          ERStyHE9gFBDa0KWfvQxHSXIuxN2mkokktiVfaTisi8SWEKRJYp+B8HCa5lSDBti
+          eXcGBK3hWR8CgYBJ+aBPmsR4i1ZJgsrP1M2YM4CDXt9uzdYK3JRTFtjf1vTEf+m4
+          mkIiyORvrphr8ROn//La3sdwhKLzZ8/VYgEnzZ9eyPuxXpbgA0suGKkoyUJ+ykCG
+          Er6pj8p4xYLjy2I+X1t7BNiqLBB1H+Ezw7XHCW1k4I+GHWqDUR1TZAwX9wKBgFhy
+          KAm3wqPuymWuL4HSXlJkflFH9XpA5z22GBowHBwjkfzSofiKvfgayX4eKJTz1Cyy
+          VZO+4yVPPQ8KThEMqBN0Xn3iLkAg87ATDwpkg1M4E6hbHNX+Y1ir96R5MOWcLELn
+          SVUmtSpREDRHltHBJR2TyKSgD2F9NUGgN1KNVKSxAoGARyx7VceWlpdmnr+i26UH
+          B4h6/rL/nY7M2oWgUaj7FeygcfemtO6cV+R1Bl876Q9Dx797hZ4ddGAgxmDFsv8J
+          f6SSzTJBB6IGxt+1ZcxD4uFXUrOVFv00br/Re14bsXQcMwi9kEJF2idbR5E7O2qc
+          qbLlPssjuZS5pDnRa05bEIQ=
           -----END PRIVATE KEY-----
         cert: |
           -----BEGIN CERTIFICATE-----
-          MIIFITCCBAmgAwIBAgISA4QDnwfowfekJU7pBgWPPB3SMA0GCSqGSIb3DQEBCwUA
+          MIIFHzCCBAegAwIBAgISA9KlIFfDVyxZ1/qZXl4HMuIOMA0GCSqGSIb3DQEBCwUA
           MDIxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQswCQYDVQQD
-          EwJSMzAeFw0yMTA2MzAwODQxNDhaFw0yMTA5MjgwODQxNDdaMBgxFjAUBgNVBAMM
-          DSouYmlnYmFuZy5kZXYwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQD1
-          ahjVSH4A+inhYyeVfOMQJhzrtt7OXpcGbSeepDY0lz+opc29BWafqcwZKef12aYM
-          U7CzoyPJCL13gOjn6FbU3h8FNkDZQ0kiZfGWQxHGYoJLB8MdXKyYgcynDCczMFNR
-          /mc7YwF0IMVpiApW/XYg2sv4ouuaBAZI/F7jQVYl1SB18gkk180YxZK9mzetie8V
-          9dCEMkodH1tq+BRzCYbrh3oSX/dL/CXYq/x29nFYTZmMctMc7T9ligS7n/JCBVTs
-          LLGL/BL7E/Ba8g54qDGR78FEW1kgr0dsWVcOWJQdb8JpwCRUUFXYHL5liFGS1Ioz
-          D+bpFfUvUxNH1sjPo18JAgMBAAGjggJJMIICRTAOBgNVHQ8BAf8EBAMCBaAwHQYD
+          EwJSMzAeFw0yMTA5MjcxNDU1MDdaFw0yMTEyMjYxNDU1MDZaMBgxFjAUBgNVBAMM
+          DSouYmlnYmFuZy5kZXYwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDb
+          aLWaC86eG74ZD5JxLJ0X4DpOTZgGeP3oY+oS5S1pE+nZq30LrC6YMQeBLSvJDWpB
+          tvV5x9F88gMzyhU94HgrWH26LBUQIBti+ip6IbS0sAKc6bicw6NBtR2F4BnLGw+m
+          rUniVT8WNrRLC1NkN5shexmTE6XAY9Ak6UpApHVmTiB8xz6hypr4JwqnqQfxDO0+
+          AfaGSHheKo5hxTSgUYULhyA9UaImHU+S/SekwGLRLX1KfcTpnz1+TZiQqShG9vqU
+          B4dAge+imwAsZTCnI9H3tmz6jWekXQYRUraJUwjEaqqLoSQT5VQmEl518ueeRKKN
+          B/8mi1pylWqNUjedV4A5AgMBAAGjggJHMIICQzAOBgNVHQ8BAf8EBAMCBaAwHQYD
           VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwHQYDVR0O
-          BBYEFLKxa8BVwd6HZjzGXLkyXZLww/DwMB8GA1UdIwQYMBaAFBQusxe3WFbLrlAJ
+          BBYEFLUbMi65bMLlINPzTplLjtCHZfa0MB8GA1UdIwQYMBaAFBQusxe3WFbLrlAJ
           QOYfr52LFMLGMFUGCCsGAQUFBwEBBEkwRzAhBggrBgEFBQcwAYYVaHR0cDovL3Iz
           Lm8ubGVuY3Iub3JnMCIGCCsGAQUFBzAChhZodHRwOi8vcjMuaS5sZW5jci5vcmcv
           MBgGA1UdEQQRMA+CDSouYmlnYmFuZy5kZXYwTAYDVR0gBEUwQzAIBgZngQwBAgEw
           NwYLKwYBBAGC3xMBAQEwKDAmBggrBgEFBQcCARYaaHR0cDovL2Nwcy5sZXRzZW5j
-          cnlwdC5vcmcwggEFBgorBgEEAdZ5AgQCBIH2BIHzAPEAdwCUILwejtWNbIhzH4KL
-          IiwN0dpNXmxPlD1h204vWE2iwgAAAXpcS8iTAAAEAwBIMEYCIQCcXRHwJqXD4XZJ
-          69yt9vwm/5d3fV5iEncCsg4XoV8APAIhALuWdIvzfv1qLlS3Yv+DrVf5t2lMGdrL
-          RilySJivVC0QAHYA9lyUL9F3MCIUVBgIMJRWjuNNExkzv98MLyALzE7xZOMAAAF6
-          XEvIqAAABAMARzBFAiEA7mPS3NK7XQQo+GxdVRq0kJX4uV3ELIKbVzPIdpXCmxYC
-          IHfgadCRBTml5nnTd7xpjwRuvRNr/gsyyyIV0Xjao4DIMA0GCSqGSIb3DQEBCwUA
-          A4IBAQBbccxKHBf4FOqHSP3U3+pCrU3Z3zhfTjYVaPP/gI7+rus4m6Jnq/pP21ak
-          RWFJx9Yfp0zYPG33H4b65vvmG2jYzb/sLorHIodSn8O7HD11peWwFzgRLflVQ2Kx
-          yPYdn/yY1BFIZ5cyz1iQNIUghMZVLc1JfqQbuRuodf2si0x7d2CTMV3k0qUvpll9
-          6KstE/OEjLA0jgRmZAq0JBHZjDeYi65LoQWF1XM6Al1p0GvhGC+x//UyYZr/sBOl
-          3FvnSe9NXeAMqeJ6QIrkFFsogPMUoTpJYs47gjMdEl6eOT2uwgchZsHpqrdHVHG6
-          9xxT5njjSqfC0xOqknR0hhhn5Pbu
+          cnlwdC5vcmcwggEDBgorBgEEAdZ5AgQCBIH0BIHxAO8AdQBElGUusO7Or8RAB9io
+          /ijA2uaCvtjLMbU/0zOWtbaBqAAAAXwn948JAAAEAwBGMEQCIBkkdKr6WRtmZYO8
+          kuchAYDxGPaCnU9FYU3BZBpsbJvLAiButEYn4AvTFiZMILymyuuqct/eFjIR9MEE
+          pNotyaD+bQB2AH0+8viP/4hVaCTCwMqeUol5K8UOeAl/LmqXaJl+IvDXAAABfCf3
+          kGUAAAQDAEcwRQIhAOOOX0qpI8xjqARUfU4ErGe8icHORlNHHzP/a6b3XE4ZAiBp
+          fMNh3oihXS1e6EM9Xs8m+9nuCi7rqLNSkCNuwisK7zANBgkqhkiG9w0BAQsFAAOC
+          AQEABMjkLKKxYyL4ZT6BPuOyqC4hnczDYUmZdCCysLu7psCjrZIAlSRxLIWXdWir
+          ogi/Vf+wdPKk38NDar0T9+rfAehuvQjQKCzIKVzr+MGauW0Wytwt63EgLIl2znvX
+          jWEIUwDQkqeFzPMbov8BK8hdLibBSz9nLrT0Zyw9mgRIzslemsi62+AjSNERTCTv
+          qyhinnBHLd3dGLOAXexwXu7ic2ZwCgnSgcli+MWC30QOh6ePJJqgw6OpwvOC9DAV
+          fkvGYFXlgYXnhQeLr0/4tzw3koclRWe/qgjAdAjB03yp1e53b+j9NoOfyobo1MFe
+          nMqEgcgAiA2VuE62Q4HE0Rs5wA==
           -----END CERTIFICATE-----
           -----BEGIN CERTIFICATE-----
           MIIFFjCCAv6gAwIBAgIRAJErCErPDBinU/bWLiWnX1owDQYJKoZIhvcNAQELBQAw
@@ -171,8 +170,12 @@ istio:
           he8Y4IWS6wY7bCkjCWDcRQJMEhg76fsO3txE+FiYruq9RUWhiF1myv4Q6W+CyBFC
           Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5
           -----END CERTIFICATE-----
+
   values:
     istiod:
+      hpaSpec:
+        maxReplicas: 1
+        minReplicas: 1
       resources:
         requests:
           cpu: "100m"
@@ -270,7 +273,7 @@ clusterAuditor:
         memory: "512Mi"
 
 gatekeeper:
-  enabled: false
+  enabled: true
   git:
     repo: http://stuart-gitea-http.git.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__policy.git
   values:
@@ -320,7 +323,7 @@ gatekeeper:
       httpsOnly:
         parameters:
           excludedResources:
-            # TODO: Fix these ingresses
+            # TODO: Fix these ingresses so they don't need to be excluded
             - "git/git-ingress"
             - "registry/registry-ingress"
 

--- a/examples/big-bang/template/flux/kustomization.yaml
+++ b/examples/big-bang/template/flux/kustomization.yaml
@@ -1,2 +1,2 @@
 bases:
-  - git::https://repo1.dso.mil/platform-one/big-bang/bigbang.git/base/flux?ref=tags/1.14.1
+  - git::https://repo1.dso.mil/platform-one/big-bang/bigbang.git/base/flux?ref=tags/1.17.0

--- a/examples/big-bang/zarf.yaml
+++ b/examples/big-bang/zarf.yaml
@@ -40,19 +40,6 @@ remote:
     - https://repo1.dso.mil/platform-one/big-bang/apps/core/monitoring.git@14.0.0-bb.10
     - https://repo1.dso.mil/platform-one/big-bang/apps/security-tools/twistlock.git@0.0.9-bb.0
 
-#    - https://repo1.dso.mil/platform-one/big-bang/bigbang.git@1.14.1
-#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/cluster-auditor.git@0.3.0-bb.5
-#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/policy.git@3.5.1-bb.8
-#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/istio-controlplane.git@1.8.4-bb.6
-#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/istio-operator.git@1.8.4-bb.2
-#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/jaeger.git@2.23.0-bb.1
-#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/kiali.git@1.37.0-bb.0
-#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/eck-operator.git@1.6.0-bb.2
-#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/elasticsearch-kibana.git@0.1.18-bb.0
-#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/fluentbit.git@0.16.1-bb.0
-#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/monitoring.git@14.0.0-bb.3
-#    - https://repo1.dso.mil/platform-one/big-bang/apps/security-tools/twistlock.git@0.0.6-bb.1
-
   images:
     # TODO: Figure out a better way to derive this list.
     # 1. Deploy Big Bang Core using some other method like https://repo1.dso.mil/platform-one/quick-start/big-bang
@@ -119,29 +106,3 @@ remote:
 
     # twistlock
     - registry1.dso.mil/ironbank/twistlock/console/console:21.04.439
-
-#    - registry1.dso.mil/ironbank/cluster-auditor/opa-collector:0.3.2
-#    - registry1.dso.mil/ironbank/elastic/eck-operator/eck-operator:1.6.0
-#    - registry1.dso.mil/ironbank/elastic/elasticsearch/elasticsearch:7.13.4
-#    - registry1.dso.mil/ironbank/elastic/kibana/kibana:7.12.0
-#    - registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:1.10.6
-#    - registry1.dso.mil/ironbank/opensource/coreos/kube-state-metrics:v1.9.8
-#    - registry1.dso.mil/ironbank/opensource/fluent/fluent-bit:1.8.1
-#    - registry1.dso.mil/ironbank/opensource/grafana/grafana:7.5.2
-#    - registry1.dso.mil/ironbank/opensource/istio-1.8/operator:1.8.4
-#    - registry1.dso.mil/ironbank/opensource/istio-1.8/pilot:1.8.4
-#    - registry1.dso.mil/ironbank/opensource/istio-1.8/proxyv2:1.8.4
-#    - registry1.dso.mil/ironbank/opensource/jaegertracing/all-in-one:1.24.0
-#    - registry1.dso.mil/ironbank/opensource/jaegertracing/jaeger-operator:1.24.0
-#    - registry1.dso.mil/ironbank/opensource/jet/kube-webhook-certgen:v1.5.1
-#    - registry1.dso.mil/ironbank/opensource/kiali/kiali-operator:v1.37.0
-#    - registry1.dso.mil/ironbank/opensource/kiali/kiali:v1.37.0
-#    - registry1.dso.mil/ironbank/opensource/kubernetes-1.21/kubectl:v1.21.1
-#    - registry1.dso.mil/ironbank/opensource/openpolicyagent/gatekeeper:v3.5.1
-#    - registry1.dso.mil/ironbank/opensource/prometheus-operator/prometheus-config-reloader:v0.46.0
-#    - registry1.dso.mil/ironbank/opensource/prometheus-operator/prometheus-operator:v0.46.0
-#    - registry1.dso.mil/ironbank/opensource/prometheus/alertmanager:v0.21.0
-#    - registry1.dso.mil/ironbank/opensource/prometheus/node-exporter:v1.0.1
-#    - registry1.dso.mil/ironbank/opensource/prometheus/prometheus:v2.25.0
-#    - registry1.dso.mil/ironbank/twistlock/console/console:21.04.412
-#    - registry1.dso.mil/ironbank/big-bang/base:8.4

--- a/examples/big-bang/zarf.yaml
+++ b/examples/big-bang/zarf.yaml
@@ -25,20 +25,20 @@ local:
 remote:
   # 1. helm template bigbang ./chart |  yq e '. | select(.kind == "GitRepository") | "- " + .spec.url + "@" + .spec.ref.tag' -
   # 2. Add the actual bigbang repo as well
-  # https://repo1.dso.mil/platform-one/big-bang/bigbang/-/tags/1.14.1
+  # https://repo1.dso.mil/platform-one/big-bang/bigbang/-/tags/1.17.0
   repos:
-    - https://repo1.dso.mil/platform-one/big-bang/bigbang.git@1.14.1
-    - https://repo1.dso.mil/platform-one/big-bang/apps/core/cluster-auditor.git@0.3.0-bb.5
-    - https://repo1.dso.mil/platform-one/big-bang/apps/core/policy.git@3.5.1-bb.8
-    - https://repo1.dso.mil/platform-one/big-bang/apps/core/istio-controlplane.git@1.8.4-bb.6
-    - https://repo1.dso.mil/platform-one/big-bang/apps/core/istio-operator.git@1.8.4-bb.2
-    - https://repo1.dso.mil/platform-one/big-bang/apps/core/jaeger.git@2.23.0-bb.1
-    - https://repo1.dso.mil/platform-one/big-bang/apps/core/kiali.git@1.37.0-bb.0
+    - https://repo1.dso.mil/platform-one/big-bang/bigbang.git@1.17.0
+    - https://repo1.dso.mil/platform-one/big-bang/apps/core/cluster-auditor.git@0.3.0-bb.7
+    - https://repo1.dso.mil/platform-one/big-bang/apps/core/policy.git@3.5.2-bb.1
+    - https://repo1.dso.mil/platform-one/big-bang/apps/core/istio-controlplane.git@1.10.4-bb.3
+    - https://repo1.dso.mil/platform-one/big-bang/apps/core/istio-operator.git@1.10.4-bb.1
+    - https://repo1.dso.mil/platform-one/big-bang/apps/core/jaeger.git@2.23.0-bb.2
+    - https://repo1.dso.mil/platform-one/big-bang/apps/core/kiali.git@1.39.0-bb.2
     - https://repo1.dso.mil/platform-one/big-bang/apps/core/eck-operator.git@1.6.0-bb.2
-    - https://repo1.dso.mil/platform-one/big-bang/apps/core/elasticsearch-kibana.git@0.1.18-bb.0
-    - https://repo1.dso.mil/platform-one/big-bang/apps/core/fluentbit.git@0.16.1-bb.0
-    - https://repo1.dso.mil/platform-one/big-bang/apps/core/monitoring.git@14.0.0-bb.3
-    - https://repo1.dso.mil/platform-one/big-bang/apps/security-tools/twistlock.git@0.0.6-bb.1
+    - https://repo1.dso.mil/platform-one/big-bang/apps/core/elasticsearch-kibana.git@0.1.21-bb.0
+    - https://repo1.dso.mil/platform-one/big-bang/apps/core/fluentbit.git@0.16.6-bb.0
+    - https://repo1.dso.mil/platform-one/big-bang/apps/core/monitoring.git@14.0.0-bb.10
+    - https://repo1.dso.mil/platform-one/big-bang/apps/security-tools/twistlock.git@0.0.9-bb.0
 
   images:
     # TODO: Figure out a better way to derive this list.
@@ -46,28 +46,63 @@ remote:
     # 2. kubectl get pods --all-namespaces -o json | jq '.items[].spec.containers[].image' | jq -s 'unique' | yq e -P
     # 3. Move all 'registry1.dso.mil/ironbank/fluxcd' images to the 'local.images' section
     # 4. Add 'docker.io/' to any images that aren't fully qualified (example: rancher/metrics-server -> docker.io/rancher/metrics-server
+    # OR go through each values.yaml file in each git repo specified above and pull out all the images
+
+    # common
+    - registry1.dso.mil/ironbank/big-bang/base:8.4
+
+    # cluster-auditor
     - registry1.dso.mil/ironbank/cluster-auditor/opa-collector:0.3.2
+
+    # policy
+    - registry1.dso.mil/ironbank/opensource/kubernetes-1.21/kubectl:v1.21.1
+    - registry1.dso.mil/ironbank/opensource/openpolicyagent/gatekeeper:v3.5.2
+
+    # istio-controlplane
+    - registry1.dso.mil/ironbank/opensource/istio/istioctl:1.10.4
+    - registry1.dso.mil/ironbank/opensource/istio/install-cni:1.10.4
+    - registry1.dso.mil/ironbank/opensource/istio/proxyv2:1.10.4
+    - registry1.dso.mil/ironbank/opensource/istio/pilot:1.10.4
+
+    # istio-operator
+    - registry1.dso.mil/ironbank/opensource/istio/operator:1.10.4
+
+    # jaeger
+    - registry1.dso.mil/ironbank/opensource/jaegertracing/jaeger-operator:1.24.0
+    - registry1.dso.mil/ironbank/opensource/jaegertracing/jaeger-es-index-cleaner:1.24.0
+    - registry1.dso.mil/ironbank/opensource/jaegertracing/all-in-one:1.24.0
+    - registry1.dso.mil/ironbank/opensource/jaegertracing/jaeger-agent:1.24.0
+    - registry1.dso.mil/ironbank/opensource/jaegertracing/jaeger-ingester:1.24.0
+    - registry1.dso.mil/ironbank/opensource/jaegertracing/jaeger-query:1.24.0
+    - registry1.dso.mil/ironbank/opensource/jaegertracing/jaeger-collector:1.24.0
+
+    # kiali
+    - registry1.dso.mil/ironbank/opensource/kiali/kiali-operator:v1.39.0
+    - registry1.dso.mil/ironbank/opensource/kiali/kiali:v1.39.0
+
+    # eck-operator
     - registry1.dso.mil/ironbank/elastic/eck-operator/eck-operator:1.6.0
-    - registry1.dso.mil/ironbank/elastic/elasticsearch/elasticsearch:7.13.4
+
+    # elasticsearch-kibana
     - registry1.dso.mil/ironbank/elastic/kibana/kibana:7.12.0
+    - registry1.dso.mil/ironbank/elastic/elasticsearch/elasticsearch:7.13.4
+
+    # fluentbit
+    - registry1.dso.mil/ironbank/opensource/fluent/fluent-bit:1.8.6
+
+    # monitoring
+    - registry1.dso.mil/ironbank/opensource/prometheus/alertmanager:v0.21.0
+    - registry1.dso.mil/ironbank/opensource/grafana/grafana:7.5.2
+    - registry1.dso.mil/ironbank/opensource/bats/bats:1.2.1
     - registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:1.10.6
     - registry1.dso.mil/ironbank/opensource/coreos/kube-state-metrics:v1.9.8
-    - registry1.dso.mil/ironbank/opensource/fluent/fluent-bit:1.8.1
-    - registry1.dso.mil/ironbank/opensource/grafana/grafana:7.5.2
-    - registry1.dso.mil/ironbank/opensource/istio-1.8/operator:1.8.4
-    - registry1.dso.mil/ironbank/opensource/istio-1.8/pilot:1.8.4
-    - registry1.dso.mil/ironbank/opensource/istio-1.8/proxyv2:1.8.4
-    - registry1.dso.mil/ironbank/opensource/jaegertracing/all-in-one:1.24.0
-    - registry1.dso.mil/ironbank/opensource/jaegertracing/jaeger-operator:1.24.0
-    - registry1.dso.mil/ironbank/opensource/jet/kube-webhook-certgen:v1.5.1
-    - registry1.dso.mil/ironbank/opensource/kiali/kiali-operator:v1.37.0
-    - registry1.dso.mil/ironbank/opensource/kiali/kiali:v1.37.0
-    - registry1.dso.mil/ironbank/opensource/kubernetes-1.21/kubectl:v1.21.1
-    - registry1.dso.mil/ironbank/opensource/openpolicyagent/gatekeeper:v3.5.1
-    - registry1.dso.mil/ironbank/opensource/prometheus-operator/prometheus-config-reloader:v0.46.0
-    - registry1.dso.mil/ironbank/opensource/prometheus-operator/prometheus-operator:v0.46.0
-    - registry1.dso.mil/ironbank/opensource/prometheus/alertmanager:v0.21.0
     - registry1.dso.mil/ironbank/opensource/prometheus/node-exporter:v1.0.1
+    - registry1.dso.mil/ironbank/opensource/jet/kube-webhook-certgen:v1.5.1
+    - registry1.dso.mil/ironbank/opensource/prometheus-operator/prometheus-operator:v0.46.0
+    - registry1.dso.mil/ironbank/opensource/jimmidyson/configmap-reload:v0.5.0
+    - registry1.dso.mil/ironbank/opensource/prometheus-operator/prometheus-config-reloader:v0.46.0
+    - registry1.dso.mil/ironbank/opensource/kubernetes-1.20/kubectl-1.20:v1.20.8
     - registry1.dso.mil/ironbank/opensource/prometheus/prometheus:v2.25.0
-    - registry1.dso.mil/ironbank/twistlock/console/console:21.04.412
-    - registry1.dso.mil/ironbank/big-bang/base:8.4
+
+    # twistlock
+    - registry1.dso.mil/ironbank/twistlock/console/console:21.04.439

--- a/examples/big-bang/zarf.yaml
+++ b/examples/big-bang/zarf.yaml
@@ -7,12 +7,12 @@ local:
   manifests: manifests
 
   files:
-    - source: https://github.com/armosec/kubescape/releases/download/v1.0.81/kubescape-ubuntu-latest
-      shasum: a1caf4805f6a0e1e4bf0c0549fea7e822f2b7f8999913f8cfdbcb5316843a443
+    - source: https://github.com/armosec/kubescape/releases/download/v1.0.88/kubescape-ubuntu-latest
+      shasum: 615c8ea98e0b87bf54dd027b413248565d60d0ff21b6b158acc600739140851b
       target: "/usr/local/bin/kubescape"
       executable: true
-    - source: https://github.com/armosec/regolibrary/releases/download/v1.0.11/nsa
-      shasum: 52299bd5a2df28b6a6ff9926e09abd0fa5e6c1094f5bb75b036a0452cfc00dfa
+    - source: https://github.com/armosec/regolibrary/releases/download/v1.0.21/nsa
+      shasum: 306292a51a377e33eff448f654bdf5aa9881fecf74f671746106796f569dee44
       target: "/usr/local/bin/kubescape-framework-nsa.json"
 
   images:

--- a/examples/big-bang/zarf.yaml
+++ b/examples/big-bang/zarf.yaml
@@ -40,6 +40,19 @@ remote:
     - https://repo1.dso.mil/platform-one/big-bang/apps/core/monitoring.git@14.0.0-bb.10
     - https://repo1.dso.mil/platform-one/big-bang/apps/security-tools/twistlock.git@0.0.9-bb.0
 
+#    - https://repo1.dso.mil/platform-one/big-bang/bigbang.git@1.14.1
+#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/cluster-auditor.git@0.3.0-bb.5
+#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/policy.git@3.5.1-bb.8
+#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/istio-controlplane.git@1.8.4-bb.6
+#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/istio-operator.git@1.8.4-bb.2
+#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/jaeger.git@2.23.0-bb.1
+#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/kiali.git@1.37.0-bb.0
+#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/eck-operator.git@1.6.0-bb.2
+#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/elasticsearch-kibana.git@0.1.18-bb.0
+#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/fluentbit.git@0.16.1-bb.0
+#    - https://repo1.dso.mil/platform-one/big-bang/apps/core/monitoring.git@14.0.0-bb.3
+#    - https://repo1.dso.mil/platform-one/big-bang/apps/security-tools/twistlock.git@0.0.6-bb.1
+
   images:
     # TODO: Figure out a better way to derive this list.
     # 1. Deploy Big Bang Core using some other method like https://repo1.dso.mil/platform-one/quick-start/big-bang
@@ -106,3 +119,29 @@ remote:
 
     # twistlock
     - registry1.dso.mil/ironbank/twistlock/console/console:21.04.439
+
+#    - registry1.dso.mil/ironbank/cluster-auditor/opa-collector:0.3.2
+#    - registry1.dso.mil/ironbank/elastic/eck-operator/eck-operator:1.6.0
+#    - registry1.dso.mil/ironbank/elastic/elasticsearch/elasticsearch:7.13.4
+#    - registry1.dso.mil/ironbank/elastic/kibana/kibana:7.12.0
+#    - registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:1.10.6
+#    - registry1.dso.mil/ironbank/opensource/coreos/kube-state-metrics:v1.9.8
+#    - registry1.dso.mil/ironbank/opensource/fluent/fluent-bit:1.8.1
+#    - registry1.dso.mil/ironbank/opensource/grafana/grafana:7.5.2
+#    - registry1.dso.mil/ironbank/opensource/istio-1.8/operator:1.8.4
+#    - registry1.dso.mil/ironbank/opensource/istio-1.8/pilot:1.8.4
+#    - registry1.dso.mil/ironbank/opensource/istio-1.8/proxyv2:1.8.4
+#    - registry1.dso.mil/ironbank/opensource/jaegertracing/all-in-one:1.24.0
+#    - registry1.dso.mil/ironbank/opensource/jaegertracing/jaeger-operator:1.24.0
+#    - registry1.dso.mil/ironbank/opensource/jet/kube-webhook-certgen:v1.5.1
+#    - registry1.dso.mil/ironbank/opensource/kiali/kiali-operator:v1.37.0
+#    - registry1.dso.mil/ironbank/opensource/kiali/kiali:v1.37.0
+#    - registry1.dso.mil/ironbank/opensource/kubernetes-1.21/kubectl:v1.21.1
+#    - registry1.dso.mil/ironbank/opensource/openpolicyagent/gatekeeper:v3.5.1
+#    - registry1.dso.mil/ironbank/opensource/prometheus-operator/prometheus-config-reloader:v0.46.0
+#    - registry1.dso.mil/ironbank/opensource/prometheus-operator/prometheus-operator:v0.46.0
+#    - registry1.dso.mil/ironbank/opensource/prometheus/alertmanager:v0.21.0
+#    - registry1.dso.mil/ironbank/opensource/prometheus/node-exporter:v1.0.1
+#    - registry1.dso.mil/ironbank/opensource/prometheus/prometheus:v2.25.0
+#    - registry1.dso.mil/ironbank/twistlock/console/console:21.04.412
+#    - registry1.dso.mil/ironbank/big-bang/base:8.4


### PR DESCRIPTION
## What/Why

- Update Big Bang example to BB v1.17.0
- Misc adjustments
    - Change port forwarding in Vagrantfile to directly forward the 2 new ports rather than expose different ports on the host than are exposed on the guest. From the user's perspective this makes no difference whatsoever but it feels cleaner to me
    - Update examples/big-bang/README.md: Add a table with all the service endpoints, usernames, and passwords, and add a note about needing to delete the `EnvoyFilter` from [this bug](https://repo1.dso.mil/platform-one/big-bang/bigbang/-/issues/802)
    - Update the NetworkPolicies with real a real CIDR
    - Update to the new `bigbang.dev` cert
    - Tweak resources for a better fit on a developer laptop
    - Reorder the YAML blocks in examples/big-bang/template/bigbang/values.yaml so they are in the same order as upstream's values.yaml (makes it easier to compare them)
    - Add a bunch of exclusions to the OPA Gatekeeper policies
    - Update the `kubescape` binary version