### PR TITLE
Add gitops data package creation prior to e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,10 @@ package-example-data-injection: ## create the Zarf package for the data injectio
 package-example-single-big-bang-package: ## Create the Zarf package for single-big-bang-package example
 	cd examples/single-big-bang-package && ../../$(ZARF_BIN) package create --confirm && mv zarf-package-* ../../build/
 
+.PHONY: package-example-gitops-data
+package-example-gitops-data:
+	cd examples/gitops-data && ../../$(ZARF_BIN) package create --confirm && mv zarf-package-* ../../build/
+
 .PHONY: test-cloud-e2e-example-game
 test-cloud-e2e-example-game: ## Runs the Doom game as an E2E test in the cloud. Requires access to an AWS account. Costs money. Make sure you ran the `build-cli`, `init-package`, and `package-example-game` targets first
 	cd test/e2e && go test ./... -run TestE2eExampleGame -v -timeout 1200s
@@ -79,7 +83,7 @@ test-cloud-e2e-gitea-and-grafana: ## E2E test of Gitea & Grafana. Requires acces
 	cd test/e2e && go test ./... -run TestGiteaAndGrafana -v -timeout 1200s
 
 .PHONY: test-cloud-e2e-gitops
-test-cloud-e2e-gitops: ## E2E test of Gitops example. Requires access to an AWS account. Costs money. Make sure you ran the `build-cli` and `init-package` targets first
+test-cloud-e2e-gitops: package-example-gitops-data ## E2E test of Gitops example. Requires access to an AWS account. Costs money. Make sure you ran the `build-cli` and `init-package` targets first
 	cd test/e2e && go test ./... -run TestGitopsExample -v -timeout 1200s
 
 .PHONY: test-cloud-e2e-data-injection


### PR DESCRIPTION
Master currently fails the e2e because the gitops package isn't being created to the run e2e tests against.


