### PR TITLE
reintroduce postgres operator example database pods

### DIFF
--- a/examples/postgres-operator/README.md
+++ b/examples/postgres-operator/README.md
@@ -2,8 +2,6 @@
 
 This example demonstrates deploying a performant and highly available PostgreSQL database to a Zarf airgap cluster. It uses Zalando's [postgres-operator](https://github.com/zalando/postgres-operator) and provides the Postgres Operator UI and a deployment of PGAdmin for demo purposes.
 
-:warning: NOTE: It looks like this example doesn't currently quite work. The operators come up but it doesn't deploy a postgres database like it used to. We are working on a fix.
-
 ## Tool Choice
 
 After looking at several alternatives, Zalando's postgres operator felt like the best choice. Other tools that were close runners-up were the postgres-operator by [CrunchyData](https://github.com/CrunchyData/postgres-operator) and [KubeDB](https://github.com/kubedb/operator).

--- a/examples/postgres-operator/manifests/image-pull-secret.yaml
+++ b/examples/postgres-operator/manifests/image-pull-secret.yaml
@@ -3,6 +3,37 @@ kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
   name: private-registry
+  namespace: default
+stringData:
+  .dockerconfigjson: |
+    {
+      "auths": {
+        "registry.dso.mil": {
+          "auth":"###ZARF_DOCKERAUTH###"
+        },
+        "registry1.dso.mil": {
+          "auth":"###ZARF_DOCKERAUTH###"
+        },
+        "docker.io": {
+          "auth":"###ZARF_DOCKERAUTH###"
+        },
+        "registry-1.docker.io": {
+          "auth":"###ZARF_DOCKERAUTH###"
+        },
+        "ghcr.io": {
+          "auth":"###ZARF_DOCKERAUTH###"
+        },
+        "registry.opensource.zalan.do": {
+          "auth":"###ZARF_DOCKERAUTH###"
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: private-registry
   namespace: minio-operator
 stringData:
   .dockerconfigjson: |

--- a/examples/postgres-operator/manifests/image-pull-secret.yaml
+++ b/examples/postgres-operator/manifests/image-pull-secret.yaml
@@ -3,37 +3,6 @@ kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
   name: private-registry
-  namespace: default
-stringData:
-  .dockerconfigjson: |
-    {
-      "auths": {
-        "registry.dso.mil": {
-          "auth":"###ZARF_DOCKERAUTH###"
-        },
-        "registry1.dso.mil": {
-          "auth":"###ZARF_DOCKERAUTH###"
-        },
-        "docker.io": {
-          "auth":"###ZARF_DOCKERAUTH###"
-        },
-        "registry-1.docker.io": {
-          "auth":"###ZARF_DOCKERAUTH###"
-        },
-        "ghcr.io": {
-          "auth":"###ZARF_DOCKERAUTH###"
-        },
-        "registry.opensource.zalan.do": {
-          "auth":"###ZARF_DOCKERAUTH###"
-        }
-      }
-    }
----
-apiVersion: v1
-kind: Secret
-type: kubernetes.io/dockerconfigjson
-metadata:
-  name: private-registry
   namespace: minio-operator
 stringData:
   .dockerconfigjson: |

--- a/examples/postgres-operator/manifests/postgres-cluster.yaml
+++ b/examples/postgres-operator/manifests/postgres-cluster.yaml
@@ -1,0 +1,28 @@
+apiVersion: "acid.zalan.do/v1"
+kind: "postgresql"
+metadata:
+  name: "acid-zarf-test"
+  namespace: "postgres-operator"
+  labels:
+    team: acid
+spec:
+  teamId: "acid"
+  postgresql:
+    version: "13"
+  numberOfInstances: 3
+  enableConnectionPooler: true
+  volume:
+    size: "2Gi"
+  users:
+    zarf: []
+  databases:
+    zarf: zarf
+  enableLogicalBackup: true
+  logicalBackupSchedule: "*/2 * * * *"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 500m
+      memory: 500Mi

--- a/examples/postgres-operator/manifests/postgres-cluster.yaml
+++ b/examples/postgres-operator/manifests/postgres-cluster.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     team: acid
 spec:
-  imagePullSecrets:
-    - name: private-registry
   teamId: "acid"
   postgresql:
     version: "13"

--- a/examples/postgres-operator/manifests/postgres-cluster.yaml
+++ b/examples/postgres-operator/manifests/postgres-cluster.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     team: acid
 spec:
+  imagePullSecrets:
+    - name: private-registry
   teamId: "acid"
   postgresql:
     version: "13"

--- a/examples/postgres-operator/manifests/postgres-operator.yaml
+++ b/examples/postgres-operator/manifests/postgres-operator.yaml
@@ -13,25 +13,10 @@ spec:
       # registry: registry1.dso.mil
       # repository: ??
       # tag: ??
-    configGeneral:
-      repair_period: 1m
-      resync_period: 2m
+    # configGeneral:
       # docker_image: registry1.dso.mil/.../spilo-13:2.1-p1
     imagePullSecrets:
       - name: private-registry
-    configTimeouts:
-      # timeout when waiting for the Postgres pods to be deleted
-      pod_deletion_wait_timeout: 3m
-      # timeout when waiting for pod role and cluster labels
-      pod_label_wait_timeout: 3m
-      # interval between consecutive attempts waiting for postgresql CRD to be created
-      ready_wait_interval: 3s
-      # timeout for the complete postgres CRD creation
-      ready_wait_timeout: 30s
-      # interval to wait between consecutive attempts to check for some K8s resources
-      resource_check_interval: 3s
-      # timeout when waiting for the presence of a certain K8s resource (e.g. Sts, PDB)
-      resource_check_timeout: 3m
     configPostgresPodResources:
       default_cpu_request: "100m"
       default_memory_request: "100Mi"

--- a/examples/postgres-operator/manifests/postgres-operator.yaml
+++ b/examples/postgres-operator/manifests/postgres-operator.yaml
@@ -13,10 +13,25 @@ spec:
       # registry: registry1.dso.mil
       # repository: ??
       # tag: ??
-    # configGeneral:
+    configGeneral:
+      repair_period: 3m
+      resync_period: 5m
       # docker_image: registry1.dso.mil/.../spilo-13:2.1-p1
     imagePullSecrets:
       - name: private-registry
+    configTimeouts:
+      # timeout when waiting for the Postgres pods to be deleted
+      pod_deletion_wait_timeout: 3m
+      # timeout when waiting for pod role and cluster labels
+      pod_label_wait_timeout: 3m
+      # interval between consecutive attempts waiting for postgresql CRD to be created
+      ready_wait_interval: 3s
+      # timeout for the complete postgres CRD creation
+      ready_wait_timeout: 30s
+      # interval to wait between consecutive attempts to check for some K8s resources
+      resource_check_interval: 3s
+      # timeout when waiting for the presence of a certain K8s resource (e.g. Sts, PDB)
+      resource_check_timeout: 3m
     configPostgresPodResources:
       default_cpu_request: "100m"
       default_memory_request: "100Mi"
@@ -79,4 +94,4 @@ metadata:
   name: zalando-postgres-operator
   namespace: postgres-operator
 imagePullSecrets: 
-   - name: private-registry
+    - name: private-registry

--- a/examples/postgres-operator/manifests/postgres-operator.yaml
+++ b/examples/postgres-operator/manifests/postgres-operator.yaml
@@ -14,8 +14,8 @@ spec:
       # repository: ??
       # tag: ??
     configGeneral:
-      repair_period: 3m
-      resync_period: 5m
+      repair_period: 1m
+      resync_period: 2m
       # docker_image: registry1.dso.mil/.../spilo-13:2.1-p1
     imagePullSecrets:
       - name: private-registry
@@ -94,4 +94,4 @@ metadata:
   name: zalando-postgres-operator
   namespace: postgres-operator
 imagePullSecrets: 
-    - name: private-registry
+  - name: private-registry

--- a/examples/postgres-operator/manifests/postgres-operator.yaml
+++ b/examples/postgres-operator/manifests/postgres-operator.yaml
@@ -54,6 +54,8 @@ spec:
       runAsNonRoot: true
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
+    podServiceAccount:
+      name: "zalando-postgres-operator"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -70,3 +72,11 @@ data:
   WALG_DISABLE_S3_SSE: "true"
   USE_WALG_RESTORE: "false"
   AWS_S3_FORCE_PATH_STYLE: "true"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: 
+  name: zalando-postgres-operator
+  namespace: postgres-operator
+imagePullSecrets: 
+   - name: private-registry

--- a/examples/postgres-operator/zarf.yaml
+++ b/examples/postgres-operator/zarf.yaml
@@ -12,7 +12,7 @@ components:
     scripts:
       retry: true
       after:
-        - "kubectl patch serviceaccount default -p '{\"imagePullSecrets\": [{\"name\": \"private-registry\"}]}'"
+        - "kubectl patch serviceaccount default -p '{\"imagePullSecrets\": [{\"name\": \"private-registry\"}]}' -n postgres-operator"
 
     charts:
       - name: postgres-operator

--- a/examples/postgres-operator/zarf.yaml
+++ b/examples/postgres-operator/zarf.yaml
@@ -9,6 +9,11 @@ components:
     required: true
     manifests: manifests
 
+    scripts:
+      retry: true
+      after:
+        - "kubectl patch serviceaccount default -p '{\"imagePullSecrets\": [{\"name\": \"private-registry\"}]}'"
+
     charts:
       - name: postgres-operator
         url: https://opensource.zalando.com/postgres-operator/charts/postgres-operator
@@ -26,6 +31,7 @@ components:
         url: https://repo1.dso.mil/platform-one/big-bang/apps/application-utilities/minio.git
         version: 4.2.3-bb.1
 
+
     images:
       - registry.opensource.zalan.do/acid/postgres-operator:v1.7.0
       - registry.opensource.zalan.do/acid/spilo-13:2.1-p1
@@ -33,5 +39,6 @@ components:
       - registry.opensource.zalan.do/acid/pgbouncer:master-18
       - registry.opensource.zalan.do/acid/postgres-operator-ui:v1.7.0
       - docker.io/dpage/pgadmin4:5.5
+      - docker.io/rancher/pause:3.1
       - registry1.dso.mil/ironbank/opensource/minio/operator:v4.2.3
       - registry1.dso.mil/ironbank/opensource/minio/minio:RELEASE.2021-08-31T05-46-54Z


### PR DESCRIPTION
Should fix #201 It appears the postgres-cluster yaml was not present in the newer versions of this example and thus the database pods were not being created accordingly.