### PR TITLE
Replace assert with require in critical parts

### DIFF
--- a/test/e2e/e2e_composability_test.go
+++ b/test/e2e/e2e_composability_test.go
@@ -29,11 +29,11 @@ func TestE2eExampleComposability(t *testing.T) {
 
 	// Right now we're just checking that `curl` returns 0. It can be enhanced by scraping the HTML that gets returned or something.
 	resp, err := http.Get("http://127.0.0.1:22333?doom")
-	assert.NoError(t, err, resp)
+	require.NoError(t, err, resp)
 
 	// Read the body into string
 	body, err := io.ReadAll(resp.Body)
-	assert.NoError(t, err, body)
+	require.NoError(t, err, body)
 
 	// Validate the doom title in body.
 	assert.Contains(t, string(body), "Zarf needs games too")


### PR DESCRIPTION

## Description

Now using require.NoError in test parts which are critical

## Related Issue

Fixes #405

## Type of change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging
