### PR TITLE
Fix the GitLab release pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ package:
     - packages
   image: golang:1.16
   before_script:
-    - ./build/zarf tools registry login registry1.dso.mil --username "robot\$bb-dev-imagepullonly" --password "$REGISTRY1_PASSWORD"
+    - ./build/zarf tools registry login registry1.dso.mil --username "$REGISTRY1_USERNAME_ZARF_ROBOT" --password "$REGISTRY1_PASSWORD_ZARF_ROBOT"
   script:
     - make ci-release
   after_script:


### PR DESCRIPTION
Fix the GitLab release pipeline by utilizing different secrets (the new Zarf robot account we just got)

I have NOT added these secrets yet to the Zarf repo in Repo1. I will do so after this gets approved but before it gets merged.