### PR TITLE
Change terraform version

### DIFF
--- a/test/tf/public-ec2-instance/main.tf
+++ b/test/tf/public-ec2-instance/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.13.7"
+  required_version = "1.0.11"
 }
 
 locals {


### PR DESCRIPTION
We are currently using the latest docker image of CloudPosse which updated the version of Terraform which was breaking our e2e tests.


This is a major update of terraform though so hopefully nothing breaks.. Lets find out..