### PR TITLE
Bug: Fetch release now depends on clean. It fails when the sync folde…

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -35,6 +35,7 @@ clean: ## Clean the sync dir
 
 .PHONY: fetch-release
 fetch-release: ## Grab the latest release as an alternative to needing to build the binaries
+	@mkdir -p sync
 	@# This probably isn't the cleanest way to get a release, but since we're moving to github, not worth adding the code until post-migration
 	@curl -fL "https://zarf-public.s3-us-gov-west-1.amazonaws.com/release/$$(git describe --tags --abbrev=0)/{zarf,zarf-mac-intel,zarf-mac-apple,zarf-init.tar.zst}" -o "sync/#1"
 	@chmod +x sync/*


### PR DESCRIPTION
Was going through the zarf big bang example and noticed this! Here is an example of what happens when you try to run the make  fetch-release while the sync folder isn't created. 
![zarf_make_fetch_release_error](https://user-images.githubusercontent.com/37223396/153662642-4e5d1489-d3e0-45ca-9a3c-33571c10aeb9.png)
 