### PR TITLE
Fix workflow yaml for github release 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
-Name: Publish Zarf Packages on Tag
+name: Publish Zarf Packages on Tag
 
 on:
   push:
-    branches:
-      - master
     tags:
       - 'v*'
 


### PR DESCRIPTION
Difficult to test master workflows in PRs--this tiny PR addresses issues found after merge, fix for #370 after #408.  Relevant docs:  https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-only-when-a-push-of-specific-tags-occurs.  