### PR TITLE
338 configurable script timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ ci-release: init-package ## Create the init package
 package-example-game: ## Create the Doom example
 	cd examples/game && ../../$(ZARF_BIN) package create --confirm && mv zarf-package-* ../../build/
 
+.PHONY: package-example-component-scripts
+package-example-component-scripts: ## Create component script example
+	cd examples/component-scripts && ../../$(ZARF_BIN) package create --confirm && mv zarf-package-* ../../build/
+
 .PHONY: package-example-data-injection
 package-example-data-injection: ## create the Zarf package for the data injection example
 	cd examples/data-injection && ../../$(ZARF_BIN) package create --confirm && mv zarf-package-* ../../build/
@@ -96,6 +100,9 @@ test-e2e: ## Run e2e tests. Will automatically build any required dependencies t
 	fi
 	@if [ ! -f ./build/zarf-package-appliance-demo-multi-games-$(ARCH).tar.zst ]; then\
 		$(MAKE) package-example-game;\
+	fi
+	@if [ ! -f zarf-package-component-scripts-$(ARCH).tar.zst ]; then\
+		$(MAKE) package-example-component-scripts;\
 	fi
 	@if [ ! -f ./build/zarf-package-data-injection-demo-$(ARCH).tar ]; then\
 		$(MAKE) package-example-data-injection;\

--- a/examples/component-scripts/zarf.yaml
+++ b/examples/component-scripts/zarf.yaml
@@ -13,6 +13,6 @@ components:
   # This script will fail after 1 seconds
   - name: fails
     scripts:
-      timeout: 1
+      timeoutSeconds: 1
       before:
         - "sleep 30"

--- a/examples/component-scripts/zarf.yaml
+++ b/examples/component-scripts/zarf.yaml
@@ -1,0 +1,18 @@
+kind: ZarfPackageConfig
+metadata:
+  name: component-scripts
+  description: "Test component to demonstrate script timeout feature"
+
+components:
+  # This script will pass after 1 second
+  - name: passes
+    scripts:
+      before:
+        - "sleep 1"
+
+  # This script will fail after 1 seconds
+  - name: fails
+    scripts:
+      timeout: 1
+      before:
+        - "sleep 30"

--- a/packages/distros/eks/eks.yaml
+++ b/packages/distros/eks/eks.yaml
@@ -2,10 +2,12 @@
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 metadata:
-  region: us-east-1
+# name: CHANGE_ME_MUST_BE_UNIQUE  
+  region: us-west-1
   version: "1.21"
 managedNodeGroups:
 - instanceType: t3.small
+# name: CHANGE_ME_MUST_BE_UNIQUE
   minSize: 3
   maxSize: 6
   spot: true

--- a/packages/distros/eks/zarf.yaml
+++ b/packages/distros/eks/zarf.yaml
@@ -1,0 +1,40 @@
+kind: ZarfPackageConfig
+metadata:
+  name: "eks-k8s-distro"
+  description: "Deploy a EKS K8s cluster"
+  architecture: multi
+
+components:
+  - name: load-eksctl
+    required: true
+    scripts:
+      after:
+        # Remove existing eksctl
+        - "rm -f eksctl"
+        # Extract the correct linux or mac binary from the tarball 
+        - "./zarf tools archiver decompress archives/eksctl_$(uname -s)_$(uname -m).tar.gz ."
+        # Cleanup temp files
+        - "rm -fr archives"
+    files:
+      - source: eks.yaml
+        target: eks.yaml
+      - source: https://github.com/weaveworks/eksctl/releases/download/v0.93.0/eksctl_Darwin_amd64.tar.gz
+        target: archives/eksctl_Darwin_amd64.tar.gz
+        shasum: 4ab4c9199ef4fcb26e3b536484773c0c4c648290e2341585c6bd5bfd79d44fb1
+      - source: https://github.com/weaveworks/eksctl/releases/download/v0.93.0/eksctl_Darwin_arm64.tar.gz
+        target: archives/eksctl_Darwin_arm64.tar.gz
+        shasum: 89adbf6085d37b70ae82d126c912ac82b9283e0fe5507a2b19343d0d566c6164
+      - source: https://github.com/weaveworks/eksctl/releases/download/v0.93.0/eksctl_Linux_amd64.tar.gz
+        target: archives/eksctl_Linux_x86_64.tar.gz
+        shasum: 7f27988d6aa4fb8041d95d6de270b9657f605a79edd317cc044dc80c49a512e8
+
+  - name: deploy-eks-cluster
+    scripts:
+      # Set timeout to 1 hr
+      timeout: 3600
+      # Show the output while the scripts run
+      showOutput: true
+      before:
+        - "./eksctl create cluster --dry-run -f eks.yaml"
+        - "sleep 15"
+        - "./eksctl create cluster -f eks.yaml"

--- a/src/cmd/destroy.go
+++ b/src/cmd/destroy.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"os"
 	"regexp"
@@ -44,7 +45,7 @@ var destroyCmd = &cobra.Command{
 			// Iterate over al matching zarf-clean scripts and exec them
 			for _, script := range scripts {
 				// Run the matched script
-				_, err := utils.ExecCommand(true, nil, script)
+				_, err := utils.ExecCommandWithContext(context.TODO(), true, script)
 				if errors.Is(err, os.ErrPermission) {
 					message.Warnf("Got a 'permission denied' when trying to execute the script (%v). Are you the right user and/or do you have the right kube-context?\n", script)
 

--- a/src/cmd/destroy.go
+++ b/src/cmd/destroy.go
@@ -45,7 +45,7 @@ var destroyCmd = &cobra.Command{
 			// Iterate over al matching zarf-clean scripts and exec them
 			for _, script := range scripts {
 				// Run the matched script
-				_, err := utils.ExecCommandWithContext(context.TODO(), true, script)
+				_, _, err := utils.ExecCommandWithContext(context.TODO(), true, script)
 				if errors.Is(err, os.ErrPermission) {
 					message.Warnf("Got a 'permission denied' when trying to execute the script (%v). Are you the right user and/or do you have the right kube-context?\n", script)
 

--- a/src/cmd/tools.go
+++ b/src/cmd/tools.go
@@ -12,7 +12,6 @@ import (
 	"github.com/defenseunicorns/zarf/src/internal/git"
 	"github.com/defenseunicorns/zarf/src/internal/k8s"
 	"github.com/defenseunicorns/zarf/src/internal/message"
-	"github.com/defenseunicorns/zarf/src/internal/pki"
 	k9s "github.com/derailed/k9s/cmd"
 	craneCmd "github.com/google/go-containerregistry/cmd/crane/cmd"
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -100,15 +99,6 @@ var configSchemaCmd = &cobra.Command{
 	},
 }
 
-var trustCACmd = &cobra.Command{
-	Use:     "trust-root-ca [CAFILEPATH]",
-	Aliases: []string{"t"},
-	Short:   "Import the given root cert into the running operating systems certificate store (Linux only)",
-	Run: func(cmd *cobra.Command, args []string) {
-		pki.AddCAToTrustStore(os.Args[0])
-	},
-}
-
 var k9sCmd = &cobra.Command{
 	Use:     "monitor",
 	Aliases: []string{"m", "k9s"},
@@ -144,10 +134,7 @@ func init() {
 	toolsCmd.AddCommand(configSchemaCmd)
 	toolsCmd.AddCommand(k9sCmd)
 	toolsCmd.AddCommand(registryCmd)
-	toolsCmd.AddCommand(trustCACmd)
 	toolsCmd.AddCommand(createReadOnlyGiteaUser)
-
-	trustCACmd.Flags().BoolVar(&configCaImport, "confirm", false, "Confirm the installation of t")
 
 	archiverCmd.AddCommand(archiverCompressCmd)
 	archiverCmd.AddCommand(archiverDecompressCmd)

--- a/src/internal/packager/common.go
+++ b/src/internal/packager/common.go
@@ -258,11 +258,11 @@ func loopScriptUntilSuccess(script string, scripts types.ZarfComponentScripts) {
 		// Oherwise try running the script
 		default:
 			ctx, cancel = context.WithTimeout(context.Background(), duration)
-			output, err := utils.ExecCommandWithContext(ctx, scripts.ShowOutput, "sh", "-c", script)
+			output, errOut, err := utils.ExecCommandWithContext(ctx, scripts.ShowOutput, "sh", "-c", script)
 			defer cancel()
 
 			if err != nil {
-				message.Debug(err, output)
+				message.Debug(err, output, errOut)
 				// If retry, let the script run again
 				if scripts.Retry {
 					continue
@@ -273,7 +273,7 @@ func loopScriptUntilSuccess(script string, scripts types.ZarfComponentScripts) {
 
 			// Dump the script output in debug if output not already streamed
 			if !scripts.ShowOutput {
-				message.Debug(output)
+				message.Debug(output, errOut)
 			}
 
 			// Close the function now that we are done

--- a/src/internal/packager/common.go
+++ b/src/internal/packager/common.go
@@ -254,7 +254,7 @@ func loopScriptUntilSuccess(script string, scripts types.ZarfComponentScripts) {
 		// On timeout abort
 		case <-timeout:
 			cancel()
-			spinner.Fatalf(nil, "Script timed out")
+			spinner.Fatalf(nil, "Script \"%s\" timed out", script)
 		// Oherwise try running the script
 		default:
 			ctx, cancel = context.WithTimeout(context.Background(), duration)
@@ -271,13 +271,13 @@ func loopScriptUntilSuccess(script string, scripts types.ZarfComponentScripts) {
 				spinner.Fatalf(err, "Script \"%s\" failed (%s)", script, err.Error())
 			}
 
-			// Script successful,continue
-			// Only show success message if not showing logging
-			if scripts.TimeoutSeconds < 120 {
+			// Dump the script output in debug if output not already streamed
+			if !scripts.ShowOutput {
 				message.Debug(output)
-				spinner.Success()
 			}
 
+			// Close the function now that we are done
+			spinner.Success()
 			return
 		}
 	}

--- a/src/internal/packager/deploy.go
+++ b/src/internal/packager/deploy.go
@@ -316,7 +316,7 @@ func handleDataInjection(wg *sync.WaitGroup, data types.ZarfDataInjection, compo
 				}
 
 				// Do the actual data injection
-				_, err := utils.ExecCommandWithContext(context.TODO(), true, "kubectl", cpPodExecArgs...)
+				_, _, err := utils.ExecCommandWithContext(context.TODO(), true, "kubectl", cpPodExecArgs...)
 				if err != nil {
 					message.Warnf("Error copying data into the pod %v: %v\n", pod, err)
 					continue
@@ -324,7 +324,7 @@ func handleDataInjection(wg *sync.WaitGroup, data types.ZarfDataInjection, compo
 					// Leave a marker in the target container for pods to track the sync action
 					cpPodExecArgs[3] = injectionCompletionMarker
 					cpPodExecArgs[4] = pod + ":" + data.Target.Path
-					_, err = utils.ExecCommandWithContext(context.TODO(), true, "kubectl", cpPodExecArgs...)
+					_, _, err = utils.ExecCommandWithContext(context.TODO(), true, "kubectl", cpPodExecArgs...)
 					if err != nil {
 						message.Warnf("Error saving the zarf sync completion file after injection into pod %v\n", pod)
 					}

--- a/src/internal/packager/deploy.go
+++ b/src/internal/packager/deploy.go
@@ -1,6 +1,7 @@
 package packager
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -125,7 +126,7 @@ func deployComponents(tempPath tempPaths, component types.ZarfComponent) {
 	message.HeaderInfof("📦 %s COMPONENT", strings.ToUpper(component.Name))
 
 	for _, script := range component.Scripts.Before {
-		loopScriptUntilSuccess(script, component.Scripts.Retry)
+		loopScriptUntilSuccess(script, component.Scripts)
 	}
 
 	if len(component.Files) > 0 {
@@ -260,7 +261,7 @@ func deployComponents(tempPath tempPaths, component types.ZarfComponent) {
 	}
 
 	for _, script := range component.Scripts.After {
-		loopScriptUntilSuccess(script, component.Scripts.Retry)
+		loopScriptUntilSuccess(script, component.Scripts)
 	}
 
 	if isSeedRegistry {
@@ -315,7 +316,7 @@ func handleDataInjection(wg *sync.WaitGroup, data types.ZarfDataInjection, compo
 				}
 
 				// Do the actual data injection
-				_, err := utils.ExecCommand(true, nil, "kubectl", cpPodExecArgs...)
+				_, err := utils.ExecCommandWithContext(context.TODO(), true, "kubectl", cpPodExecArgs...)
 				if err != nil {
 					message.Warnf("Error copying data into the pod %v: %v\n", pod, err)
 					continue
@@ -323,7 +324,7 @@ func handleDataInjection(wg *sync.WaitGroup, data types.ZarfDataInjection, compo
 					// Leave a marker in the target container for pods to track the sync action
 					cpPodExecArgs[3] = injectionCompletionMarker
 					cpPodExecArgs[4] = pod + ":" + data.Target.Path
-					_, err = utils.ExecCommand(true, nil, "kubectl", cpPodExecArgs...)
+					_, err = utils.ExecCommandWithContext(context.TODO(), true, "kubectl", cpPodExecArgs...)
 					if err != nil {
 						message.Warnf("Error saving the zarf sync completion file after injection into pod %v\n", pod)
 					}

--- a/src/internal/packager/validate/validate.go
+++ b/src/internal/packager/validate/validate.go
@@ -36,7 +36,7 @@ func Run() {
 
 func validatePackageName(subject string) error {
 	// https://regex101.com/r/vpi8a8/1
-	isValid := regexp.MustCompile(`^[a-z\-]+$`).MatchString
+	isValid := regexp.MustCompile(`^[a-z0-9\-]+$`).MatchString
 	if isValid(subject) {
 		return nil
 	}

--- a/src/internal/pki/pki.go
+++ b/src/internal/pki/pki.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/internal/message"
-	"github.com/defenseunicorns/zarf/src/internal/utils"
 	"github.com/defenseunicorns/zarf/src/types"
 )
 
@@ -62,27 +61,6 @@ func GeneratePKI(conf *types.TLSConfig) GeneratedPKI {
 	})
 
 	return results
-}
-
-func AddCAToTrustStore(caFilePath string) {
-	message.Info("Adding Ephemeral CA to the host root trust store")
-
-	rhelBinary := "update-ca-trust"
-	debianBinary := "update-ca-certificates"
-
-	if utils.VerifyBinary(rhelBinary) {
-		utils.CreatePathAndCopy(caFilePath, "/etc/pki/ca-trust/source/anchors/zarf-ca.crt")
-		_, err := utils.ExecCommand(true, nil, rhelBinary, "extract")
-		if err != nil {
-			message.Error(err, "Error adding the ephemeral CA to the RHEL root trust")
-		}
-	} else if utils.VerifyBinary(debianBinary) {
-		utils.CreatePathAndCopy(caFilePath, "/usr/local/share/ca-certificates/extra/zarf-ca.crt")
-		_, err := utils.ExecCommand(true, nil, debianBinary)
-		if err != nil {
-			message.Error(err, "Error adding the ephemeral CA to the trust store")
-		}
-	}
 }
 
 // newCertificate creates a new template

--- a/src/internal/utils/exec.go
+++ b/src/internal/utils/exec.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -17,10 +18,10 @@ const colorCyan = "\x1b[36;1m"
 const colorWhite = "\x1b[37;1m"
 
 //nolint
-func ExecCommand(showLogs bool, envVariables []string, commandName string, args ...string) (string, error) {
+func ExecCommandWithContext(ctx context.Context, showLogs bool, commandName string, args ...string) (string, error) {
 	if showLogs {
 		fmt.Println()
-		fmt.Printf("%s", colorGreen)
+		fmt.Printf("  %s", colorGreen)
 		fmt.Print(commandName + " ")
 		fmt.Printf("%s", colorCyan)
 		fmt.Printf("%v", args)
@@ -29,11 +30,9 @@ func ExecCommand(showLogs bool, envVariables []string, commandName string, args 
 		fmt.Println("")
 	}
 
-	cmd := exec.Command(commandName, args...)
+	cmd := exec.CommandContext(ctx, commandName, args...)
+
 	env := os.Environ()
-	if envVariables != nil {
-		env = append(env, envVariables...)
-	}
 	cmd.Env = env
 
 	var stdoutBuf, stderrBuf bytes.Buffer

--- a/src/internal/utils/exec.go
+++ b/src/internal/utils/exec.go
@@ -18,7 +18,7 @@ const colorCyan = "\x1b[36;1m"
 const colorWhite = "\x1b[37;1m"
 
 //nolint
-func ExecCommandWithContext(ctx context.Context, showLogs bool, commandName string, args ...string) (string, error) {
+func ExecCommandWithContext(ctx context.Context, showLogs bool, commandName string, args ...string) (string, string, error) {
 	if showLogs {
 		fmt.Println()
 		fmt.Printf("  %s", colorGreen)
@@ -44,7 +44,7 @@ func ExecCommandWithContext(ctx context.Context, showLogs bool, commandName stri
 	stderr := io.MultiWriter(os.Stderr, &stderrBuf)
 
 	if err := cmd.Start(); err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	if showLogs {
@@ -61,14 +61,14 @@ func ExecCommandWithContext(ctx context.Context, showLogs bool, commandName stri
 	}
 
 	if err := cmd.Wait(); err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	if showLogs {
 		if errStdout != nil || errStderr != nil {
-			return "", errors.New("unable to capture stdOut or stdErr")
+			return "", "", errors.New("unable to capture stdOut or stdErr")
 		}
 	}
 
-	return stdoutBuf.String(), nil
+	return stdoutBuf.String(), stderrBuf.String(), nil
 }

--- a/src/test/e2e/e2e_component_scripts_test.go
+++ b/src/test/e2e/e2e_component_scripts_test.go
@@ -1,0 +1,22 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestE2eComponentScripts(t *testing.T) {
+	defer e2e.cleanupAfterTest(t)
+
+	path := fmt.Sprintf("../../../build/zarf-package-component-scripts-%s.tar.zst", e2e.arch)
+
+	// Deploy the simple script that should pass
+	output, err := e2e.execZarfCommand("package", "deploy", path, "--confirm", "--components=passes")
+	require.NoError(t, err, output)
+
+	// Deploy the simple script that should fail the timeout
+	output, err = e2e.execZarfCommand("package", "deploy", path, "--confirm", "--components=fails")
+	require.Error(t, err, output)
+}

--- a/src/test/e2e/e2e_general_cli_test.go
+++ b/src/test/e2e/e2e_general_cli_test.go
@@ -43,12 +43,6 @@ func TestGeneralCLI(t *testing.T) {
 	_, err = e2e.execZarfCommand("init", "--confirm", "--components=k3s,foo,logging")
 	assert.Error(t, err)
 
-	// Test for expected failure when given invalid hostnames
-	output, err = e2e.execZarfCommand("pki", "regenerate", "--host", "zarf@server")
-	assert.Error(t, err, output)
-	output, err = e2e.execZarfCommand("pki", "regenerate", "--host=some_unique_server")
-	assert.Error(t, err, output)
-
 	// Test that changing the log level actually applies the requested level
 	output, _ = e2e.execZarfCommand("version", "--log-level=warn")
 	expectedOutString := "Log level set to warn"

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -75,7 +75,7 @@ type ZarfManifest struct {
 // ZarfComponentScripts are scripts that run before or after a component is deployed
 type ZarfComponentScripts struct {
 	ShowOutput     bool     `yaml:"showOutput,omitempty"`
-	TimeoutSeconds int      `yaml:"timeout,omitempty"`
+	TimeoutSeconds int      `yaml:"timeoutSeconds,omitempty"`
 	Retry          bool     `yaml:"retry,omitempty"`
 	Before         []string `yaml:"before,omitempty"`
 	After          []string `yaml:"after,omitempty"`

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -74,9 +74,11 @@ type ZarfManifest struct {
 
 // ZarfComponentScripts are scripts that run before or after a component is deployed
 type ZarfComponentScripts struct {
-	Retry  bool     `yaml:"retry,omitempty"`
-	Before []string `yaml:"before,omitempty"`
-	After  []string `yaml:"after,omitempty"`
+	ShowOutput     bool     `yaml:"showOutput,omitempty"`
+	TimeoutSeconds int      `yaml:"timeout,omitempty"`
+	Retry          bool     `yaml:"retry,omitempty"`
+	Before         []string `yaml:"before,omitempty"`
+	After          []string `yaml:"after,omitempty"`
 }
 
 // ZarfMetadata lists information about the current ZarfPackage

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -155,6 +155,12 @@
     },
     "ZarfComponentScripts": {
       "properties": {
+        "showOutput": {
+          "type": "boolean"
+        },
+        "timeout": {
+          "type": "integer"
+        },
         "retry": {
           "type": "boolean"
         },

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -158,7 +158,7 @@
         "showOutput": {
           "type": "boolean"
         },
-        "timeout": {
+        "timeoutSeconds": {
           "type": "integer"
         },
         "retry": {


### PR DESCRIPTION
Add the ability to define a script timeout length in seconds and show logs inline.  Also added an EKS example use-case for when this would be useful

Example:
```
  - name: example-one-hour-timeout-with-show-logs
    scripts:
      timeout: 3600
      showOutput: true
      before:
        - "some-long-running-command-here"
```

Fixes #338 

## Type of change
- [x] New feature (non-breaking change which adds functionality)