### PR TITLE
Bug Fix: Fix regexp creation to use a proper string

### DIFF
--- a/cli/internal/packager/create.go
+++ b/cli/internal/packager/create.go
@@ -75,7 +75,7 @@ func addLocalAssets(tempPath componentPaths, assets config.ZarfComponent) {
 	if len(assets.Charts) > 0 {
 		logrus.Info("Loading static helm charts")
 		_ = utils.CreateDirectory(tempPath.charts, 0700)
-		re := regexp.MustCompile(`\\.git$`)
+		re := regexp.MustCompile("\\.git$")
 		for _, chart := range assets.Charts {
 			matched := re.MatchString(chart.Url)
 			if matched {


### PR DESCRIPTION
Without this, the regex will not catch charts provided by git and all charts downloaded as a published chart.

I was trying to build the postgres example package and was getting an error because it was trying to download helm charts as a published helm chart instead of as a chart hosted on a git repo.