### PR TITLE
WIP: Better Kubeconfig support

### DIFF
--- a/cli/internal/k8s/common.go
+++ b/cli/internal/k8s/common.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"time"
 
@@ -153,36 +152,15 @@ func init() {
 func getRestConfig() *rest.Config {
 	message.Debug("k8s.getRestConfig()")
 
-	// use the KUBECONFIG context if it exists
-	configPath := os.Getenv("KUBECONFIG")
-	if configPath == "" {
-		// use the current context in the default kubeconfig in the home path of the user
-		homePath, err := os.UserHomeDir()
-		if err != nil {
-			message.Fatal(nil, "Unable to load the current user's home directory")
-		}
-		configPath = homePath + "/.kube/config"
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags("", configPath)
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{}).ClientConfig()
 	if err != nil {
 		message.Fatalf(err, "Unable to connect to the K8s cluster")
 	}
+
 	return config
 }
-
-//func getRestConfig() *rest.Config {
-//	message.Debug("k8s.getRestConfig()")
-//
-//	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-//		clientcmd.NewDefaultClientConfigLoadingRules(),
-//		&clientcmd.ConfigOverrides{}).ClientConfig()
-//	if err != nil {
-//		message.Fatalf(err, "Unable to connect to the K8s cluster")
-//	}
-//
-//	return config
-//}
 
 func getClientset() *kubernetes.Clientset {
 	message.Debug("k8s.getClientSet()")

--- a/cli/internal/k8s/common.go
+++ b/cli/internal/k8s/common.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"time"
 
@@ -153,21 +152,13 @@ func init() {
 func getRestConfig() *rest.Config {
 	message.Debug("k8s.getRestConfig()")
 
-	// use the KUBECONFIG context if it exists
-	configPath := os.Getenv("KUBECONFIG")
-	if configPath == "" {
-		// use the current context in the default kubeconfig in the home path of the user
-		homePath, err := os.UserHomeDir()
-		if err != nil {
-			message.Fatal(nil, "Unable to load the current user's home directory")
-		}
-		configPath = homePath + "/.kube/config"
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags("", configPath)
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{}).ClientConfig()
 	if err != nil {
 		message.Fatalf(err, "Unable to connect to the K8s cluster")
 	}
+
 	return config
 }
 

--- a/cli/internal/k8s/common.go
+++ b/cli/internal/k8s/common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"time"
 
@@ -152,15 +153,36 @@ func init() {
 func getRestConfig() *rest.Config {
 	message.Debug("k8s.getRestConfig()")
 
-	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
-		&clientcmd.ConfigOverrides{}).ClientConfig()
+	// use the KUBECONFIG context if it exists
+	configPath := os.Getenv("KUBECONFIG")
+	if configPath == "" {
+		// use the current context in the default kubeconfig in the home path of the user
+		homePath, err := os.UserHomeDir()
+		if err != nil {
+			message.Fatal(nil, "Unable to load the current user's home directory")
+		}
+		configPath = homePath + "/.kube/config"
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", configPath)
 	if err != nil {
 		message.Fatalf(err, "Unable to connect to the K8s cluster")
 	}
-
 	return config
 }
+
+//func getRestConfig() *rest.Config {
+//	message.Debug("k8s.getRestConfig()")
+//
+//	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+//		clientcmd.NewDefaultClientConfigLoadingRules(),
+//		&clientcmd.ConfigOverrides{}).ClientConfig()
+//	if err != nil {
+//		message.Fatalf(err, "Unable to connect to the K8s cluster")
+//	}
+//
+//	return config
+//}
 
 func getClientset() *kubernetes.Clientset {
 	message.Debug("k8s.getClientSet()")

--- a/docs/workstation.md
+++ b/docs/workstation.md
@@ -2,8 +2,6 @@
 
 There are several ways to use Zarf & the tooling needed depends on what you plan to do with it.  Here are some of the most common use cases, along with what you'll need to install on your workstation to play along.
 
-&nbsp;
-
 ## Just gimmie Zarf!
 
 The simplest path to Zarf is to download a pre-built release and execute it on your shell (just like any other CLI tool). To do that:
@@ -20,11 +18,11 @@ The simplest path to Zarf is to download a pre-built release and execute it on y
 
     - The appropriate zarf binary for your system (choose _one_):
 
-        | system          | binary            |
-        | ---             | ---               |
-        | Linux (64bit)   | `zarf`            |
-        | Intel-based Mac | `zarf-mac-intel`  |
-        | [Apple-based Mac](https://support.apple.com/en-us/HT211814) | `zarf-mac-apple`  |
+        | system                                                      | binary           |
+        | ----------------------------------------------------------- | ---------------- |
+        | Linux (64bit)                                               | `zarf`           |
+        | Intel-based Mac                                             | `zarf-mac-intel` |
+        | [Apple-based Mac](https://support.apple.com/en-us/HT211814) | `zarf-mac-apple` |
 
     - (optional) The checksum file: `zarf.sha256`.
 
@@ -40,8 +38,6 @@ The simplest path to Zarf is to download a pre-built release and execute it on y
     > zarf-mac-intel: OK
     ```
 
-&nbsp;
-
 ### Try it out
 
 Once you've got everything downloaded, you're ready to run commands directly against the zarf binary, like:
@@ -51,8 +47,6 @@ chmod +x ./zarf && ./zarf help
 
 # substitute ./zarf-mac-intel or ./zarf-mac-apple above, as appropriate
 ```
-
-&nbsp;
 
 ## I want a demo/example sandbox
 
@@ -93,27 +87,29 @@ You'll need to install _these_ tools to run the examples if you want to use Vagr
     >
     > _Currently_ only used by the `big-bang` example but still required to start the singular example VM!
 
-&nbsp;
-
 ### Try it out
 
 Once you've got everything installed you're ready to run some examples! We recommend giving the [Get Started - game](../examples/game/README.md) example a try!
 <!-- update link once Get Started page is written! -->
 
-&nbsp;
-
 ## I need a dev machine
 
-During dev & test, Zarf gets its exercise the same way the examples do&mdash;inside a VM.  Getting setup for development means that you'll need to install:
+During dev & test, Zarf gets its exercise the same way the examples do.  Getting setup for development means that you'll need to install:
 
-1. The [demo/example sandbox](#i-want-a-demoexample-sandbox) prerequisites &mdash; the virtualization stack we use for execution isolation.
+1. The [demo/example sandbox](#i-want-a-demoexample-sandbox) prerequisites
 
-1. [Go](https://golang.org/doc/install) &mdash; the programming language / build tools we use to create the `zarf` (et al.) binary.
+1. [Go](https://golang.org/doc/install) -- the programming language / build tools we use to create the `zarf` (et al.) binary.
 
     Currently required version is `1.16.x`.
-
-&nbsp;
 
 ### Try it out
 
 Once everything is installed, you're ready to build your _own_ version of Zarf. Give it a try using the instructions here: [Build Your First Zarf](./first-time-build.md).
+
+## Troubleshooting
+
+### Zarf deployed to the wrong cluster!
+
+Zarf supports setups that have configured multiple Kubernetes clusters, either by having multiple Contexts in a single `KUBECONFIG` file, or by specifying multiple files in the `KUBECONFIG` environment variable, or a combination of both. To ensure you are deploying to the right cluster, first run something like `kubectl get nodes` with no extra parameters. If the nodes you see belong to the cluster you want to deploy to, then Zarf will use that cluster as well. See the [Kubernetes Docs page on configuring multiple clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) for more information.
+
+Zarf does not yet support the optional flags like `--kubeconfig` that you might use with `kubectl`, though it is a feature we are interested in adding at a later time.

--- a/test/e2e/e2e_multiple_files_in_kubeconfig_test.go
+++ b/test/e2e/e2e_multiple_files_in_kubeconfig_test.go
@@ -1,0 +1,26 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestE2eMultipleFilesInKubeconfig tests that `zarf init` works even if the KUBECONFIG env var contains multiple files
+// in it separated by a colon, which is a syntax supported by `kubectl`
+func TestE2eMultipleFilesInKubeconfig(t *testing.T) {
+	defer e2e.cleanupAfterTest(t)
+
+	originalKubeconfig := os.Getenv("KUBECONFIG")
+	defer func(key, value string) {
+		err := os.Setenv(key, value)
+		require.NoErrorf(t, err, "Unable to set KUBECONFIG env var back to original value")
+	}("KUBECONFIG", originalKubeconfig)
+	err := os.Setenv("KUBECONFIG", fmt.Sprintf("%s:/foo/bar.yaml", originalKubeconfig))
+
+	//run `zarf init`
+	output, err := e2e.execZarfCommand("init", "--confirm")
+	require.NoError(t, err, output)
+}

--- a/test/e2e/e2e_multiple_files_in_kubeconfig_test.go
+++ b/test/e2e/e2e_multiple_files_in_kubeconfig_test.go
@@ -21,6 +21,6 @@ func TestE2eMultipleFilesInKubeconfig(t *testing.T) {
 	err := os.Setenv("KUBECONFIG", fmt.Sprintf("%s:/foo/bar.yaml", originalKubeconfig))
 
 	//run `zarf init`
-	output, err := e2e.execZarfCommand("init", "--confirm")
+	output, err := e2e.execZarfCommand("init", "--confirm", "-l", "debug")
 	require.NoError(t, err, output)
 }


### PR DESCRIPTION
## Description

Update the `getRestConfig()` function to provide Kubeconfig support that is closer to the capabilities of `kubectl`. Specifically, the ability to have multiple files specified in the `KUBECONFIG` environment variable (which is a default given the way it happens in `client-go`

## Related Issue

<!--- This project prefers to accept pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

Fixes #373 

## Type of change

<!-- Please delete options that are not relevant -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist before merging

<!-- Please delete options that are not relevant -->

- [x] Tests have been added/updated as necessary (add the `needs-tests` label)
- [x] Documentation has been updated as necessary (add the `needs-docs` label)
- [x] (Optional) Changes have been linted locally with [golangci-lint](https://github.com/golangci/golangci-lint). (NOTE: We haven't turned on lint checks in the pipeline yet so linting may be hard if it shows a lot of lint errors in places that weren't touched by changes. Thus, linting is optional right now.)
