### PR TITLE
Update build to catch all tags, not just annotated ones

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -6,7 +6,7 @@
 # test: deps
 # 	gotestsum
 
-CLI_VERSION := $(if $(shell git describe), $(shell git describe), "UnknownVersion")
+CLI_VERSION := $(if $(shell git describe --tags), $(shell git describe --tags), "UnknownVersion")
 
 build:
 	mkdir -p ../build


### PR DESCRIPTION
I noticed when testing things today that my `zarf version` was still returning 0.12 even though 0.13 was released and I had the latest changes in master. Turns out 'git describe' only returns the latest annotated tag. When building binaries we want to catch all tags, not just annotated ones.

`git describe --tags` returns the latest tag, annotated or not.