### PR TITLE
Check for a $KUBECONFIG env-variable

### DIFF
--- a/cli/internal/k8s/common.go
+++ b/cli/internal/k8s/common.go
@@ -34,13 +34,18 @@ func init() {
 }
 
 func getRestConfig() *rest.Config {
-	homePath, err := os.UserHomeDir()
-	if err != nil {
-		message.Fatal(nil, "Unable to load the current user's home directory")
+	// use the KUBECONFIG context if it exists
+	configPath := os.Getenv("KUBECONFIG")
+	if configPath == "" {
+		// use the current context in the default kubeconfig in the home path of the user
+		homePath, err := os.UserHomeDir()
+		if err != nil {
+			message.Fatal(nil, "Unable to load the current user's home directory")
+		}
+		configPath = homePath + "/.kube/config"
 	}
 
-	// use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", homePath+"/.kube/config")
+	config, err := clientcmd.BuildConfigFromFlags("", configPath)
 	if err != nil {
 		message.Fatalf(err, "Unable to connect to the K8s cluster")
 	}

--- a/test/e2e/e2e_general_cli_test.go
+++ b/test/e2e/e2e_general_cli_test.go
@@ -67,6 +67,10 @@ func TestGeneralCli(t *testing.T) {
 		output, err = e2e.runSSHCommand("sudo timeout 120 sudo bash -c 'cd /home/%s/build && ./zarf package deploy zarf-package-kafka-strimzi-demo.tar.zst --confirm' || false", e2e.username)
 		require.NoError(e2e.testing, err, output)
 
+		// Test that Zarf checks the $KUBECONFIG env variable
+		output, err = e2e.runSSHCommand("sudo timeout 120 sudo bash -c 'rm -rf /tmp/zarf-* && mv /root/.kube/config /home/%s/zarf-kube-config && export KUBECONFIG=/home/%s/zarf-kube-config && echo 'JPERRYISSTINKY' && echo $KUBECONFIG && cd /home/%s/build && ./zarf package deploy zarf-package-kafka-strimzi-demo.tar.zst -l trace --confirm' || false", e2e.username, e2e.username, e2e.username)
+		require.NoError(e2e.testing, err, output)
+
 		// Test that `zarf package deploy` doesn't die when given a URL
 		// NOTE: Temporarily commenting this out because this seems out of scope for a general cli test. Having this included also means we would have to fully standup a `zarf init` command.
 		// TODO: Move this to it's own e2e test.


### PR DESCRIPTION
This PR adds a check for the $KUBECONFIG environment variable when Zarf is trying to generate a config to talk to a native kubernetes cluster.

Closes #315 