### PR TITLE
filter init host suggestions by hostname validator

### DIFF
--- a/cli/cmd/initialize.go
+++ b/cli/cmd/initialize.go
@@ -114,7 +114,7 @@ func promptAndValidateHost() {
 					for _, iface := range interfaces {
 						// Conver the CIRD to the IP string if valid
 						ip, _, _ := net.ParseCIDR(iface.String())
-						if iface.String() != "" {
+						if utils.ValidHostname(ip.String()) {
 							suggestions = append(suggestions, ip.String())
 						}
 					}


### PR DESCRIPTION
When using the host suggestion list, IPv6 address break the init due to an invalid hostname format.  This is something we 
can look at further down the road but I don't think we're ready to sign up for full IPv6 support today for a number of reasons.  

<img width="1230" alt="Screen Shot 2021-12-14 at 1 02 45 AM" src="https://user-images.githubusercontent.com/882485/145967022-285d4827-fe6c-41bc-897d-cf2673cfea3e.png">

