### PR TITLE
Hotfix: Change release names of resources uploaded to S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,11 @@ jobs:
         with:
           generate_release_notes: true    # Generates basic release notes that we can edit later
           body: |
-            - [zarf-linux-amd64](https://zarf-public.s3-us-gov-west-1.amazonaws.com/release/${{ github.ref_name }}/zarf)
-            - [zarf-macos-m1](https://zarf-public.s3-us-gov-west-1.amazonaws.com/release/${{ github.ref_name }}zarf-mac-apple)
-            - [zarf-macos-intel](https://zarf-public.s3-us-gov-west-1.amazonaws.com/release/${{ github.ref_name }}zarf-mac-intel)
-            - [zarf-int.tar.zst](https://zarf-public.s3-us-gov-west-1.amazonaws.com/release/${{ github.ref_name }}/zarf-init-amd64.tar.zst)
-            - [zarf-int.tar.zst](https://zarf-public.s3-us-gov-west-1.amazonaws.com/release/${{ github.ref_name }}/zarf-init-arm64.tar.zst)
+            - [zarf](https://zarf-public.s3-us-gov-west-1.amazonaws.com/release/${{ github.ref_name }}/zarf)
+            - [zarf-mac-apple](https://zarf-public.s3-us-gov-west-1.amazonaws.com/release/${{ github.ref_name }}zarf-mac-apple)
+            - [zarf-mac-intel](https://zarf-public.s3-us-gov-west-1.amazonaws.com/release/${{ github.ref_name }}zarf-mac-intel)
+            - [zarf-init-amd64.tar.zst](https://zarf-public.s3-us-gov-west-1.amazonaws.com/release/${{ github.ref_name }}/zarf-init-amd64.tar.zst)
+            - [zarf-init-arm64.tar.zst](https://zarf-public.s3-us-gov-west-1.amazonaws.com/release/${{ github.ref_name }}/zarf-init-arm64.tar.zst)
             - [zarf.sha256](https://zarf-public.s3-us-gov-west-1.amazonaws.com/release/${{ github.ref_name }}/zarf.sha256)
           files: |
             build/zarf


### PR DESCRIPTION
## Description

The name of the artifacts uploaded to the S3 bucket should match the name of the resources when they're built locally.
