### PR TITLE
Make GitOps E2E test more robust + minor cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,12 +90,6 @@ test-cloud-e2e-gitops: package-example-gitops-data ## E2E test of Gitops example
 test-cloud-e2e-data-injection: package-example-data-injection ## E2E test of the Data Injection example. Requires access to an AWS account. Costs money. Make sure you ran the `build-cli` and `init-package` targets first
 	cd test/e2e && go test ./... -run TestDataInjection -v -timeout 1200s
 
-################ BEGIN Pending removal post-merge
-.PHONY: test-cloud-e2e-git-based-helm-chart
-test-cloud-e2e-git-based-helm-chart:
-	echo done
-################ END Pending removal post-merge
-
 .PHONY: test-cloud-e2e-general-cli
 test-cloud-e2e-general-cli: ## Runs tests of the CLI that don't need a cluster
 	cd test/e2e && go test ./... -run TestGeneralCli -v -timeout 1200s

--- a/examples/gitops-data/zarf.yaml
+++ b/examples/gitops-data/zarf.yaml
@@ -10,7 +10,7 @@ components:
       - ghcr.io/stefanprodan/podinfo:6.0.0
     repos:
       # Do a tag-provided Git Repo mirror
-      - https://github.com/defenseunicorns/zarf.git@v0.12.0
+      - https://github.com/defenseunicorns/zarf.git@v0.15.0
         # Do a tag-provided Git Repo mirror with the default branch of main
       - https://repo1.dso.mil/platform-one/big-bang/apps/security-tools/twistlock.git@0.0.9-bb.0
         # Do a full Git Repo Mirror

--- a/test/e2e/e2e_gitops_example_test.go
+++ b/test/e2e/e2e_gitops_example_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	teststructure "github.com/gruntwork-io/terratest/modules/test-structure"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,27 +38,26 @@ func TestGitopsExample(t *testing.T) {
 		output, err = e2e.runSSHCommand("sudo bash -c 'cd /home/%s/build && git clone http://zarf-git-user:$(./zarf tools get-admin-password)@127.0.0.1:45003/zarf-git-user/mirror__github.com__stefanprodan__podinfo.git'", e2e.username)
 		require.NoError(t, err, output)
 
-		// Check for tagged git repo mirror (foo.git@1.2.3) from https://github.com/defenseunicorns/zarf.git@v0.12.0
+		// Check for tagged git repo mirror (foo.git@1.2.3) from https://github.com/defenseunicorns/zarf.git@v0.15.0
 		output, err = e2e.runSSHCommand("sudo bash -c 'cd /home/%s/build && git clone http://zarf-git-user:$(./zarf tools get-admin-password)@127.0.0.1:45003/zarf-git-user/mirror__github.com__defenseunicorns__zarf.git'", e2e.username)
 		require.NoError(t, err, output)
 
 		// Check for correct tag
-		expectedTag := "v0.12.0\n"
+		expectedTag := "v0.15.0\n"
 		output, err = e2e.runSSHCommand("sudo bash -c 'cd /home/%s/build/mirror__github.com__defenseunicorns__zarf && git tag'", e2e.username)
 		require.NoError(t, err, output)
-		assert.Equal(t, expectedTag, output, "Expected tag should match output")
+		require.Equal(t, expectedTag, output, "Expected tag should match output")
 
 		// Check for correct commits
-		expectedCommits := "4fb0f14\ncd45237\n9ac3338"
+		expectedCommits := "9eb207e\n7636dd0\ne02cec9"
 		output, err = e2e.runSSHCommand("sudo bash -c 'cd /home/%s/build/mirror__github.com__defenseunicorns__zarf && git log -3 --oneline --pretty=format:\"%%h\"'", e2e.username)
 		require.NoError(t, err, output)
-		assert.Equal(t, expectedCommits, output, "Expected commits should match output")
+		require.Equal(t, expectedCommits, output, "Expected commits should match output")
 
-		// Check for correct branches
-		expectedBranch := "* master\n"
-		output, err = e2e.runSSHCommand("sudo bash -c 'cd /home/%s/build/mirror__github.com__stefanprodan__podinfo && git branch --list'", e2e.username)
+		// Check for existence of tags without specifying them, signifying that not using '@1.2.3' syntax brought over the whole repo
+		expectedTag = "0.2.2"
+		output, err = e2e.runSSHCommand("sudo bash -c 'cd /home/%s/build/mirror__github.com__stefanprodan__podinfo && git tag'", e2e.username)
 		require.NoError(t, err, output)
-		assert.Equal(t, expectedBranch, output, "Expected Branch should match output")
+		require.Contains(t, output, expectedTag, "Output should contain expected tag")
 	})
-
 }


### PR DESCRIPTION
- Make GitOps E2E test more robust by using a newer tag that got created after the major force push to master
- Minor cleanup of dead code