### PR TITLE
Update post-renderer to verify secret data for existing secrets

### DIFF
--- a/cli/cmd/destroy.go
+++ b/cli/cmd/destroy.go
@@ -40,6 +40,10 @@ var destroyCmd = &cobra.Command{
 
 			// If Zarf didn't deploy the cluster, only delete the ZarfNamespace
 			k8s.DeleteZarfNamespace()
+
+			// Delete the zarf-registry secret in the default namespace
+			defaultSecret, _ := k8s.GetSecret("default", "zarf-registry")
+			k8s.DeleteSecret(defaultSecret)
 		}
 	},
 }

--- a/cli/internal/k8s/namespace.go
+++ b/cli/internal/k8s/namespace.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"os"
 	"time"
 
 	"github.com/defenseunicorns/zarf/cli/internal/message"
@@ -76,7 +75,7 @@ func DeleteZarfNamespace() {
 		_, err := clientset.CoreV1().Namespaces().Get(context.TODO(), ZarfNamespace, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			spinner.Successf("Zarf removed from this cluster")
-			os.Exit(0)
+			return
 		}
 		time.Sleep(1 * time.Second)
 	}


### PR DESCRIPTION
Checking that a secret exists isn't enough, we want to make sure the contents of the secret are what we expect it to be.

Fixes #330 