### PR TITLE
Update gitops-service component in init config

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -15,10 +15,10 @@ Backed by tooling you already know (and love) & structured to fill the gaps you 
 
 Zarf's work necessitates that some components are "always on" (a.k.a. required & cannot be disabled). Those include:
 
-|                   |Description|
-|---                |---|
-|container-seed-registry|Adds a container registry so Zarf can bootstrap itself into the cluster.|
-|container-registry |Adds a container registry service&mdash;[docker registry](https://docs.docker.com/registry/)&mdash;into the cluster.|
+|                         | Description                                                                                                          |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| container-seed-registry | Adds a container registry so Zarf can bootstrap itself into the cluster.                                             |
+| container-registry      | Adds a container registry service&mdash;[docker registry](https://docs.docker.com/registry/)&mdash;into the cluster. |
 
 &nbsp;
 
@@ -29,11 +29,11 @@ In addition to those that are always installed, Zarf's optional components provi
 
 These optional components are listed below along with the "magic strings" you pass to `zarf init --components` to pull them in:
 
-| --components |Description|
-|--------------|---|
-| k3s          |Installs a lightweight Kubernetes Cluster on the local host&mdash;[k3s](https://k3s.io/)&mdash;and configures it to start up on boot.|
-| logging      |Adds a log monitoring stack&mdash;[promtail / loki / graphana (a.k.a. PLG)](https://github.com/grafana/loki)&mdash;into the cluster.|
-| git-server   |Adds a [GitOps](https://www.cloudbees.com/gitops/what-is-gitops)-compatible source control service&mdash;[Gitea](https://gitea.io/en-us/)&mdash;into the cluster.|
+| --components | Description                                                                                                                                                       |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| k3s          | Installs a lightweight Kubernetes Cluster on the local host&mdash;[k3s](https://k3s.io/)&mdash;and configures it to start up on boot.                             |
+| logging      | Adds a log monitoring stack&mdash;[promtail / loki / graphana (a.k.a. PLG)](https://github.com/grafana/loki)&mdash;into the cluster.                              |
+| git-server   | Adds a [GitOps](https://www.cloudbees.com/gitops/what-is-gitops)-compatible source control service&mdash;[Gitea](https://gitea.io/en-us/)&mdash;into the cluster. |
 
 &nbsp;
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -29,11 +29,11 @@ In addition to those that are always installed, Zarf's optional components provi
 
 These optional components are listed below along with the "magic strings" you pass to `zarf init --components` to pull them in:
 
-|--components       |Description|
-|---                |---|
-|k3s                |Installs a lightweight Kubernetes Cluster on the local host&mdash;[k3s](https://k3s.io/)&mdash;and configures it to start up on boot.|
-|logging            |Adds a log monitoring stack&mdash;[promtail / loki / graphana (a.k.a. PLG)](https://github.com/grafana/loki)&mdash;into the cluster.|
-|gitops-service     |Adds a [GitOps](https://www.cloudbees.com/gitops/what-is-gitops)-compatible source control service&mdash;[Gitea](https://gitea.io/en-us/)&mdash;into the cluster.|
+| --components |Description|
+|--------------|---|
+| k3s          |Installs a lightweight Kubernetes Cluster on the local host&mdash;[k3s](https://k3s.io/)&mdash;and configures it to start up on boot.|
+| logging      |Adds a log monitoring stack&mdash;[promtail / loki / graphana (a.k.a. PLG)](https://github.com/grafana/loki)&mdash;into the cluster.|
+| git-server   |Adds a [GitOps](https://www.cloudbees.com/gitops/what-is-gitops)-compatible source control service&mdash;[Gitea](https://gitea.io/en-us/)&mdash;into the cluster.|
 
 &nbsp;
 

--- a/docs/what-is-zarf.md
+++ b/docs/what-is-zarf.md
@@ -96,7 +96,7 @@ Find some detailed uses of the `zarf.yaml` file in [our examples](../examples/).
 
 #### (2) - Package
 
-Actually making a Zarf package out of a `zarf.yaml` file is a matter of calling a single, simple command: `zarf package`.  You'll see a `zarf-package-*.tar.zst` file pop into existence afterward&mdash;that's your package.
+Actually making a Zarf package out of a `zarf.yaml` file is a matter of calling a single, simple command: `zarf package create`.  You'll see a `zarf-package-*.tar.zst` file pop into existence afterward&mdash;that's your package.
 
 Find out more about that by calling the CLI for help, or check out an example package build in [our game example](../examples/game#package-the-game).
 
@@ -136,9 +136,9 @@ Move a Zarf release + your desired packages to your Zarf cluster machine.
 
 Make your machine into a **single node** Zarf cluster with the command: `zarf init`.
 
-Recommended Zarf components: `management`.
+Recommended Zarf components: `k3s`.
 
-Deploy your package into the Zarf cluster with the command: `zarf deploy`.
+Deploy your package into the Zarf cluster with the command: `zarf package deploy`.
 
 #### (✓) - Use it
 
@@ -159,11 +159,13 @@ Move a Zarf release + desired packages to your Zarf cluster machine.
 
 #### (1) - Zarf cluster
 
-Make your Zarf cluster machine into a **single node** Zarf cluster with the command: `zarf init`.
+Configure your system to talk to an existing Kubernetes cluster, then run `zarf init`
 
-Recommended Zarf components: `management` & `gitops-services`.
+Recommended Zarf components: `git-server`.
 
-Deploy your package into the Zarf cluster with the command: `zarf deploy`.
+Deploy your package into the Zarf cluster with the command: `zarf package deploy`.
+
+> Utility Mode can be used in "single node K3s" mode too, just add the `k3s` component as well when running `zarf init`.
 
 #### (2) - Downstream cluster
 

--- a/examples/big-bang/README.md
+++ b/examples/big-bang/README.md
@@ -59,7 +59,7 @@ make vm-init
 
 ```shell
 # Initialize Zarf
-./zarf init --confirm --components k3s,gitops-service
+./zarf init --confirm --components k3s,git-server
 
 # (Optional) Inspect the results
 ./zarf tools k9s

--- a/examples/istio-with-separate-cert/README.md
+++ b/examples/istio-with-separate-cert/README.md
@@ -54,7 +54,7 @@ make vm-init
 
 ```shell
 # Initialize Zarf
-./zarf init --confirm --components k3s,gitops-service
+./zarf init --confirm --components k3s,git-server
 
 # (Optional) Inspect the results
 ./zarf tools k9s

--- a/packages/gitea/zarf.yaml
+++ b/packages/gitea/zarf.yaml
@@ -3,7 +3,7 @@ metadata:
   name: Zarf Gitea Service for Gitops
 
 components:
-  - name: gitops-service
+  - name: gitea
     description: "Add Gitea for serving gitops-based clusters in an airgap"
     images:
       - gitea/gitea:1.13.7

--- a/packages/gitea/zarf.yaml
+++ b/packages/gitea/zarf.yaml
@@ -3,7 +3,7 @@ metadata:
   name: Zarf Gitea Service for Gitops
 
 components:
-  - name: gitea
+  - name: git-server
     description: "Add Gitea for serving gitops-based clusters in an airgap"
     images:
       - gitea/gitea:1.13.7

--- a/packages/gitea/zarf.yaml
+++ b/packages/gitea/zarf.yaml
@@ -4,7 +4,7 @@ metadata:
 
 components:
   - name: gitops-service
-    description: "Add Registry and Gitea for serving gitops-based clusters in an airgap"
+    description: "Add Gitea for serving gitops-based clusters in an airgap"
     images:
       - gitea/gitea:1.13.7
     charts:

--- a/src/test/e2e/e2e_gitea_and_grafana_test.go
+++ b/src/test/e2e/e2e_gitea_and_grafana_test.go
@@ -12,7 +12,7 @@ func TestGiteaAndGrafana(t *testing.T) {
 	defer e2e.cleanupAfterTest(t)
 
 	// run `zarf init`
-	output, err := e2e.execZarfCommand("init", "--components=gitops-service,logging", "--confirm")
+	output, err := e2e.execZarfCommand("init", "--components=git-server,logging", "--confirm")
 	require.NoError(t, err, output)
 
 	// Establish the port-forward into the gitea service; give the service a few seconds to come up since this is not a command we can retry

--- a/src/test/e2e/e2e_gitops_example_test.go
+++ b/src/test/e2e/e2e_gitops_example_test.go
@@ -15,7 +15,7 @@ func TestGitopsExample(t *testing.T) {
 	defer e2e.cleanupAfterTest(t)
 
 	// run `zarf init`
-	output, err := e2e.execZarfCommand("init", "--confirm", "--components=gitops-service")
+	output, err := e2e.execZarfCommand("init", "--confirm", "--components=git-server")
 	require.NoError(t, err, output)
 
 	path := fmt.Sprintf("../../../build/zarf-package-gitops-service-data-%s.tar.zst", e2e.arch)

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -36,6 +36,6 @@ components:
     import:
       path: packages/logging-pgl
 
-  - name: gitea
+  - name: git-server
     import:
       path: packages/gitea

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -36,6 +36,6 @@ components:
     import:
       path: packages/logging-pgl
 
-  - name: gitops-service
+  - name: gitea
     import:
       path: packages/gitea


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Any relevant motivation or context is also helpful, as well as any dependencies that are required for this change -->

Update the name of the `gitops-service` component in the init config to `git-server`, since it now only includes a git server. 

## Related Issue

<!--- This project prefers to accept pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

none

## Type of change

<!-- Please delete options that are not relevant -->

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before merging

<!-- Please delete options that are not relevant -->

- [X] Tests have been added/updated as necessary (add the `needs-tests` label)
- [X] Documentation has been updated as necessary (add the `needs-docs` label)
- [X] An ADR has been written as necessary (add the `needs-adr` label) [ [1](https://github.com/joelparkerhenderson/architecture-decision-record) [2](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) [3](https://adr.github.io/) ]
- [X] (Optional) Changes have been linted locally with [golangci-lint](https://github.com/golangci/golangci-lint). (NOTE: We haven't turned on lint checks in the pipeline yet so linting may be hard if it shows a lot of lint errors in places that weren't touched by changes. Thus, linting is optional right now.)
