### PR TITLE
make sure we get an image before trying to create injector pod

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -56,7 +56,7 @@ components:
       - source: assets/misc/empty-file
         target: /etc/rancher/k3s/k3s.yaml
         symlinks:
-          - /root/.kube/configkube
+          - /root/.kube/config
 
   - name: container-registry-seed
     required: true


### PR DESCRIPTION
`zarf init --components=k3s --confirm` goes so quick that it tries to inject the zarf registry before k3s is able to actually populate a cluster. This ensure we wait until a pod exists within the k3s cluster that way we can actually fetch an image to use as part of our injection pod.
