### PR TITLE
Simplify cluster instantiation in tests

### DIFF
--- a/.github/workflows/test-k3d.yml
+++ b/.github/workflows/test-k3d.yml
@@ -6,23 +6,23 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Install GoLang
+      - name: "Install GoLang"
         uses: actions/setup-go@v2
         with:
           go-version: 1.16.x
-      - name: Checkout Repo
+      - name: "Checkout Repo"
         uses: actions/checkout@v2
-      - uses: AbsaOSS/k3d-action@v2
-        name: "Create Single Cluster"
+      - name: "Create K3d Cluster"
+        uses: AbsaOSS/k3d-action@v2
         with:
           cluster-name: "k3d-cluster"
           args: >-
             --agents 1
             --no-lb
             --k3s-arg "--no-deploy=traefik@server:*"
-      - name: Build CLI
+      - name: "Build CLI"
         run: make build-cli-linux
-      - name: Make Packages
+      - name: "Make Packages"
         run: make init-package package-example-game package-example-data-injection package-example-gitops-data package-example-compose
-      - name: Run Tests
-        run: TESTDISTRO=k3d make test-e2e
+      - name: "Run Tests"
+        run: make test-e2e

--- a/.github/workflows/test-k3d.yml
+++ b/.github/workflows/test-k3d.yml
@@ -12,17 +12,10 @@ jobs:
           go-version: 1.16.x
       - name: "Checkout Repo"
         uses: actions/checkout@v2
-      - name: "Create K3d Cluster"
-        uses: AbsaOSS/k3d-action@v2
-        with:
-          cluster-name: "k3d-cluster"
-          args: >-
-            --agents 1
-            --no-lb
-            --k3s-arg "--no-deploy=traefik@server:*"
       - name: "Build CLI"
         run: make build-cli-linux
       - name: "Make Packages"
         run: make init-package package-example-game package-example-data-injection package-example-gitops-data package-example-compose
       - name: "Run Tests"
-        run: make test-e2e
+        # NOTE: This test run will create its own K3d cluster. A single cluster will be used throughout the test run.
+        run: TESTDISTRO=k3d make test-e2e

--- a/.github/workflows/test-k3d.yml
+++ b/.github/workflows/test-k3d.yml
@@ -19,7 +19,7 @@ jobs:
           args: >-
             --agents 1
             --no-lb
-            --k3s-arg "--no-deploy=traefik"
+            --k3s-arg "--no-deploy=traefik@server:*"
       - name: Build CLI
         run: make build-cli-linux
       - name: Make Packages

--- a/.github/workflows/test-k3d.yml
+++ b/.github/workflows/test-k3d.yml
@@ -12,6 +12,14 @@ jobs:
           go-version: 1.16.x
       - name: Checkout Repo
         uses: actions/checkout@v2
+      - uses: AbsaOSS/k3d-action@v2
+        name: "Create Single Cluster"
+        with:
+          cluster-name: "k3d-cluster"
+          args: >-
+            --agents 1
+            --no-lb
+            --k3s-arg "--no-deploy=traefik"
       - name: Build CLI
         run: make build-cli-linux
       - name: Make Packages

--- a/.github/workflows/test-k3s.yml
+++ b/.github/workflows/test-k3s.yml
@@ -17,5 +17,7 @@ jobs:
       - name: Make Packages
         run: make init-package package-example-game package-example-data-injection package-example-gitops-data package-example-compose
       - name: Run Tests
-        # NOTE: "PATH=$PATH" preserves the default user $PATH. This is needed to maintain the version of go installed in a previous step
+        # NOTE: "PATH=$PATH" preserves the default user $PATH. This is needed to maintain the version of go installed
+        #       in a previous step. This test run will use Zarf to create a K3s cluster, and a brand new cluster will be
+        #       used for each test
         run: sudo env "PATH=$PATH" TESTDISTRO=k3s make test-e2e

--- a/.github/workflows/test-k3s.yml
+++ b/.github/workflows/test-k3s.yml
@@ -6,17 +6,17 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Install GoLang
+      - name: "Install GoLang"
         uses: actions/setup-go@v2
         with:
           go-version: 1.16.x
-      - name: Checkout Repo
+      - name: "Checkout Repo"
         uses: actions/checkout@v2
-      - name: Build CLI
+      - name: "Build CLI"
         run: make build-cli-linux
-      - name: Make Packages
+      - name: "Make Packages"
         run: make init-package package-example-game package-example-data-injection package-example-gitops-data package-example-compose
-      - name: Run Tests
+      - name: "Run Tests"
         # NOTE: "PATH=$PATH" preserves the default user $PATH. This is needed to maintain the version of go installed
         #       in a previous step. This test run will use Zarf to create a K3s cluster, and a brand new cluster will be
         #       used for each test

--- a/.github/workflows/test-kind.yml
+++ b/.github/workflows/test-kind.yml
@@ -6,15 +6,17 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Install GoLang
+      - name: "Install GoLang"
         uses: actions/setup-go@v2
         with:
           go-version: 1.16.x
-      - name: Checkout Repo
+      - name: "Checkout Repo"
         uses: actions/checkout@v2
-      - name: Build CLI
+      - name: "Create k8s Kind Cluster"
+        uses: helm/kind-action@v1.2.0
+      - name: "Build CLI"
         run: make build-cli-linux
-      - name: Make Packages
+      - name: "Make Packages"
         run: make init-package package-example-game package-example-data-injection package-example-gitops-data package-example-compose
-      - name: Run Tests
-        run: TESTDISTRO=kind make test-e2e
+      - name: "Run Tests"
+        run: make test-e2e

--- a/.github/workflows/test-kind.yml
+++ b/.github/workflows/test-kind.yml
@@ -19,4 +19,7 @@ jobs:
       - name: "Make Packages"
         run: make init-package package-example-game package-example-data-injection package-example-gitops-data package-example-compose
       - name: "Run Tests"
-        run: make test-e2e
+        # NOTE: We want to test providing a cluster to the test framework so this one creates its own KinD cluster
+        #       rather than having the test suite do it. The K3d tests do a self-provisioned cluster and the K3s tests
+        #       use Zarf to create the cluster. In this test a single cluster will be used throughout the test run.
+        run: TESTDISTRO=provided make test-e2e

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,17 @@
 run:
   timeout: 5m
   skip-files:
-    - cli/internal/message/logo.go  
+    - cli/internal/message/logo.go
 linters:
   enable-all: true
   disable:
     - exhaustivestruct
+    - goerr113
+    - gofumpt
     - lll
     - stylecheck
+    - testpackage
+    - varnamelen
     - wrapcheck
     - wsl
 issues:

--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,9 @@ package-example-compose:
 	cd examples/composable-packages && ../../$(ZARF_BIN) package create --confirm && mv zarf-package-* ../../build/
 
 # TODO: This can be cleaned up a little more when `zarf init` is able to provide the path to the `zarf-init-<arch>.tar.zst`
-.PHONY: test-new-e2e
-test-e2e: ## Run e2e tests. All dependencies are assumed to be built and in the ./build directory
-	@ #Check to make sure all the packages we need exist
+.PHONY: test-e2e
+test-e2e: ## Run e2e tests. Will automatically build any required dependencies that aren't present
+	@#Check to make sure all the packages we need exist
 	@if [ ! -f $(ZARF_BIN) ]; then\
 		$(MAKE) build-cli;\
 	fi
@@ -107,4 +107,4 @@ test-e2e: ## Run e2e tests. All dependencies are assumed to be built and in the 
 	@if [ ! -f ./build/zarf-package-compose-example-$(ARCH).tar.zst ]; then\
 		$(MAKE) package-example-compose;\
 	fi
-	cd test/e2e && cp ../../build/zarf-init-$(ARCH).tar.zst . && go test ./... -v -timeout 2400s && rm zarf-init-$(ARCH).tar.zst
+	cd test/e2e && cp ../../build/zarf-init-$(ARCH).tar.zst . && go test ./... -gcflags="all=-N -l" -v -count=1 --run TestE2eExampleGame -timeout 2400s && rm zarf-init-$(ARCH).tar.zst

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ package-example-compose:
 
 # TODO: This can be cleaned up a little more when `zarf init` is able to provide the path to the `zarf-init-<arch>.tar.zst`
 .PHONY: test-new-e2e
-test-e2e: ## Run e2e tests on a KiND cluster. All dependencies are assumed to be built and in the ./build directory
+test-e2e: ## Run e2e tests. All dependencies are assumed to be built and in the ./build directory
 	@ #Check to make sure all the packages we need exist
 	@if [ ! -f $(ZARF_BIN) ]; then\
 		$(MAKE) build-cli;\

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ package-example-compose:
 
 # TODO: This can be cleaned up a little more when `zarf init` is able to provide the path to the `zarf-init-<arch>.tar.zst`
 .PHONY: test-e2e
-test-e2e: ## Run e2e tests. Will automatically build any required dependencies that aren't present
+test-e2e: ## Run e2e tests. Will automatically build any required dependencies that aren't present. Requires env var TESTDISTRO=[provided|kind|k3d|k3s]
 	@#Check to make sure all the packages we need exist
 	@if [ ! -f $(ZARF_BIN) ]; then\
 		$(MAKE) build-cli;\

--- a/Makefile
+++ b/Makefile
@@ -107,4 +107,4 @@ test-e2e: ## Run e2e tests. Will automatically build any required dependencies t
 	@if [ ! -f ./build/zarf-package-compose-example-$(ARCH).tar.zst ]; then\
 		$(MAKE) package-example-compose;\
 	fi
-	cd test/e2e && cp ../../build/zarf-init-$(ARCH).tar.zst . && go test ./... -gcflags="all=-N -l" -v -count=1 --run TestE2eExampleGame -timeout 2400s && rm zarf-init-$(ARCH).tar.zst
+	cd test/e2e && cp ../../build/zarf-init-$(ARCH).tar.zst . && go test ./... -v -count=1 -timeout 2400s && rm zarf-init-$(ARCH).tar.zst

--- a/cli/internal/k8s/common.go
+++ b/cli/internal/k8s/common.go
@@ -154,6 +154,8 @@ func init() {
 func getRestConfig() *rest.Config {
 	message.Debug("k8s.getRestConfig()")
 
+	// Build the config from the currently active kube context in the default way that the k8s client-go gets it, which
+	// is to look at the KUBECONFIG env var
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(),
 		&clientcmd.ConfigOverrides{}).ClientConfig()

--- a/cli/internal/k8s/common.go
+++ b/cli/internal/k8s/common.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"time"
 
@@ -153,21 +152,13 @@ func init() {
 func getRestConfig() *rest.Config {
 	message.Debug("k8s.getRestConfig()")
 
-	// use the KUBECONFIG context if it exists
-	configPath := os.Getenv("KUBECONFIG")
-	if configPath == "" {
-		// use the current context in the default kubeconfig in the home path of the user
-		homePath, err := os.UserHomeDir()
-		if err != nil {
-			message.Fatal(nil, "Unable to load the current user's home directory")
-		}
-		configPath = homePath + "/.kube/config"
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags("", configPath)
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{}).ClientConfig()
 	if err != nil {
 		message.Fatalf(err, "Unable to connect to the K8s cluster")
 	}
+
 	return config
 }
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,40 +1,50 @@
 # Zarf End-To-End Tests
 
-This directory holds all of our e2e tests that we use to verify Zarf functionality in an environment that replicates a live setting. The tests in this directory are automatically run against all the default K8s distros whenever a PR is opened against the repo. 
+This directory holds all of our e2e tests that we use to verify Zarf functionality in an environment that replicates a live setting. The tests in this directory are automatically run against several K8s distros whenever a PR is opened or updated.
 
-
-# Running Tests Locally
+## Running Tests Locally
 The tests in this directory are also able to be run locally!
 
-## Dependencies
+### Dependencies
 Running the tests locally have the same prerequisites as running and building Zarf:
  1. GoLang >= `1.16.x`
  2. Make
- 3. Docker 
-
+ 3. (for the `kind` and `k3d` options only) Docker
+ 4. (for the `k3s` cluster only) Linux with root privileges
 
 ### Existing K8s Cluster
-If you have a cluster already running, great! As long as your kubeconfig is accessible at `~/.kube/.config` or is exposed in your `$KUBECONFIG` environment variable, the e2e tests will be able to use your cluster to run your tests. This means that you can even test remote distros like EKS, AKS, and GKE. When the tests are completed, your cluster will still be accessible but note that since the tests are actively using your cluster it might be in a very different state.
+If you have a cluster already running, and use the env var `TESTDISTRO=provided`, the test suite will use the `KUBECONFIG` env var and the cluster that is currently configured as the active context. To make sure you are running in the right cluster, run something like `kubectl get nodes` with no optional flags and if the nodes that appear are the ones you expect, then the tests will use that cluster as well.
 
+This means that you are able to run the tests against any remote distro you want, like EKS, AKS, GKE, RKE, etc.
 
 ### No Existing K8s Cluster
-If you do not have a local cluster running, no worries! The e2e tests use the `sigs.k8s.io/kind` and `github.com/rancher/k3d/v5` libraries to stand up local clusters to test against.
+If you do not have a local cluster running, no worries! The e2e tests use the `sigs.k8s.io/kind` and `github.com/rancher/k3d/v5` libraries to stand up local clusters to test against. All you have to do is make sure Docker is running and set the `TESTDISTRO` env var to either `"kind"` or `"k3d"` and the test suite will automatically create the appropriate cluster before the test run, run the tests on it, then automatically destroy it to clean up.
 
-If you want to specify which distros to run the tests against you can set the `TESTDISTRO` environment variable with a comma separated list of K8s distros to use for the testing, each distro is run iteratively. The list of potential distros lists in the `distroTests` struct in `main_test.go`. If nothing is specified, it all 'default' distros are run.
-
-> NOTE: If running against the k3s distro you have to be 'root' to successfully create the cluster.
-
-If you did not have a local cluster running before the e2e test but you want to keep it up afterwards to do some debugging, you can set the `SKIP_TEARDOWN` environment variable and the e2e tests will leave the create cluster up after all testing is completed.
+You can also use K3s by setting `TESTDISTRO=k3s` but note that there are extra requirements of being on Linux with root privileges.
 
 ### Actually Running The Test
-We recommend running the tests by going to the main directory of the Zarf repo and running `make test-e2e` this will guarantee all the necessary packages are built and in the right place for the test to find. If you already built everything you can run the tests by staying in this directory and using the command `go test ./... -v`
+Here are a few different ways to run the tests, based on your specific situation:
+
+```shell
+# The default way, from the root directory of the repo. Will run all of the tests against your chosen k8s distro. Will automatically build any binary dependencies that don't already exist.
+TESTDISTRO="[provided|kind|k3d|k3s]" make test-e2e
+
+# If you already have everything build, you can run this inside this folder. This lets you customize the test run.
+TESTDISTRO=YourChoiceHere go test ./... -v
+
+# Let's say you only want to run one test. You would run:
+TESTDISTRO=YourChoiceHere go test ./... -v -run TestFooBarBaz
+```
 
 > NOTE: The zarf binary and built packages need to live in the ./build directory but if you're trying to run the tests locally with 'go test ./...' then the zarf-init package will need to be in this directory.
 
 ## Adding More Tests
-> NOTE: Since all of the tests use the same K8s cluster, do not write new tests to be executed in parallel and remember to cleanup the cluster after each test by executing `e2e.cleanupAfterTest(t)`. This runs a `zarf destroy --confirm --remove-components` so that the cluster is in a good enough state to run the next test against.
+There are a few requirements for all of our tests, that will need to be followed when new tests are added.
 
+1. Tests may not run in parallel, since they use the same kubernetes cluster to run them.
+2. Each test must begin with `defer e2e.cleanupAfterTest(t)` so that the cluster can be reset back to empty when finished.
 
-Coming Soon: In the future, our goals is to be able to run all of the tests while using an exhaustive combination of different k8s distros and base operating systems. 
-
-
+## Coming Soon
+1. More Linux distros tested
+2. More K8s distros tested, including cloud distros like EKS
+3. Make the tests that run in the CI pipeline more efficient by using more parallelization

--- a/test/e2e/clusters/clusters.go
+++ b/test/e2e/clusters/clusters.go
@@ -1,0 +1,260 @@
+package clusters
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	k3dCluster "github.com/rancher/k3d/v5/cmd/cluster"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	kindCluster "sigs.k8s.io/kind/pkg/cluster"
+	kindcmd "sigs.k8s.io/kind/pkg/cmd"
+)
+
+// DistroToUse is an "enum" that helps figure out what the user wants to use for the k8s cluster.
+// Based on this article: https://threedots.tech/post/safer-enums-in-go/
+type DistroToUse struct {
+	slug string
+}
+
+var (
+	// Unknown is the "enum" representation for when we don't know what distro the user wants
+	Unknown = DistroToUse{""}
+	// Provided is the "enum" representation for when the user wants to use the k8s cluster that is already present
+	Provided = DistroToUse{"provided"}
+	// Kind is the "enum" representation for when the user wants the test suite to set up its own KinD cluster
+	Kind = DistroToUse{"kind"}
+	// K3d is the "enum" representation for when the user wants the test suite to set up its own K3d cluster
+	K3d = DistroToUse{"k3d"}
+	// K3s is the "enum" representation for when the user wants the test suite to use Zarf's built-in K3s cluster
+	K3s = DistroToUse{"k3s"}
+)
+
+const (
+	kindClusterName = "kind-zarf-test"
+	k3dClusterName  = "k3d-zarf-test"
+)
+
+// String returns the expected value from the environment variable for each distro option
+func (c DistroToUse) String() string {
+	return c.slug
+}
+
+// GetDistroToUseFromString decides which cluster the user wants based on the string value passed from an environment
+// variable
+func GetDistroToUseFromString(s string) (DistroToUse, error) {
+	switch s {
+	case Provided.slug:
+		return Provided, nil
+	case Kind.slug:
+		return Kind, nil
+	case K3d.slug:
+		return K3d, nil
+	case K3s.slug:
+		return K3s, nil
+	}
+	return Unknown, fmt.Errorf("\"%v\" is not a valid value for determining which k8s distro to use", s)
+}
+
+// CreateClusterWithTemporaryKubeconfig creates a temporary Kubeconfig file, updates the process's KUBECONFIG env var
+// to point at the new file, and creates a kubernetes cluster. It returns the path to the temporary Kubeconfig file,
+// or an error if something went wrong. The caller is responsible for destroying the cluster and deleting the temporary
+// kubeconfig file. The KUBECONFIG env var doesn't need to be reset since it was only changed for the current process.
+func CreateClusterWithTemporaryKubeconfig(distroToUse DistroToUse) (string, error) {
+	// Create the temporary Kubeconfig file
+	var clusterName string
+	switch distroToUse {
+	case Kind:
+		clusterName = kindClusterName
+	case K3d:
+		clusterName = k3dClusterName
+	}
+	tempKubeconfigFile, err := ioutil.TempFile("", clusterName+"*.yaml")
+	if err != nil {
+		return "", err
+	}
+
+	// Set the KUBECONFIG env var to the new file
+	err = os.Setenv("KUBECONFIG", tempKubeconfigFile.Name())
+	if err != nil {
+		return "", err
+	}
+
+	// Create the cluster
+	switch distroToUse {
+	case Kind:
+		err = createKindCluster(tempKubeconfigFile.Name())
+		if err != nil {
+			return "", err
+		}
+	case K3d:
+		err = createK3dClusterUsingCurrentKubeconfig()
+		if err != nil {
+			return "", err
+		}
+	}
+	return tempKubeconfigFile.Name(), nil
+}
+
+// DeleteClusterAndTemporaryKubeconfig is intended to be deferred at the end of TestMain execution so we can clean up
+// the cluster and temp file that we made.
+func DeleteClusterAndTemporaryKubeconfig(distroToUse DistroToUse, tempKubeconfigFilePath string) error {
+	// Defer the temp file delete so it always happens no matter what
+	defer func(name string) {
+		_ = os.Remove(name)
+	}(tempKubeconfigFilePath)
+
+	// Delete the cluster
+	switch distroToUse {
+	case Kind:
+		err := deleteKindCluster(tempKubeconfigFilePath)
+		if err != nil {
+			return err
+		}
+	case K3d:
+		err := deleteK3dCluster()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TryValidateClusterIsRunning establishes a valid connection to the currently configured cluster, then returns,
+// throwing an error if anything went wrong.
+func TryValidateClusterIsRunning() error {
+	clientSet, err := GetClientSet()
+	if err != nil {
+		return fmt.Errorf("unable to connect to the cluster: %w", err)
+	}
+	pods, err := clientSet.CoreV1().Pods("kube-system").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to list running pods: %w", err)
+	}
+	if len(pods.Items) < 1 {
+		return fmt.Errorf("established connection to cluster, but no pods were found")
+	}
+
+	return nil
+}
+
+// GetConfig gets the currently configured Kubeconfig, or throws an error if something went wrong.
+func GetConfig() (*rest.Config, error) {
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+// GetClientSet establishes a connection with the currently configured k8s cluster and returns the ClientSet object
+// that is needed to interact with it.
+func GetClientSet() (*kubernetes.Clientset, error) {
+	config, err := GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientSet, nil
+}
+
+// createKindCluster creates a KinD cluster given the path to use to create a kubeconfig file.
+// It returns an error if something went wrong.
+func createKindCluster(kubeconfigFile string) error {
+	provider := kindCluster.NewProvider(kindCluster.ProviderWithLogger(kindcmd.NewLogger()))
+	err := provider.Create(
+		kindClusterName,
+		kindCluster.CreateWithNodeImage(""),
+		kindCluster.CreateWithRetain(false),
+		kindCluster.CreateWithWaitForReady(time.Duration(0)),
+		kindCluster.CreateWithKubeconfigPath(kubeconfigFile),
+		kindCluster.CreateWithDisplayUsage(false))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// deleteKindCluster deletes the KinD cluster that was created at the beginning of the test suite, and removes the
+// cluster configuration from the provided Kubeconfig file. It does not delete the file itself.
+func deleteKindCluster(kubeconfigFile string) error {
+	provider := kindCluster.NewProvider(kindCluster.ProviderWithLogger(kindcmd.NewLogger()))
+	err := provider.Delete(kindClusterName, kubeconfigFile)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// createK3dClusterUsingCurrentKubeconfig creates a K3d cluster. It will automatically modify the currently configured
+// Kubeconfig file and switch the current context to the new cluster. It returns an error if something went wrong.
+func createK3dClusterUsingCurrentKubeconfig() error {
+	// Guide on how to do args and flags:
+	// https://stackoverflow.com/questions/49848898/cobra-how-to-set-flags-programmatically-in-tests/50880663#50880663
+	createClusterCommand := k3dCluster.NewCmdClusterCreate()
+	createClusterCommand.SetArgs([]string{
+		k3dClusterName,
+		"--kubeconfig-update-default=true",
+		"--kubeconfig-switch-context=true",
+		"--wait=true",
+		"--timeout=120s",
+	})
+	err := createClusterCommand.ExecuteContext(context.TODO())
+	if err != nil {
+		return err
+	}
+	// The cluster needs a bit more time to become healthy
+	err = waitForHealthyCluster()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// deleteK3dCluster deletes the K3d cluster that was created at the beginning of the test suite. It uses the currently
+// configured Kubeconfig file (from the KUBECONFIG env var)
+func deleteK3dCluster() error {
+	deleteClusterCommand := k3dCluster.NewCmdClusterDelete()
+	deleteClusterCommand.SetArgs([]string{
+		k3dClusterName,
+	})
+	err := deleteClusterCommand.ExecuteContext(context.TODO())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// waitForHealthyCluster can be used to wait until the cluster is healthy if it needs a little extra time to spin up.
+func waitForHealthyCluster() error {
+	attempt := 0
+	success := false
+	for attempt < 15 {
+		err := TryValidateClusterIsRunning()
+		if err == nil {
+			success = true
+			break
+		} else {
+			time.Sleep(1 * time.Second)
+			attempt++
+		}
+	}
+	if success {
+		return nil
+	} else {
+		return fmt.Errorf("the cluster did not become healthy in time")
+	}
+}

--- a/test/e2e/clusters/clusters.go
+++ b/test/e2e/clusters/clusters.go
@@ -16,19 +16,19 @@ import (
 	kindcmd "sigs.k8s.io/kind/pkg/cmd"
 )
 
-// DistroToUse is an "enum" for helping determine which k8s distro to run the tests on
+// DistroToUse is an "enum" for helping determine which k8s distro to run the tests on.
 type DistroToUse int
 
 const (
-	// DistroUnknown is the "enum" representation for when we don't know what distro the user wants
+	// DistroUnknown is the "enum" representation for when we don't know what distro the user wants.
 	DistroUnknown DistroToUse = iota
-	// DistroProvided is the "enum" representation for when the user wants to use the k8s cluster that is already present
+	// DistroProvided is the "enum" representation for when the user wants to use the k8s cluster that is already present.
 	DistroProvided
-	// DistroKind is the "enum" representation for when the user wants the test suite to set up its own KinD cluster
+	// DistroKind is the "enum" representation for when the user wants the test suite to set up its own KinD cluster.
 	DistroKind
-	// DistroK3d is the "enum" representation for when the user wants the test suite to set up its own K3d cluster
+	// DistroK3d is the "enum" representation for when the user wants the test suite to set up its own K3d cluster.
 	DistroK3d
-	// DistroK3s is the "enum" representation for when the user wants the test suite to use Zarf's built-in K3s cluster
+	// DistroK3s is the "enum" representation for when the user wants the test suite to use Zarf's built-in K3s cluster.
 	DistroK3s
 
 	kindClusterName = "kind-zarf-test"
@@ -36,7 +36,7 @@ const (
 )
 
 // GetDistroToUseFromString decides which cluster the user wants based on the string value passed from an environment
-// variable
+// variable.
 func GetDistroToUseFromString(s string) (DistroToUse, error) {
 	match := map[string]DistroToUse{
 		"provided": DistroProvided,
@@ -220,7 +220,7 @@ func createK3dClusterUsingCurrentKubeconfig() error {
 }
 
 // deleteK3dCluster deletes the K3d cluster that was created at the beginning of the test suite. It uses the currently
-// configured Kubeconfig file (from the KUBECONFIG env var)
+// configured Kubeconfig file (from the KUBECONFIG env var).
 func deleteK3dCluster() error {
 	deleteClusterCommand := k3dCluster.NewCmdClusterDelete()
 	deleteClusterCommand.SetArgs([]string{
@@ -230,6 +230,7 @@ func deleteK3dCluster() error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -45,7 +45,7 @@ func getCLIName() string {
 // deferred at the beginning of each test. Example:
 //
 // func TestE2eFooBarBaz(t *testing.T) {
-//	   defer e2e.cleanupAfterTest(t)
+//     defer e2e.cleanupAfterTest(t)
 //     doAllTheOtherStuff...
 // }
 func (e2e *ZarfE2ETest) cleanupAfterTest(t *testing.T) {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -116,7 +116,7 @@ func (e2e *ZarfE2ETest) execZarfCommand(commandString ...string) (string, error)
 	// TODO: It might be a nice feature to read some flag/env and change the stdout and stderr to pipe to the terminal running the test
 
 	// Check if we need to deploy the k3s component
-	if e2e.distroToUse == clusters.K3s && commandString[0] == "init" {
+	if e2e.distroToUse == clusters.DistroK3s && commandString[0] == "init" {
 		componentAdded := false
 		for idx, str := range commandString {
 			if strings.Contains(str, "components") {

--- a/test/e2e/e2e_composability_test.go
+++ b/test/e2e/e2e_composability_test.go
@@ -24,7 +24,7 @@ func TestE2eExampleComposability(t *testing.T) {
 	require.NoError(t, err, output)
 
 	// Establish the port-forward into the game service
-	err = e2e.execZarfBackgroundCommand("connect", "doom", "--local-port=22333")
+	err = e2e.execZarfBackgroundCommand("connect", "doom", "--local-port=22333", "--cli-only")
 	require.NoError(t, err, "unable to connect to the doom port-forward")
 
 	// Right now we're just checking that `curl` returns 0. It can be enhanced by scraping the HTML that gets returned or something.

--- a/test/e2e/e2e_example_game_test.go
+++ b/test/e2e/e2e_example_game_test.go
@@ -23,7 +23,7 @@ func TestE2eExampleGame(t *testing.T) {
 	require.NoError(t, err, output)
 
 	// Establish the port-forward into the game service
-	err = e2e.execZarfBackgroundCommand("connect", "doom", "--local-port=22333")
+	err = e2e.execZarfBackgroundCommand("connect", "doom", "--local-port=22333", "--cli-only")
 	require.NoError(t, err, "unable to connect to the doom port-forward")
 
 	// Check that 'curl' returns something.

--- a/test/e2e/e2e_gitea_and_grafana_test.go
+++ b/test/e2e/e2e_gitea_and_grafana_test.go
@@ -16,7 +16,7 @@ func TestGiteaAndGrafana(t *testing.T) {
 	require.NoError(t, err, output)
 
 	// Establish the port-forward into the gitea service; give the service a few seconds to come up since this is not a command we can retry
-	err = e2e.execZarfBackgroundCommand("connect", "git")
+	err = e2e.execZarfBackgroundCommand("connect", "git", "--cli-only")
 	assert.NoError(t, err, "unable to establish tunnel to git")
 
 	// Make sure Gitea comes up cleanly
@@ -25,7 +25,7 @@ func TestGiteaAndGrafana(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 
 	// Establish the port-forward into the logging service
-	err = e2e.execZarfBackgroundCommand("connect", "logging")
+	err = e2e.execZarfBackgroundCommand("connect", "logging", "--cli-only")
 	assert.NoError(t, err, "unable to establish tunnel to logging")
 
 	// Make sure Grafana comes up cleanly

--- a/test/e2e/e2e_gitops_example_test.go
+++ b/test/e2e/e2e_gitops_example_test.go
@@ -25,7 +25,7 @@ func TestGitopsExample(t *testing.T) {
 	require.NoError(t, err, output)
 
 	// Create a tunnel to the git resources
-	err = e2e.execZarfBackgroundCommand("connect", "git")
+	err = e2e.execZarfBackgroundCommand("connect", "git", "--cli-only")
 	assert.NoError(t, err, "unable to establish tunnel to git")
 
 	// Check for full git repo mirror (foo.git) from https://github.com/stefanprodan/podinfo.git

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -52,20 +52,13 @@ func doAllTheThings(m *testing.M) (int, error) {
 	// If needed:
 	// [1] Create the cluster with a temporary kubeconfig file
 	// [2] Update the the KUBECONFIG env var
-	// [3] Defer the cluster destroy, deletion of the temp file, and rest of the KUBECONFIG env var back to original
-	//     value
+	// [3] Defer the cluster destroy and deletion of the temp file. We don't need to set the env var back since it was
+	//     only changed for the current process.
 	if e2e.distroToUse == clusters.Kind || e2e.distroToUse == clusters.K3d {
 		// Create the cluster
 		tempKubeconfigFilePath, err := clusters.CreateClusterWithTemporaryKubeconfig(e2e.distroToUse)
 		if err != nil {
 			return 1, fmt.Errorf("unable to create %v cluster: %w", e2e.distroToUse.String(), err)
-		}
-
-		// Modify KUBECONFIG
-		currentKubeconfig := os.Getenv("KUBECONFIG")
-		err = os.Setenv("KUBECONFIG", currentKubeconfig)
-		if err != nil {
-			return 1, fmt.Errorf("unable to update KUBECONFIG env var: %w", err)
 		}
 
 		// Defer cleanup

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -4,100 +4,30 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"strings"
 	"testing"
 
 	"github.com/defenseunicorns/zarf/cli/config"
 )
 
-type testSuite struct {
-	standard         bool
-	setupFunction    func() error
-	tearDownFunction func() error
-}
-
 var (
-	e2e         ZarfE2ETest
-	distroTests = map[string]testSuite{
-		"k3d": {
-			standard:         true,
-			setupFunction:    e2e.setUpK3D,
-			tearDownFunction: e2e.tearDownK3D,
-		},
-		"kind": {
-			standard:         true,
-			setupFunction:    e2e.setUpKind,
-			tearDownFunction: e2e.tearDownKind,
-		},
-		"k3s": {
-			standard:         false,
-			setupFunction:    e2e.setUpK3s,
-			tearDownFunction: e2e.tearDownK3s,
-		},
-	}
+	e2e ZarfE2ETest
 )
 
 // TestMain will exec each test, one by one
 func TestMain(m *testing.M) {
-	var err error
 	retCode := 0
 
 	e2e.arch = config.GetArch()
 
 	// Set up constants for the tests
 	e2e.zarfBinPath = path.Join("../../build", getCLIName())
-	e2e.kubeconfigPath, err = getKubeconfigPath()
-	if err != nil {
-		fmt.Printf("Unable to get the kubeconfig path for running the e2e tests because of err :%v\n", err)
-		os.Exit(1)
-	}
 
-	// Check if a valid kubeconfig exists
-	validCubeConfig := e2e.checkIfClusterRunning()
-
-	// If the current kubeconfig points to an existing cluster run the tests against that cluster
-	if validCubeConfig {
+	// Run the tests if a valid cluster exists or we're being told to create the K3s cluster
+	if e2e.checkIfClusterRunning() || shouldCreateK3sCluster() {
 		retCode = m.Run()
 	} else {
-		// Run the tests against all the distros provided
-		distroToUse := strings.Split(os.Getenv("TESTDISTRO"), ",")
-		if len(distroToUse) == 1 && distroToUse[0] == "" {
-			distroToUse = []string{}
-			// No distros were specified; Use all the standard distros
-			for key, value := range distroTests {
-				if value.standard {
-					distroToUse = append(distroToUse, key)
-				}
-			}
-		}
-
-		for _, distroName := range distroToUse {
-			testSuiteFunctions, exists := distroTests[distroName]
-			if !exists {
-				fmt.Printf("Provided distro %v is not recognized, continuing tests but reporting as failure\n", distroName)
-				retCode = 1
-				continue
-			}
-
-			// Setup the cluster
-			err := testSuiteFunctions.setupFunction()
-			// nolint
-			defer testSuiteFunctions.tearDownFunction()
-			if err != nil {
-				fmt.Printf("Unable to setup %s environment to run the e2e test because of err: %v\n", distroName, err)
-				os.Exit(1)
-			}
-
-			// exec test and capture exit code to pass to os
-			testCode := m.Run()
-			retCode = testCode | retCode
-
-			// Teardown the cluster now that tests are completed
-			err = testSuiteFunctions.tearDownFunction()
-			if err != nil {
-				fmt.Printf("Unable to cleanly teardown %s environment because of err: %v\n", distroName, err)
-			}
-		}
+		fmt.Printf(`Unable to run tests. No valid cluster present and TESTDISTRO != "k3s"`)
+		retCode = 1
 	}
 
 	// If exit code is distinct of zero, the test will be failed (red)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -77,10 +77,12 @@ func doAllTheThings(m *testing.M) (int, error) {
 		}(tempKubeconfigFilePath)
 	}
 
-	// Final check to make sure we have a working k8s cluster
-	err = clusters.TryValidateClusterIsRunning()
-	if err != nil {
-		return 1, fmt.Errorf("unable to connect to a running k8s cluster: %w", err)
+	// Final check to make sure we have a working k8s cluster, skipped if we are using K3s
+	if e2e.distroToUse != clusters.K3s {
+		err = clusters.TryValidateClusterIsRunning()
+		if err != nil {
+			return 1, fmt.Errorf("unable to connect to a running k8s cluster: %w", err)
+		}
 	}
 
 	// Run the tests, with the cluster cleanup being deferred to the end of the function call

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -7,29 +7,84 @@ import (
 	"testing"
 
 	"github.com/defenseunicorns/zarf/cli/config"
+	"github.com/defenseunicorns/zarf/test/e2e/clusters"
 )
 
 var (
-	e2e ZarfE2ETest
+	e2e ZarfE2ETest //nolint:gochecknoglobals
 )
 
-// TestMain will exec each test, one by one
+// TestMain lets us customize the test run. See https://medium.com/goingogo/why-use-testmain-for-testing-in-go-dafb52b406bc
 func TestMain(m *testing.M) {
-	retCode := 0
+	retCode, err := doAllTheThings(m)
+	if err != nil {
+		fmt.Println(err) //nolint:forbidigo
+	}
+	os.Exit(retCode)
+}
 
+// doAllTheThings just wraps what should go in TestMain. It's in its own function so it can
+// [a] Not have a bunch of `os.Exit()` calls in it
+// [b] Do defers properly
+// [c] Handle errors cleanly
+//
+// It returns the return code passed from `m.Run()` and any error thrown.
+func doAllTheThings(m *testing.M) (int, error) {
+	var err error
+
+	// Set up constants in the global variable that all the tests are able to access
 	e2e.arch = config.GetArch()
 
-	// Set up constants for the tests
 	e2e.zarfBinPath = path.Join("../../build", getCLIName())
-
-	// Run the tests if a valid cluster exists or we're being told to create the K3s cluster
-	if e2e.checkIfClusterRunning() || shouldCreateK3sCluster() {
-		retCode = m.Run()
-	} else {
-		fmt.Printf(`Unable to run tests. No valid cluster present and TESTDISTRO != "k3s"`)
-		retCode = 1
+	e2e.distroToUse, err = clusters.GetDistroToUseFromString(os.Getenv("TESTDISTRO"))
+	if err != nil {
+		return 1, fmt.Errorf("unable to determine which k8s cluster to use. Env var TESTDISTRO must be present with "+
+			"value [provided|kind|k3d|k3s]: %v", err)
 	}
 
-	// If exit code is distinct of zero, the test will be failed (red)
-	os.Exit(retCode)
+	// Validate that the Zarf binary exists. If it doesn't that means the dev hasn't built it, usually by running
+	// `make build-cli`
+	_, err = os.Stat(e2e.zarfBinPath)
+	if err != nil {
+		return 1, fmt.Errorf("zarf binary %v not found", e2e.zarfBinPath)
+	}
+
+	// If needed:
+	// [1] Create the cluster with a temporary kubeconfig file
+	// [2] Update the the KUBECONFIG env var
+	// [3] Defer the cluster destroy, deletion of the temp file, and rest of the KUBECONFIG env var back to original
+	//     value
+	if e2e.distroToUse == clusters.Kind || e2e.distroToUse == clusters.K3d {
+		// Create the cluster
+		tempKubeconfigFilePath, err := clusters.CreateClusterWithTemporaryKubeconfig(e2e.distroToUse)
+		if err != nil {
+			return 1, fmt.Errorf("unable to create %v cluster: %w", e2e.distroToUse.String(), err)
+		}
+
+		// Modify KUBECONFIG
+		currentKubeconfig := os.Getenv("KUBECONFIG")
+		err = os.Setenv("KUBECONFIG", currentKubeconfig)
+		if err != nil {
+			return 1, fmt.Errorf("unable to update KUBECONFIG env var: %w", err)
+		}
+
+		// Defer cleanup
+		defer func(tempKubeconfigFilePath string) {
+			err := clusters.DeleteClusterAndTemporaryKubeconfig(e2e.distroToUse, tempKubeconfigFilePath)
+			if err != nil {
+				fmt.Println(fmt.Errorf("unable to delete cluster and temporary kubeconfig: %w", err)) //nolint:forbidigo
+			}
+		}(tempKubeconfigFilePath)
+	}
+
+	// Final check to make sure we have a working k8s cluster
+	err = clusters.TryValidateClusterIsRunning()
+	if err != nil {
+		return 1, fmt.Errorf("unable to connect to a running k8s cluster: %w", err)
+	}
+
+	// Run the tests, with the cluster cleanup being deferred to the end of the function call
+	retcode := m.Run()
+
+	return retcode, nil
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Any relevant motivation or context is also helpful, as well as any dependencies that are required for this change -->

Simplifies the handling of kubernetes clusters from this logic:

1. Determine if a cluster is already running, and if it is, use it instead of creating one
1. If a cluster isn't running, create one using the Golang libraries for Kind and/or K3d, using a hard-coded `KUBECONFIG` file (`~/.kube/config`)
    - If TESTDISTRO is not set, run the tests twice, once on KinD, and again on K3d
    - If TESTDISTRO is set to either `kind` or `k3d` only do that one
1. Run the tests
1. Destroy the cluster if it was created and delete the `~/.kube/config` file 

To this:

1. Expect TESTDISTRO env var to be set, with value one of `provided`, `kind`, `k3d`, or `k3s` and error out if it isn't
1. If TESTDISTRO is 
    - `kind` or `k3d` -- create that cluster using the associated golang library, using a temporary file for the KUBECONFIG.
    - `provided` -- Use the provided cluster, using the existing KUBECONFIG
    - `k3s` -- Use `zarf init --components k3s` to create the cluster and `zarf destroy` to delete it (done as part of each test so that each test gets a fresh cluster)
1. Run the tests
1. If not `provided` or `k3s`, destroy the cluster and temporary KUBECONFIG file

The pipeline will provide the KinD cluster, and will expect the tests to create the K3d and K3s clusters

## Related Issue

<!--- This project prefers to accept pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

Fixes #406
Related to #373 (except for needing a new e2e test)

## Type of change

<!-- Please delete options that are not relevant -->

- [X] Refactor (non-breaking change which preserves functionality and increases maintainability)

## Checklist before merging

<!-- Please delete options that are not relevant -->

- [x] Tests have been added/updated as necessary (add the `needs-tests` label)
- [x] Documentation has been updated as necessary (add the `needs-docs` label)
- [x] An ADR has been written as necessary (add the `needs-adr` label) [ [1](https://github.com/joelparkerhenderson/architecture-decision-record) [2](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) [3](https://adr.github.io/) ]
- [x] (Optional) Changes have been linted locally with [golangci-lint](https://github.com/golangci/golangci-lint). (NOTE: We haven't turned on lint checks in the pipeline yet so linting may be hard if it shows a lot of lint errors in places that weren't touched by changes. Thus, linting is optional right now.)
