### PR TITLE
k3s component actually waits for node to come up

### DIFF
--- a/cli/internal/packager/seed.go
+++ b/cli/internal/packager/seed.go
@@ -17,6 +17,10 @@ func preSeedRegistry(tempPath tempPaths) {
 		err         error
 	)
 
+	if err := k8s.WaitForHealthyCluster(30); err != nil {
+		message.Fatal(err, "The cluster we are using never reported 'healthy'")
+	}
+
 	if clusterArch, err = k8s.GetArchitecture(); err != nil {
 		message.Errorf(err, "Unable to validate the cluster system architecture")
 	}

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -25,7 +25,7 @@ components:
         - "systemctl daemon-reload"
         - "systemctl enable --now k3s"
         # Wait for the K3s node to come up
-        - "NODECOUNT=$(kubectl get nodes -o name | grep 'node/' | wc -l) && [ $NODECOUNT -gt 0 ]"
+        - "/usr/sbin/kubectl get nodes"
         # Make sure things are really ready in k8s
         - "/usr/sbin/kubectl wait --for=condition=available deployment/coredns -n kube-system"
     files:

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -25,7 +25,7 @@ components:
         - "systemctl daemon-reload"
         - "systemctl enable --now k3s"
         # Wait for the K3s node to come up
-        - "/usr/sbin/kubectl get nodes"
+        - "NODECOUNT=$(kubectl get nodes -o name | grep 'node/' | wc -l) && [ $NODECOUNT -gt 0 ]"
         # Make sure things are really ready in k8s
         - "/usr/sbin/kubectl wait --for=condition=available deployment/coredns -n kube-system"
     files:


### PR DESCRIPTION
The previous command was just running the 'k get nodes' command without verifying any nodes were actually returned.

## Description

As part of the 'after' script definitions for the k3s component we will now verify that at least 1 k3s node is returned when 'kubectl get nodes' is executed.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

