### PR TITLE
Add workflow to disable PR if certain labels exist

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,13 @@
+name: Enforce PR Labels
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+
+
+jobs:
+  enforce-labels:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: yogevbd/enforce-label-action@2.1.0
+      with:
+        BANNED_LABELS: "needs-docs,needs-tests,needs-adr"


### PR DESCRIPTION
## Description
Add a workflow that checks if certain 'banned' labels have been applied to a PR. If the labels exist, the workflow will fail preventing a merge. This is useful as we review PRs so we can make sure proper documentation and tests have been added before getting merged.


## Related Issue
Closes #352 

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
