### PR TITLE
Fix error handling when building a zarf package with gitops repos that have `@tag` format

### DIFF
--- a/cli/internal/git/checkout.go
+++ b/cli/internal/git/checkout.go
@@ -57,7 +57,11 @@ func checkoutHashAsBranch(path string, hash plumbing.Hash, branch plumbing.Refer
 		logContext.Fatal("Not a valid git repo or unable to open")
 	}
 
-	objRef, _ := repo.Object(plumbing.AnyObject, hash)
+	objRef, err := repo.Object(plumbing.AnyObject, hash)
+	if err != nil {
+		logContext.Debug(err)
+		logContext.Fatal("An error occurred when getting the repo's object reference")
+	}
 
 	var commitHash plumbing.Hash
 	switch objRef := objRef.(type) {

--- a/cli/internal/git/checkout.go
+++ b/cli/internal/git/checkout.go
@@ -57,29 +57,27 @@ func checkoutHashAsBranch(path string, hash plumbing.Hash, branch plumbing.Refer
 		logContext.Fatal("Not a valid git repo or unable to open")
 	}
 
-	objRef, err := repo.Object(plumbing.AnyObject, hash)
+	objRef, _ := repo.Object(plumbing.AnyObject, hash)
 
-	if err != nil {
-		var commitHash plumbing.Hash
-		switch objRef := objRef.(type) {
-		case *object.Tag:
-			commitHash = objRef.Target
-		case *object.Commit:
-			commitHash = objRef.Hash
-		default:
-			// This shouldn't ever hit, but we should at least log it if someday it
-			// does get hit
-			logContext.Debug("Unsupported tag hash type: " + objRef.Type().String())
-			logContext.Fatal("Checkout failed. Hash type not supported.")
-		}
-
-		options := &git.CheckoutOptions{
-			Hash:   commitHash,
-			Branch: branch,
-			Create: true,
-		}
-		checkout(path, options)
+	var commitHash plumbing.Hash
+	switch objRef := objRef.(type) {
+	case *object.Tag:
+		commitHash = objRef.Target
+	case *object.Commit:
+		commitHash = objRef.Hash
+	default:
+		// This shouldn't ever hit, but we should at least log it if someday it
+		// does get hit
+		logContext.Debug("Unsupported tag hash type: " + objRef.Type().String())
+		logContext.Fatal("Checkout failed. Hash type not supported.")
 	}
+
+	options := &git.CheckoutOptions{
+		Hash:   commitHash,
+		Branch: branch,
+		Create: true,
+	}
+	checkout(path, options)
 }
 
 // checkout performs a `git checkout` on the path provided using the options provided

--- a/cli/internal/git/utils.go
+++ b/cli/internal/git/utils.go
@@ -195,7 +195,7 @@ func RemoveHeadCopies(gitDirectory string) []*plumbing.Reference {
 	head, err := repo.Head()
 	if err != nil {
 		logContext.Debug(err)
-		logContext.Fatal("Failed to identify references")
+		logContext.Fatal("Failed to identify references when running `repo.Head()`")
 	}
 
 	headHash := head.Hash().String()
@@ -225,7 +225,7 @@ func removeReferences(
 	references, err := repo.References()
 	if err != nil {
 		logContext.Debug(err)
-		logContext.Fatal("Failed to identify references")
+		logContext.Fatal("Failed to identify references when running `repo.References()`")
 	}
 
 	head, err := repo.Head()

--- a/cli/internal/git/utils.go
+++ b/cli/internal/git/utils.go
@@ -195,7 +195,7 @@ func RemoveHeadCopies(gitDirectory string) []*plumbing.Reference {
 	head, err := repo.Head()
 	if err != nil {
 		logContext.Debug(err)
-		logContext.Fatal("Failed to identify references when running `repo.Head()`")
+		logContext.Fatal("Failed to identify references when getting the repo's head")
 	}
 
 	headHash := head.Hash().String()
@@ -225,7 +225,7 @@ func removeReferences(
 	references, err := repo.References()
 	if err != nil {
 		logContext.Debug(err)
-		logContext.Fatal("Failed to identify references when running `repo.References()`")
+		logContext.Fatal("Failed to identify references when getting the repo's references")
 	}
 
 	head, err := repo.Head()


### PR DESCRIPTION
Fix #210 