### PR TITLE
200 confirm prompting components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ package-example-single-big-bang-package: ## Create the Zarf package for single-b
 package-example-gitops-data:
 	cd examples/gitops-data && ../../$(ZARF_BIN) package create --confirm && mv zarf-package-* ../../build/
 
+.PHONY: package-example-tiny-kafka
+package-example-tiny-kafka:
+	cd examples/tiny-kafka && ../../$(ZARF_BIN) package create --confirm && mv zarf-package-* ../../build/
+
 .PHONY: test-cloud-e2e-example-game
 test-cloud-e2e-example-game: ## Runs the Doom game as an E2E test in the cloud. Requires access to an AWS account. Costs money. Make sure you ran the `build-cli`, `init-package`, and `package-example-game` targets first
 	cd test/e2e && go test ./... -run TestE2eExampleGame -v -timeout 1200s
@@ -97,7 +101,7 @@ test-cloud-e2e-git-based-helm-chart:
 ################ END Pending removal post-merge
 
 .PHONY: test-cloud-e2e-general-cli
-test-cloud-e2e-general-cli: ## Runs tests of the CLI that don't need a cluster
+test-cloud-e2e-general-cli: package-example-tiny-kafka ## Runs tests of the CLI that don't need a cluster
 	cd test/e2e && go test ./... -run TestGeneralCli -v -timeout 1200s
 
 .PHONY: test-e2e

--- a/cli/internal/packager/common.go
+++ b/cli/internal/packager/common.go
@@ -79,16 +79,18 @@ func confirmAction(configPath string, userMessage string) bool {
 	utils.ColorPrintYAML(text)
 
 	// Display prompt if not auto-confirmed
+	var confirmFlag bool
 	if config.DeployOptions.Confirm {
 		message.Infof("%s Zarf package confirmed", userMessage)
+		return config.DeployOptions.Confirm
 	} else {
 		prompt := &survey.Confirm{
 			Message: userMessage + " this Zarf package?",
 		}
-		_ = survey.AskOne(prompt, &config.DeployOptions.Confirm)
+		_ = survey.AskOne(prompt, &confirmFlag)
 	}
 
-	return config.DeployOptions.Confirm
+	return confirmFlag
 }
 
 func getValidComponents(allComponents []types.ZarfComponent, requestedComponentNames []string) []types.ZarfComponent {

--- a/cli/internal/packager/common.go
+++ b/cli/internal/packager/common.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"github.com/defenseunicorns/zarf/cli/types"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -12,6 +11,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/defenseunicorns/zarf/cli/types"
 
 	"github.com/goccy/go-yaml"
 
@@ -99,7 +100,7 @@ func getValidComponents(allComponents []types.ZarfComponent, requestedComponentN
 		// If the component is not required check if the user wants it deployed
 		if !confirmComponent {
 			// Check if this is one of the components that has been requested
-			if len(requestedComponentNames) > 0 {
+			if len(requestedComponentNames) > 0 || config.DeployOptions.Confirm {
 				for index, requestedComponent := range requestedComponentNames {
 					if strings.ToLower(requestedComponent) == component.Name {
 						confirmComponent = true


### PR DESCRIPTION
- [x] Check if the confirm flag has been set before prompting for components
- [x] Update interactive confirm to not write response to config *
- [x] Write explicit test to verify we can deploy a package without being prompted when the confirm flag is provided


* This is so we can read the config.confirm value later to determine if the command is being run in 'script' mode.
This gives us the ability to be confident if/when we can prompt the user with a question.
