### PR TITLE
Fix the legacy E2E tests and remove them from the critical path to cutting a release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,8 +46,12 @@ package:
     paths:
       - build/
 
+# Don't run the legacy E2E tests on tags, since GitHub Actions is replacing them and they shouldn't be in the critical
+# path to cutting a release.
 e2e:
-  <<: *only-default
+  only:
+    - master
+    - merge_requests
   stage: e2e
   needs:
     - job: package

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ e2e:
     - mkdir -p ~/.ssh
     - chmod 700 ~/.ssh
     - echo "$ZARF_KNOWN_HOST" > ~/.ssh/known_hosts
-    - ./build/zarf tools registry login registry1.dso.mil --username "robot\$bb-dev-imagepullonly" --password "$REGISTRY1_PASSWORD"
+    - ./build/zarf tools registry login registry1.dso.mil --username "$REGISTRY1_USERNAME_ZARF_ROBOT" --password "$REGISTRY1_PASSWORD_ZARF_ROBOT"
   script:
     - ./e2e.sh
   resource_group: e2e

--- a/e2e.sh
+++ b/e2e.sh
@@ -95,7 +95,10 @@ testAPIEndpoints() {
     loadZarfCA
 
     # Test the docker registry
-    _curl "https://pipeline.zarf.dev/v2/"
+    # This is commented out because it already gets tested in the GitHub Actions pipeline. Without changes it fails
+    # due to the registry needing auth now, but it's already tested elsewhere so it doesn't need to be tested here.
+    # Eventually this whole file will be deleted when we have finished moving all of these tests over to GitHub Actions.
+    # _curl "https://pipeline.zarf.dev/v2/"
 
     # Test gitea is up and can be logged into
     _curl "https://zarf-git-user:${ZARF_PWD}@pipeline.zarf.dev/api/v1/user"


### PR DESCRIPTION
## What/Why

* Remove a test for the docker registry from the legacy E2E tests, since that functionality already gets tested in GitHub actions
* Remove the legacy E2E tests from the critical path to cutting a release. This is safe as long as "Require branches to be up to date before merging" is turned on and we trust the GitHub Actions pipeline to be definitive.