### PR TITLE
fix(credentialParser): validate error before parsing password to avoid nil pointer. #418

### DIFF
--- a/cli/internal/git/utils.go
+++ b/cli/internal/git/utils.go
@@ -63,10 +63,10 @@ func credentialParser() []Credential {
 	scanner := bufio.NewScanner(credentialsFile)
 	for scanner.Scan() {
 		gitUrl, err := url.Parse(scanner.Text())
-		password, _ := gitUrl.User.Password()
 		if err != nil {
 			continue
 		}
+		password, _ := gitUrl.User.Password()
 		credential := Credential{
 			Path: gitUrl.Host,
 			Auth: http.BasicAuth{


### PR DESCRIPTION
…

## Description

<!-- Please include a summary of the change. Any relevant motivation or context is also helpful, as well as any dependencies that are required for this change -->

Even though the credentialParser is capturing an error during the parsing, it tries to retrieve the password without being sure the error is nil

## Related Issue

<!--- This project prefers to accept pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

Fixes # (issue)
#418 

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging

<!-- Please delete options that are not relevant -->

- [x] (Optional) Changes have been linted locally with [golangci-lint](https://github.com/golangci/golangci-lint). (NOTE: We haven't turned on lint checks in the pipeline yet so linting may be hard if it shows a lot of lint errors in places that weren't touched by changes. Thus, linting is optional right now.)
