### PR TITLE
Add ability to deploy remote packages

### DIFF
--- a/cli/cmd/package.go
+++ b/cli/cmd/package.go
@@ -28,7 +28,7 @@ var packageCreateCmd = &cobra.Command{
 
 var packageDeployCmd = &cobra.Command{
 	Use:   "deploy PACKAGE",
-	Short: "deploys an update package file (runs offline)",
+	Short: "Deploys an update package from a local file or URL (runs offline)",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		packageName := choosePackage(args)

--- a/cli/cmd/package.go
+++ b/cli/cmd/package.go
@@ -12,6 +12,8 @@ import (
 var confirmCreate bool
 var confirmDeploy bool
 var deployComponents string
+var insecureDeploy bool
+var shasum string
 
 var packageCmd = &cobra.Command{
 	Use:   "package",
@@ -32,7 +34,8 @@ var packageDeployCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		packageName := choosePackage(args)
-		packager.Deploy(packageName, confirmDeploy, deployComponents)
+		localPackagePath := packager.HandleIfURL(packageName, shasum, insecureDeploy)
+		packager.Deploy(localPackagePath, confirmDeploy, deployComponents)
 	},
 }
 
@@ -71,4 +74,6 @@ func init() {
 	packageCreateCmd.Flags().BoolVar(&confirmCreate, "confirm", false, "Confirm package creation without prompting")
 	packageDeployCmd.Flags().BoolVar(&confirmDeploy, "confirm", false, "Confirm package deployment without prompting")
 	packageDeployCmd.Flags().StringVar(&deployComponents, "components", "", "Comma-separated list of components to install.  Adding this flag will skip the init prompts for which components to install")
+	packageDeployCmd.Flags().BoolVar(&insecureDeploy, "insecure", false, "Skip shasum validation of remote package. Required if deploying a remote package and `--shasum` is not provided")
+	packageDeployCmd.Flags().StringVar(&shasum, "shasum", "", "Shasum of the package to deploy. Required if deployinga remote package and `--insecure` is not provided")
 }

--- a/cli/cmd/package.go
+++ b/cli/cmd/package.go
@@ -41,7 +41,7 @@ var packageDeployCmd = &cobra.Command{
 
 var packageInspectCmd = &cobra.Command{
 	Use:   "inspect PACKAGE",
-	Short: "lists the paylod of an update package file (runs offline)",
+	Short: "lists the payload of an update package file (runs offline)",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		packageName := choosePackage(args)
@@ -75,5 +75,5 @@ func init() {
 	packageDeployCmd.Flags().BoolVar(&confirmDeploy, "confirm", false, "Confirm package deployment without prompting")
 	packageDeployCmd.Flags().StringVar(&deployComponents, "components", "", "Comma-separated list of components to install.  Adding this flag will skip the init prompts for which components to install")
 	packageDeployCmd.Flags().BoolVar(&insecureDeploy, "insecure", false, "Skip shasum validation of remote package. Required if deploying a remote package and `--shasum` is not provided")
-	packageDeployCmd.Flags().StringVar(&shasum, "shasum", "", "Shasum of the package to deploy. Required if deployinga remote package and `--insecure` is not provided")
+	packageDeployCmd.Flags().StringVar(&shasum, "shasum", "", "Shasum of the package to deploy. Required if deploying a remote package and `--insecure` is not provided")
 }

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -21,7 +21,6 @@ const ZarfLocalIP = "127.0.0.1"
 const ZarfGitUser = "zarf-git-user"
 
 var CLIVersion = "unset"
-var ValidPackageExtensions = [...]string{".tar.zst", ".tar", ".zip"}
 
 var config ZarfConfig
 
@@ -48,6 +47,10 @@ func GetMetaData() ZarfMetatdata {
 
 func GetComponents() []ZarfComponent {
 	return config.Components
+}
+
+func GetValidPackageExtensions() [3]string {
+	return [...]string{".tar.zst", ".tar", ".zip"}
 }
 
 func Load(path string) {

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -20,8 +20,10 @@ const PackagePrefix = "zarf-package-"
 const ZarfLocalIP = "127.0.0.1"
 const ZarfGitUser = "zarf-git-user"
 
-var config ZarfConfig
 var CLIVersion = "unset"
+var ValidPackageExtensions = [...]string{".tar.zst", ".tar", ".zip"}
+
+var config ZarfConfig
 
 func IsZarfInitConfig() bool {
 	return strings.ToLower(config.Kind) == "zarfinitconfig"

--- a/cli/internal/packager/deploy.go
+++ b/cli/internal/packager/deploy.go
@@ -199,7 +199,7 @@ func HandleIfURL(packagePath string, shasum string, insecureDeploy bool) string 
 
 	// Check the extension on the package is what we expect
 	if !isValidFileExtension(providedURL.Path) {
-		logrus.Fatalf("Only %s file extensions are permitted.\n", config.ValidPackageExtensions)
+		logrus.Fatalf("Only %s file extensions are permitted.\n", config.GetValidPackageExtensions)
 	}
 
 	// Download the package
@@ -240,7 +240,7 @@ func HandleIfURL(packagePath string, shasum string, insecureDeploy bool) string 
 }
 
 func isValidFileExtension(filename string) bool {
-	for _, extension := range config.ValidPackageExtensions {
+	for _, extension := range config.GetValidPackageExtensions() {
 		if strings.HasSuffix(filename, extension) {
 			logrus.WithField("packagePath", filename).Warn("Package extension is valid.")
 			return true

--- a/cli/internal/packager/deploy.go
+++ b/cli/internal/packager/deploy.go
@@ -22,8 +22,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var validExtensions = []string{".tar.zst", ".tar", ".zip"}
-
 func Deploy(packagePath string, confirm bool, componentRequest string) {
 	// Prevent disk pressure on smaller systems due to leaking temp files
 	_ = os.RemoveAll("/tmp/zarf*")
@@ -186,7 +184,7 @@ func deployComponents(tempPath componentPaths, assets config.ZarfComponent) {
 	}
 }
 
-// If privded package is a URL download it to a temp directory
+// If provided package is a URL download it to a temp directory
 func HandleIfURL(packagePath string, shasum string, insecureDeploy bool) string {
 	// Check if the user gave us a remote package
 	providedURL, err := url.Parse(packagePath)
@@ -201,7 +199,7 @@ func HandleIfURL(packagePath string, shasum string, insecureDeploy bool) string 
 
 	// Check the extension on the package is what we expect
 	if !isValidFileExtension(providedURL.Path) {
-		logrus.Fatalf("The URL provided (%s) had an unrecognized file extension.\n", providedURL.String())
+		logrus.Fatalf("Only %s file extensions are permitted.\n", config.ValidPackageExtensions)
 	}
 
 	// Download the package
@@ -242,7 +240,7 @@ func HandleIfURL(packagePath string, shasum string, insecureDeploy bool) string 
 }
 
 func isValidFileExtension(filename string) bool {
-	for _, extension := range validExtensions {
+	for _, extension := range config.ValidPackageExtensions {
 		if strings.HasSuffix(filename, extension) {
 			logrus.WithField("packagePath", filename).Warn("Package extension is valid.")
 			return true

--- a/test/e2e/e2e_general_cli_test.go
+++ b/test/e2e/e2e_general_cli_test.go
@@ -2,13 +2,14 @@ package test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/ssh"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	teststructure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestGeneralCli(t *testing.T) {
@@ -91,4 +92,7 @@ func testGeneralCliStuff(t *testing.T, terraformOptions *terraform.Options, keyP
 	require.Error(t, err, output)
 	output, err = ssh.CheckSshCommandE(t, publicHost, fmt.Sprintf("cd /home/%s/build && ./zarf pki regenerate --host some_unique_server", username))
 	require.Error(t, err, output)
+
+	// Test that `zarf package deploy` doesn't die when given a URL
+	output, err = ssh.CheckSshCommandE(t, publicHost, fmt.Sprintf("sudo bash -c 'cd /home/%s/build && ./zarf package deploy https://zarf-examples.s3.amazonaws.com/zarf-package-appliance-demo-doom.tar.zst --confirm'", username))
 }

--- a/test/e2e/e2e_general_cli_test.go
+++ b/test/e2e/e2e_general_cli_test.go
@@ -94,5 +94,12 @@ func testGeneralCliStuff(t *testing.T, terraformOptions *terraform.Options, keyP
 	require.Error(t, err, output)
 
 	// Test that `zarf package deploy` doesn't die when given a URL
+	output, err = ssh.CheckSshCommandE(t, publicHost, fmt.Sprintf("sudo bash -c 'cd /home/%s/build && ./zarf package deploy https://zarf-examples.s3.amazonaws.com/zarf-package-appliance-demo-doom.tar.zst --confirm --insecure'", username))
+	require.NoError(t, err, output)
+	output, err = ssh.CheckSshCommandE(t, publicHost, fmt.Sprintf("sudo bash -c 'cd /home/%s/build && ./zarf package deploy https://zarf-examples.s3.amazonaws.com/zarf-package-appliance-demo-doom.tar.zst --confirm --shasum e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'", username))
+	require.NoError(t, err, output)
+
+	// Test that `zarf package deploy` gives an error if deploying a remote package without the --insecure or --shasum flags
 	output, err = ssh.CheckSshCommandE(t, publicHost, fmt.Sprintf("sudo bash -c 'cd /home/%s/build && ./zarf package deploy https://zarf-examples.s3.amazonaws.com/zarf-package-appliance-demo-doom.tar.zst --confirm'", username))
+	require.Error(t, err, output)
 }


### PR DESCRIPTION
Adding the ability for Zarf to deploy remote packages. This checks if the deployPath given is a URL with a file extension we recognize. If the path is a valid package it gets downloaded to /temp and processed.

This also renames `packageName` to `packagePath` to try to show that the variable is more than just a name and could either be a full path to a file or even a URL to some online resource.

**Potential Issues To Add After Merge:**
- [ ] Add more verification checks on the file being downloaded (in addition to the file extension and sha256 check we're currently doing?)
- [ ] Add credentials to access the url provided, currently we are only able to download packages that are public.
- [ ] Check remote filetype instead of simply checking the file extension.