### PR TITLE
Add skeleton of new E2E test that tests Gitea and Grafana

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -265,11 +265,102 @@ jobs:
           GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
   # Run the E2E test of Gitea and Grafana
-  # TODO: finish this
-  # e2e-gitea-grafana:
+  e2e-gitea-grafana:
+    runs-on: ubuntu-latest
+    needs: [parse, build]
+    if: needs.parse.outputs.run-e2e == 'true'
+    container: cloudposse/test-harness:latest
+    steps:
+      # Update GitHub status for pending pipeline run
+      - name: "Update GitHub Status for pending"
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_STATE: pending
+          GITHUB_CONTEXT: "/test e2e - Gitea & Grafana"
+          GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor }}"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
+      # Checkout the code from GitHub Pull Request
+      - name: "Checkout the code"
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
-  # Run the Game E2E test
+      # Download the built artifacts
+      - name: "Download the built artifacts"
+        uses: actions/download-artifact@v2
+
+      - name: "Run E2E tests"
+        shell: bash -x -e -o pipefail {0}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_DEFENSEUNICORNS_COMMERCIAL_SA_ZARF }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEFENSEUNICORNS_COMMERCIAL_SA_ZARF }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          # cloudposse/test-harness has golang 1.15, we need 1.16. This is the easiest way I know to do it. This should definitely be revisited and cleaned up.
+          git clone --branch v0.8.0 --depth 1 https://github.com/asdf-vm/asdf.git $HOME/.asdf
+          source ~/.asdf/asdf.sh
+          export PATH="$HOME/.asdf/bin:$PATH"
+          asdf plugin-add golang https://github.com/kennyp/asdf-golang.git
+          asdf install golang 1.16.7
+          asdf global golang 1.16.7
+          export GOPATH="$HOME/go"
+          export PATH="$PATH:$GOPATH/bin"
+          chmod +x build/zarf
+          make test-cloud-e2e-gitea-and-grafana
+
+      # Update GitHub status for failing pipeline run
+      - name: "Update GitHub Status for failure"
+        if: ${{ failure() }}
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_STATE: failure
+          GITHUB_CONTEXT: "/test e2e - Gitea & Grafana"
+          GITHUB_DESCRIPTION: "run failed"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
+
+      # Update GitHub status for successful pipeline run
+      - name: "Update GitHub Status for success"
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_STATE: success
+          GITHUB_CONTEXT: "/test e2e - Gitea & Grafana"
+          GITHUB_DESCRIPTION: "run passed"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
+
+      # Update GitHub status for cancelled pipeline run
+      - name: "Update GitHub Status for cancelled"
+        if: ${{ cancelled() }}
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_STATE: error
+          GITHUB_CONTEXT: "/test e2e - Gitea & Grafana"
+          GITHUB_DESCRIPTION: "run cancelled"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
+
+  # Run E2E test for general CLI stuff
   e2e-general-cli:
     runs-on: ubuntu-latest
     needs: [ parse, build ]

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -264,6 +264,11 @@ jobs:
           GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
           GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
+  # Run the E2E test of Gitea and Grafana
+  # TODO: finish this
+  # e2e-gitea-grafana:
+
+
   # Run the Game E2E test
   e2e-general-cli:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ package-example-game: ## Create the Doom example
 test-cloud-e2e-example-game: ## Runs the Doom game as an E2E test in the cloud. Requires access to an AWS account. Costs money. Make sure you ran the `build-cli`, `init-package`, and `package-example-game` targets first
 	cd test/e2e && go test ./... -run TestE2eExampleGame -v -timeout 1200s
 
+.PHONY: test-cloud-e2e-gitea-and-grafana
+test-cloud-e2e-gitea-and-grafana: ## E2E test of Gitea & Grafana. Requires access to an AWS account. Costs money. Make sure you ran the `build-cli` and `init-package` targets first
+	cd test/e2e && go test ./... -run TestGiteaAndGrafana -v -timeout 1200s
+
 .PHONY: test-cloud-e2e-general-cli
 test-cloud-e2e-general-cli: ## Runs tests of the CLI that don't need a cluster
 	cd test/e2e && go test ./... -run TestGeneralCli -v -timeout 1200s

--- a/test/e2e/e2e_gitea_and_grafana_test.go
+++ b/test/e2e/e2e_gitea_and_grafana_test.go
@@ -1,0 +1,81 @@
+package test
+
+import (
+	"testing"
+)
+
+func TestGiteaAndGrafana(t *testing.T) {
+	t.Parallel()
+	return
+	//
+	//// Our SSH username, will change based on which AMI we use
+	//username := "ubuntu"
+	//
+	//// Copy the terraform folder to a temp directory so we can run multiple tests in parallel
+	//tmpFolder := teststructure.CopyTerraformFolderToTemp(t, "..", "tf/public-ec2-instance")
+	//
+	//// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	//defer teststructure.RunTestStage(t, "TEARDOWN", func() {
+	//	teardown(t, tmpFolder)
+	//})
+	//
+	//// Deploy the terraform infra
+	//teststructure.RunTestStage(t, "SETUP", func() {
+	//	setup(t, tmpFolder)
+	//})
+	//
+	//// Upload the Zarf artifacts
+	//teststructure.RunTestStage(t, "UPLOAD", func() {
+	//	terraformOptions := teststructure.LoadTerraformOptions(t, tmpFolder)
+	//	keyPair := teststructure.LoadEc2KeyPair(t, tmpFolder)
+	//
+	//	syncFileToRemoteServer(t, terraformOptions, keyPair, username, "../../build/zarf", fmt.Sprintf("/home/%s/build/zarf", username), "0700")
+	//	syncFileToRemoteServer(t, terraformOptions, keyPair, username, "../../build/zarf-init.tar.zst", fmt.Sprintf("/home/%s/build/zarf-init.tar.zst", username), "0600")
+	//	syncFileToRemoteServer(t, terraformOptions, keyPair, username, "../../build/zarf-package-appliance-demo-doom.tar.zst", fmt.Sprintf("/home/%s/build/zarf-package-appliance-demo-doom.tar.zst", username), "0600")
+	//})
+	//
+	//teststructure.RunTestStage(t, "TEST", func() {
+	//	terraformOptions := teststructure.LoadTerraformOptions(t, tmpFolder)
+	//	keyPair := teststructure.LoadEc2KeyPair(t, tmpFolder)
+	//
+	//	// Finally run the actual test
+	//	testGameExample(t, terraformOptions, keyPair, username)
+	//})
+}
+
+//func testGameExample(t *testing.T, terraformOptions *terraform.Options, keyPair *aws.Ec2Keypair, username string) {
+//	// Run `terraform output` to get the value of an output variable
+//	publicInstanceIP := terraform.Output(t, terraformOptions, "public_instance_ip")
+//
+//	// We're going to try to SSH to the instance IP, using the Key Pair we created earlier, and the user "ubuntu",
+//	// as we know the Instance is running an Ubuntu AMI that has such a user
+//	publicHost := ssh.Host{
+//		Hostname:    publicInstanceIP,
+//		SshKeyPair:  keyPair.KeyPair,
+//		SshUserName: username,
+//	}
+//
+//	// Make sure `zarf --help` doesn't error
+//	output, err := ssh.CheckSshCommandE(t, publicHost, fmt.Sprintf("sudo /home/%s/build/zarf --help", username))
+//	require.NoError(t, err, output)
+//
+//	// run `zarf init`
+//	output, err = ssh.CheckSshCommandE(t, publicHost, fmt.Sprintf("sudo bash -c 'cd /home/%s/build && ./zarf init --confirm --components management --host 127.0.0.1'", username))
+//	require.NoError(t, err, output)
+//
+//	// Wait until the Docker registry is ready
+//	output, err = ssh.CheckSshCommandE(t, publicHost, "timeout 300 bash -c 'while [[ \"$(curl -sfSL --retry 15 --retry-connrefused --retry-delay 5 -o /dev/null -w \"%{http_code}\" \"https://127.0.0.1/v2/\")\" != \"401\" ]]; do sleep 1; done' || false")
+//	require.NoError(t, err, output)
+//
+//	// Deploy the game
+//	output, err = ssh.CheckSshCommandE(t, publicHost, fmt.Sprintf("sudo bash -c 'cd /home/%s/build && ./zarf package deploy zarf-package-appliance-demo-doom.tar.zst --confirm'", username))
+//	require.NoError(t, err, output)
+//
+//	// Wait for the game to be live. Right now we're just checking that `curl` returns 0. It can be enhanced by scraping the HTML that gets returned or something.
+//	output, err = ssh.CheckSshCommandE(t, publicHost, "timeout 300 bash -c 'while [[ \"$(curl -sfSL --retry 15 --retry-connrefused --retry-delay 5 -o /dev/null -w \"%{http_code}\" \"https://127.0.0.1\")\" != \"200\" ]]; do sleep 1; done' || false")
+//	require.NoError(t, err, output)
+//
+//	// Run `zarf destroy` to make sure that works correctly
+//	output, err = ssh.CheckSshCommandE(t, publicHost, fmt.Sprintf("sudo bash -c 'cd /home/%s/build && ./zarf destroy --confirm'", username))
+//	require.NoError(t, err, output)
+//}


### PR DESCRIPTION
This PR will add the baseline for a new test, a new PR will add the actual test. It has to be done this way because GitHub Actions only pulls its job definitions from master, not branches.