### PR TITLE
Fallback to host-provided git on clone failure during package create

### DIFF
--- a/examples/gitops-data/zarf.yaml
+++ b/examples/gitops-data/zarf.yaml
@@ -11,7 +11,9 @@ components:
     repos:
       # Do a tag-provided Git Repo mirror
       - https://github.com/defenseunicorns/zarf.git@v0.15.0
-        # Do a tag-provided Git Repo mirror with the default branch of main
+      # Do a tag-provided Git Repo mirror with the default branch of main
       - https://repo1.dso.mil/platform-one/big-bang/apps/security-tools/twistlock.git@0.0.9-bb.0
         # Do a full Git Repo Mirror
       - https://github.com/stefanprodan/podinfo.git
+        # Clone an azure repo that breaks in go-git and has to fall back to the host git
+      - https://me0515@dev.azure.com/me0515/zarf-public-test/_git/zarf-public-test

--- a/src/internal/git/pull.go
+++ b/src/internal/git/pull.go
@@ -60,7 +60,7 @@ func pull(gitUrl, targetFolder string, spinner *message.Spinner) {
 
 		// If we can't clone with go-git, fallback to the host clone
 		// Only support "all tags" due to the azure clone url format including a username
-		stdOut, stdErr, err := utils.ExecCommandWithContext(context.TODO(), false, "git", "clone", gitUrl, targetFolder)
+		stdOut, stdErr, err := utils.ExecCommandWithContext(context.TODO(), false, "git", "clone", "--origin", onlineRemoteName, gitUrl, targetFolder)
 		spinner.Updatef(stdOut)
 		spinner.Debugf(stdErr)
 

--- a/src/internal/git/pull.go
+++ b/src/internal/git/pull.go
@@ -56,6 +56,7 @@ func pull(gitUrl, targetFolder string, spinner *message.Spinner) {
 	if err == git.ErrRepositoryAlreadyExists {
 		spinner.Debugf("Repo already cloned")
 	} else if err != nil {
+		spinner.Debugf("Failed to clone repo: %s", err)
 		message.Infof("Falling back to host git for %s", gitUrl)
 
 		// If we can't clone with go-git, fallback to the host clone

--- a/src/internal/git/pull.go
+++ b/src/internal/git/pull.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"context"
+
 	"github.com/defenseunicorns/zarf/src/internal/message"
 	"github.com/defenseunicorns/zarf/src/internal/utils"
 	"github.com/go-git/go-git/v5"
@@ -20,13 +22,13 @@ func DownloadRepoToTemp(gitUrl string, spinner *message.Spinner) string {
 	return path
 }
 
-func Pull(gitUrl string, targetFolder string, spinner *message.Spinner) string {
+func Pull(gitUrl, targetFolder string, spinner *message.Spinner) string {
 	path := targetFolder + "/" + transformURLtoRepoName(gitUrl)
 	pull(gitUrl, path, spinner)
 	return path
 }
 
-func pull(gitUrl string, targetFolder string, spinner *message.Spinner) {
+func pull(gitUrl, targetFolder string, spinner *message.Spinner) {
 	spinner.Updatef("Processing git repo %s", gitUrl)
 
 	gitCred := FindAuthForHost(gitUrl)
@@ -54,7 +56,19 @@ func pull(gitUrl string, targetFolder string, spinner *message.Spinner) {
 	if err == git.ErrRepositoryAlreadyExists {
 		spinner.Debugf("Repo already cloned")
 	} else if err != nil {
-		spinner.Fatalf(err, "Not a valid git repo or unable to clone")
+		message.Infof("Falling back to host git for %s", gitUrl)
+
+		// If we can't clone with go-git, fallback to the host clone
+		// Only support "all tags" due to the azure clone url format including a username
+		stdOut, stdErr, err := utils.ExecCommandWithContext(context.TODO(), false, "git", "clone", gitUrl, targetFolder)
+		spinner.Updatef(stdOut)
+		spinner.Debugf(stdErr)
+
+		if err != nil {
+			spinner.Fatalf(err, "Not a valid git repo or unable to clone")
+		}
+
+		return
 	}
 
 	if !fetchAllTags {
@@ -80,6 +94,5 @@ func pull(gitUrl string, targetFolder string, spinner *message.Spinner) {
 
 		fetchTag(targetFolder, tag)
 		CheckoutTagAsBranch(targetFolder, tag, trunkBranchName)
-
 	}
 }

--- a/src/internal/git/push.go
+++ b/src/internal/git/push.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/defenseunicorns/zarf/src/config"
@@ -30,9 +31,10 @@ func PushAllDirectories(localPath string) {
 	defer spinner.Stop()
 
 	for _, path := range paths {
-		spinner.Updatef("Pushing git repo %s", localPath)
+		basename := filepath.Base(path)
+		spinner.Updatef("Pushing git repo %s", basename)
 		if err := push(path, spinner); err != nil {
-			spinner.Fatalf(err, "Unable to push the git repo %s", localPath)
+			spinner.Fatalf(err, "Unable to push the git repo %s", basename)
 		}
 
 		// Add the read-only user to this repo


### PR DESCRIPTION
## Description

This PR allows for graceful failure on various go-git cloning issues related to authentication, git protocol, etc during the `zarf package create` execution.  On a clone failure, the git package will attempt to call the host-based `git clone` before completely failing.  Note that due to the format of Azure http git clone urls, this command will not support single-tag/single-depth clones in this PR.  

## Related Issue

Related to #456 
Fixes #417 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist before merging

- [x] Tests included via the addition of the new test case in the gitops example
