### PR TITLE
Create .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+run:
+  timeout: 5m
+linters:
+  enable-all: true
+  disable:
+    - exhaustivestruct
+    - stylecheck
+    - wrapcheck
+    - wsl
+issues:
+  exclude-use-default: false


### PR DESCRIPTION
I'm proposing a linter configuration. One that, for now, will do nothing unless you install `golangci-lint` and run it. IDEs can be configured to use it automatically and give you file suggestions.

If accepted, later on I'll propose adding a linter check to the CI pipeline, but for now I just want to propose adding the config file that people can choose to either use or not use.

I looked through what it was picking up in our codebase and picked 4 linters to disable, as I don't believe they are something we care about, though totally open to feedback there. I suspect there are other linters we will want to disable because they will identify things that we really don't care much about.

Fix #350 