### PR TITLE
Better KUBECONFIG support

### DIFF
--- a/cli/internal/k8s/common.go
+++ b/cli/internal/k8s/common.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"time"
 
@@ -153,21 +152,13 @@ func init() {
 func getRestConfig() *rest.Config {
 	message.Debug("k8s.getRestConfig()")
 
-	// use the KUBECONFIG context if it exists
-	configPath := os.Getenv("KUBECONFIG")
-	if configPath == "" {
-		// use the current context in the default kubeconfig in the home path of the user
-		homePath, err := os.UserHomeDir()
-		if err != nil {
-			message.Fatal(nil, "Unable to load the current user's home directory")
-		}
-		configPath = homePath + "/.kube/config"
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags("", configPath)
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{}).ClientConfig()
 	if err != nil {
 		message.Fatalf(err, "Unable to connect to the K8s cluster")
 	}
+
 	return config
 }
 

--- a/cli/internal/k8s/common.go
+++ b/cli/internal/k8s/common.go
@@ -149,9 +149,13 @@ func init() {
 	klog.SetLogger(generateLogShim())
 }
 
+// getRestConfig uses the K8s "client-go" library to get the currently active kube context, in the same way that
+// "kubectl" gets it if no extra config flags like "--kubeconfig" are passed
 func getRestConfig() *rest.Config {
 	message.Debug("k8s.getRestConfig()")
 
+	// Build the config from the currently active kube context in the default way that the k8s client-go gets it, which
+	// is to look at the KUBECONFIG env var
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(),
 		&clientcmd.ConfigOverrides{}).ClientConfig()


### PR DESCRIPTION
## Description

Supports KUBECONFIG env vars in a way that more closely resembles how `kubectl` handles it, by utilizing the defaults in the `client-go` library

## Related Issue

<!--- This project prefers to accept pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

Related to #373 (but doesn't close it since it isn't adding a needed E2E test)

## Type of change

<!-- Please delete options that are not relevant -->

- [X] New feature (non-breaking change which adds functionality)

## Checklist before merging

<!-- Please delete options that are not relevant -->

- [X] Tests have been added/updated as necessary (add the `needs-tests` label)
- [X] Documentation has been updated as necessary (add the `needs-docs` label)
- [X] An ADR has been written as necessary (add the `needs-adr` label) [ [1](https://github.com/joelparkerhenderson/architecture-decision-record) [2](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) [3](https://adr.github.io/) ]
- [X] (Optional) Changes have been linted locally with [golangci-lint](https://github.com/golangci/golangci-lint). (NOTE: We haven't turned on lint checks in the pipeline yet so linting may be hard if it shows a lot of lint errors in places that weren't touched by changes. Thus, linting is optional right now.)
