### PR TITLE
Give warning message if invalid permissions to destroy empty local k3s cluster

### DIFF
--- a/assets/scripts/zarf-clean-k3s.sh
+++ b/assets/scripts/zarf-clean-k3s.sh
@@ -92,8 +92,7 @@ rm -f /usr/sbin/k3s
 rm -f /usr/sbin/ctr
 rm -f /usr/sbin/crictl
 rm -f /usr/sbin/kubectl
-rm -f /usr/sbin/k9s
-rm -f /usr/sbin/k3s-remove.sh
+rm -f /opt/zarf/k3s-remove.sh
 rm -fr zarf-pki
 
 echo -e '\033[0m'

--- a/cli/cmd/destroy.go
+++ b/cli/cmd/destroy.go
@@ -1,13 +1,17 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"regexp"
 
+	"github.com/defenseunicorns/zarf/cli/config"
 	"github.com/defenseunicorns/zarf/cli/internal/helm"
+	"github.com/defenseunicorns/zarf/cli/internal/message"
+	"github.com/defenseunicorns/zarf/cli/internal/utils"
+	"github.com/defenseunicorns/zarf/cli/types"
 
 	"github.com/defenseunicorns/zarf/cli/internal/k8s"
-	"github.com/defenseunicorns/zarf/cli/internal/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -20,17 +24,35 @@ var destroyCmd = &cobra.Command{
 	Aliases: []string{"d"},
 	Short:   "Tear it all down, we'll miss you Zarf...",
 	Run: func(cmd *cobra.Command, args []string) {
+		// NOTE: If 'zarf init' failed to deploy the k3s component (or if we're looking at the wrong kubeconfig)
+		//       there will be no zarf-state to load and the struct will be empty. In these cases, if we can find
+		//       the scripts to remove k3s, we will still try to remove a locally installed k3s cluster
 		state := k8s.LoadZarfState()
 		_ = os.Remove(".zarf-registry")
 
-		if state.ZarfAppliance {
-			// If Zarf deployed the cluster, burn it all down
+		// If Zarf deployed the cluster, burn it all down
+		if state.ZarfAppliance || (state == types.ZarfState{Distro: k8s.DistroIsUnknown}) {
+			// Check if we have the scripts to destory everything
+			fileInfo, err := os.Stat(config.ZarfCleanupScriptsPath)
+			if errors.Is(err, os.ErrNotExist) || !fileInfo.IsDir() {
+				message.Warnf("Unable to find the folder (%v) which has the scripts to cleanup the cluster. Do you have the right kube-context?\n", config.ZarfCleanupScriptsPath)
+				return
+			}
+
+			// Run all the scripts!
 			pattern := regexp.MustCompile(`(?mi)zarf-clean-.+\.sh$`)
-			scripts := utils.RecursiveFileList("/usr/sbin", pattern)
+			scripts := utils.RecursiveFileList(config.ZarfCleanupScriptsPath, pattern)
 			// Iterate over al matching zarf-clean scripts and exec them
 			for _, script := range scripts {
 				// Run the matched script
-				_, _ = utils.ExecCommand(true, nil, script)
+				_, err := utils.ExecCommand(true, nil, script)
+				if errors.Is(err, os.ErrPermission) {
+					message.Warnf("Got a 'permission denied' when trying to execute the script (%v). Are you the right user and/or do you have the right kube-context?\n", script)
+
+					// Don't remove scripts we can't execute so the user can try to manually run
+					continue
+				}
+
 				// Try to remove the script, but ignore any errors
 				_ = os.Remove(script)
 			}

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -38,6 +38,8 @@ const (
 	ZarfConnectLabelName             = "zarf.dev/connect-name"
 	ZarfConnectAnnotationDescription = "zarf.dev/connect-description"
 	ZarfConnectAnnotationUrl         = "zarf.dev/connect-url"
+
+	ZarfCleanupScriptsPath = "/opt/zarf"
 )
 
 var (

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -45,7 +45,7 @@ components:
         target: /var/lib/rancher/k3s/agent/images/k3s.tar.zst
       # K3s removal script
       - source: assets/scripts/zarf-clean-k3s.sh
-        target: /usr/sbin/zarf-clean-k3s.sh
+        target: /opt/zarf/zarf-clean-k3s.sh
         executable: true
       # The K3s systemd service definition
       - source: assets/scripts/k3s.service


### PR DESCRIPTION
## Description

If zarf init was not able to successfully start up a k3s cluster then no state-secret will exist in the cluster for Zarf to determine if k3s was installed when 'zarf init' was run. In these cases we should search for the scripts to remove k3s on the local file system and try to execute them.

## Related Issue

Fixes #371 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
