### PR TITLE
Add helm release name property to zarf chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,10 @@ package-example-single-big-bang-package: ## Create the Zarf package for single-b
 package-example-gitops-data:
 	cd examples/gitops-data && ../../$(ZARF_BIN) package create --confirm && mv zarf-package-* ../../build/
 
+.PHONY: package-example-helm-releasename
+package-example-helm-releasename:
+	cd examples/helm-with-different-releaseName-values && ../../$(ZARF_BIN) package create --confirm && mv zarf-package-* ../../build/
+
 .PHONY: package-example-tiny-kafka
 package-example-tiny-kafka:
 	cd examples/tiny-kafka && ../../$(ZARF_BIN) package create --confirm && mv zarf-package-* ../../build/
@@ -143,6 +147,9 @@ test-e2e: ## Run e2e tests. Will automatically build any required dependencies t
 	fi
 	@if [ ! -f ./build/zarf-package-gitops-service-data-$(ARCH).tar.zst ]; then\
 		$(MAKE) package-example-gitops-data;\
+	fi
+	@if [ ! -f ./build/zarf-package-test-helm-releasename-$(ARCH).tar.zst ]; then\
+		$(MAKE) package-example-helm-releasename;\
 	fi
 	@if [ ! -f ./build/zarf-package-compose-example-$(ARCH).tar.zst ]; then\
 		$(MAKE) package-example-compose;\

--- a/examples/helm-with-different-releaseName-values/values.yaml
+++ b/examples/helm-with-different-releaseName-values/values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/examples/helm-with-different-releaseName-values/zarf.yaml
+++ b/examples/helm-with-different-releaseName-values/zarf.yaml
@@ -3,37 +3,45 @@ metadata:
   name: test-helm-releasename
   description: "Deploys same chart with different names"
 components:
-  - name: etcd-1
+  - name: nginx-1
     required: true
     charts:
-      - name: etcd # use the default name if releaseName not specified
+      - name: nginx # use the default name if releaseName not specified
         url: https://charts.bitnami.com/bitnami
-        version: 8.1.2
-        namespace: etcd
+        version: 11.1.5
+        namespace: nginx
+        valuesFiles:
+          - values.yaml
     images:
-      - docker.io/bitnami/etcd:3.5.4-debian-10-r21
-  - name: etcd-2
+      - docker.io/bitnami/nginx:1.21.6-debian-10-r114
+  - name: nginx-2
     required: true
     charts:
-      - name: etcd
-        releaseName: etcd-2
+      - name: nginx
+        releaseName: nginx-2
         url: https://charts.bitnami.com/bitnami
-        version: 8.1.2
-        namespace: etcd
+        version: 11.1.5
+        namespace: nginx
+        valuesFiles:
+          - values.yaml
     images:
-      - docker.io/bitnami/etcd:3.5.4-debian-10-r21
-  - name: etcd-3-4 # multiple charts in same component
+      - docker.io/bitnami/nginx:1.21.6-debian-10-r114
+  - name: nginx-3-4 # multiple charts in same component
     required: true
     charts:
-      - name: etcd
-        releaseName: etcd-3
+      - name: nginx
+        releaseName: nginx-3
         url: https://charts.bitnami.com/bitnami
-        version: 8.1.2
-        namespace: etcd-three-four
-      - name: etcd
-        releaseName: etcd-4
+        version: 11.1.5
+        namespace: nginx-three-four
+        valuesFiles:
+          - values.yaml
+      - name: nginx
+        releaseName: nginx-4
         url: https://charts.bitnami.com/bitnami
-        version: 8.1.2
-        namespace: etcd-three-four
+        version: 11.1.5
+        namespace: nginx-three-four
+        valuesFiles:
+          - values.yaml
     images:
-      - docker.io/bitnami/etcd:3.5.4-debian-10-r21
+      - docker.io/bitnami/nginx:1.21.6-debian-10-r114

--- a/examples/helm-with-different-releaseName-values/zarf.yaml
+++ b/examples/helm-with-different-releaseName-values/zarf.yaml
@@ -1,0 +1,39 @@
+kind: ZarfPackageConfig
+metadata:
+  name: test-helm-releasename
+  description: "Deploys same chart with different names"
+components:
+  - name: etcd-1
+    required: true
+    charts:
+      - name: etcd # use the default name if releaseName not specified
+        url: https://charts.bitnami.com/bitnami
+        version: 8.1.2
+        namespace: etcd
+    images:
+      - docker.io/bitnami/etcd:3.5.4-debian-10-r21
+  - name: etcd-2
+    required: true
+    charts:
+      - name: etcd
+        releaseName: etcd-2
+        url: https://charts.bitnami.com/bitnami
+        version: 8.1.2
+        namespace: etcd
+    images:
+      - docker.io/bitnami/etcd:3.5.4-debian-10-r21
+  - name: etcd-3-4 # multiple charts in same component
+    required: true
+    charts:
+      - name: etcd
+        releaseName: etcd-3
+        url: https://charts.bitnami.com/bitnami
+        version: 8.1.2
+        namespace: etcd-three-four
+      - name: etcd
+        releaseName: etcd-4
+        url: https://charts.bitnami.com/bitnami
+        version: 8.1.2
+        namespace: etcd-three-four
+    images:
+      - docker.io/bitnami/etcd:3.5.4-debian-10-r21

--- a/src/internal/helm/chart.go
+++ b/src/internal/helm/chart.go
@@ -45,7 +45,11 @@ func InstallOrUpgradeChart(options ChartOptions) ConnectStrings {
 
 	var output *release.Release
 
-	options.ReleaseName = fmt.Sprintf("zarf-%s", options.Chart.Name)
+	if options.Chart.ReleaseName != "" {
+		options.ReleaseName = fmt.Sprintf("zarf-%s", options.Chart.ReleaseName)
+	} else {
+		options.ReleaseName = fmt.Sprintf("zarf-%s", options.Chart.Name)
+	}
 	actionConfig, err := createActionConfig(options.Chart.Namespace, spinner)
 	postRender := NewRenderer(options, actionConfig)
 
@@ -132,7 +136,11 @@ func TemplateChart(options ChartOptions) (string, error) {
 	client.ClientOnly = true
 	client.IncludeCRDs = true
 
-	client.ReleaseName = fmt.Sprintf("zarf-%s", options.Chart.Name)
+	if options.Chart.ReleaseName != "" {
+		client.ReleaseName = fmt.Sprintf("zarf-%s", options.Chart.ReleaseName)
+	} else {
+		client.ReleaseName = fmt.Sprintf("zarf-%s", options.Chart.Name)
+	}
 
 	// Namespace must be specified
 	client.Namespace = options.Chart.Namespace

--- a/src/test/e2e/e2e_helm_test.go
+++ b/src/test/e2e/e2e_helm_test.go
@@ -19,13 +19,12 @@ func TestE2eExampleHelm(t *testing.T) {
 	path := fmt.Sprintf("../../../build/zarf-package-test-helm-releasename-%s.tar.zst", e2e.arch)
 
 	// Deploy the charts
-	output, err = e2e.execZarfCommand("package", "deploy", path, "--confirm", "-l=trace")
+	output, err = e2e.execZarfCommand("package", "deploy", path, "--confirm")
 	require.NoError(t, err, output)
 
-	// Verify the configmap was properly templated
-	kubectlOut, _ := exec.Command("kubectl", "get", "pods", "-A", "--selector=app.kubernetes.io/name=etcd", "--no-headers").Output()
-	assert.Contains(t, string(kubectlOut), "zarf-etcd-0")
-	assert.Contains(t, string(kubectlOut), "zarf-etcd-2-0")
-	assert.Contains(t, string(kubectlOut), "zarf-etcd-3-0")
-	assert.Contains(t, string(kubectlOut), "zarf-etcd-4-0")
+	// Verify multiple helm installs of different release names were deployed
+	kubectlOut, _ := exec.Command("kubectl", "get", "pods", "-A", "--selector=app.kubernetes.io/name=nginx", "--no-headers").Output()
+	assert.Contains(t, string(kubectlOut), "zarf-nginx-2")
+	assert.Contains(t, string(kubectlOut), "zarf-nginx-3")
+	assert.Contains(t, string(kubectlOut), "zarf-nginx-4")
 }

--- a/src/test/e2e/e2e_helm_test.go
+++ b/src/test/e2e/e2e_helm_test.go
@@ -23,7 +23,7 @@ func TestE2eExampleHelm(t *testing.T) {
 	require.NoError(t, err, output)
 
 	// Verify the configmap was properly templated
-	kubectlOut, _ := exec.Command("kubectl", "-A", "get", "pods", "--selector=app.kubernetes.io/name=etcd", "--no-headers").Output()
+	kubectlOut, _ := exec.Command("kubectl", "get", "pods", "-A", "--selector=app.kubernetes.io/name=etcd", "--no-headers").Output()
 	assert.Contains(t, string(kubectlOut), "zarf-etcd-0")
 	assert.Contains(t, string(kubectlOut), "zarf-etcd-2-0")
 	assert.Contains(t, string(kubectlOut), "zarf-etcd-3-0")

--- a/src/test/e2e/e2e_helm_test.go
+++ b/src/test/e2e/e2e_helm_test.go
@@ -1,0 +1,31 @@
+package test
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestE2eExampleHelm(t *testing.T) {
+	//defer e2e.cleanupAfterTest(t)
+
+	//run `zarf init`
+	output, err := e2e.execZarfCommand("init", "--confirm")
+	require.NoError(t, err, output)
+
+	path := fmt.Sprintf("../../../build/zarf-package-test-helm-releasename-%s.tar.zst", e2e.arch)
+
+	// Deploy the charts
+	output, err = e2e.execZarfCommand("package", "deploy", path, "--confirm")
+	require.NoError(t, err, output)
+
+	// Verify the configmap was properly templated
+	kubectlOut, _ := exec.Command("kubectl", "-A", "get", "pods", "--selector=app.kubernetes.io/name=etcd", "--no-headers").Output()
+	assert.Contains(t, string(kubectlOut), "zarf-etcd-0")
+	assert.Contains(t, string(kubectlOut), "zarf-etcd-2-0")
+	assert.Contains(t, string(kubectlOut), "zarf-etcd-3-0")
+	assert.Contains(t, string(kubectlOut), "zarf-etcd-4-0")
+}

--- a/src/test/e2e/e2e_helm_test.go
+++ b/src/test/e2e/e2e_helm_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestE2eExampleHelm(t *testing.T) {
-	//defer e2e.cleanupAfterTest(t)
+	defer e2e.cleanupAfterTest(t)
 
 	//run `zarf init`
 	output, err := e2e.execZarfCommand("init", "--confirm")
@@ -19,7 +19,7 @@ func TestE2eExampleHelm(t *testing.T) {
 	path := fmt.Sprintf("../../../build/zarf-package-test-helm-releasename-%s.tar.zst", e2e.arch)
 
 	// Deploy the charts
-	output, err = e2e.execZarfCommand("package", "deploy", path, "--confirm")
+	output, err = e2e.execZarfCommand("package", "deploy", path, "--confirm", "-l=trace")
 	require.NoError(t, err, output)
 
 	// Verify the configmap was properly templated

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -18,7 +18,7 @@ type ZarfFile struct {
 // ZarfChart defines a helm chart to be deployed.
 type ZarfChart struct {
 	Name        string   `yaml:"name"`
-	ReleaseName string   `yaml:"releaseName"`
+	ReleaseName string   `yaml:"releaseName,omitempty"`
 	Url         string   `yaml:"url"`
 	Version     string   `yaml:"version"`
 	Namespace   string   `yaml:"namespace"`

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -18,6 +18,7 @@ type ZarfFile struct {
 // ZarfChart defines a helm chart to be deployed.
 type ZarfChart struct {
 	Name        string   `yaml:"name"`
+	ReleaseName string   `yaml:"releaseName"`
 	Url         string   `yaml:"url"`
 	Version     string   `yaml:"version"`
 	Namespace   string   `yaml:"namespace"`

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -41,6 +41,9 @@
         "name": {
           "type": "string"
         },
+        "releaseName": {
+          "type": "string"
+        },
         "url": {
           "type": "string"
         },


### PR DESCRIPTION
## Description

Added `releaseName` property to ZarfChart and updated the install/upgrade chart function to use `releaseName` if provided or fall back to `name` if not provided to keep backwards compatibility and not require the new property.

Tested this change by deploying multiple copies of cert-manager chart (just as a test) to the same namespace using different Zarf components and the same Zarf component with a list of charts too.

```
kind: ZarfPackageConfig
metadata:
  name: test-helm-releasename
  description: "Deploys same chart with different names"
components:
  - name: cert-manager
    required: false
    charts:
      - name: cert-manager
        # releaseName: cert-manager # use the default name if releaseName not specified
        url: https://charts.jetstack.io
        version: 1.6.3
        namespace: cert-manager
    images:
      - "quay.io/jetstack/cert-manager-cainjector:v1.6.3"
      - "quay.io/jetstack/cert-manager-controller:v1.6.3"
      - "quay.io/jetstack/cert-manager-webhook:v1.6.3"
      - "quay.io/jetstack/cert-manager-ctl:v1.6.3"
  - name: cert-manager-2
    required: false
    charts:
      - name: cert-manager
        releaseName: cert-manager-2
        url: https://charts.jetstack.io
        version: 1.6.3
        namespace: cert-manager
    images:
      - "quay.io/jetstack/cert-manager-cainjector:v1.6.3"
      - "quay.io/jetstack/cert-manager-controller:v1.6.3"
      - "quay.io/jetstack/cert-manager-webhook:v1.6.3"
      - "quay.io/jetstack/cert-manager-ctl:v1.6.3"
  - name: cert-manager-3-4
    required: false
    charts:
      - name: cert-manager
        releaseName: cert-manager-3
        url: https://charts.jetstack.io
        version: 1.6.3
        namespace: cert-manager-three-four
      - name: cert-manager
        releaseName: cert-manager-4
        url: https://charts.jetstack.io
        version: 1.6.3
        namespace: cert-manager-three-four
    images:
      - "quay.io/jetstack/cert-manager-cainjector:v1.6.3"
      - "quay.io/jetstack/cert-manager-controller:v1.6.3"
      - "quay.io/jetstack/cert-manager-webhook:v1.6.3"
      - "quay.io/jetstack/cert-manager-ctl:v1.6.3"
  ```

## Related Issue

Fixes #479 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist before merging

<!-- Please delete options that are not relevant -->

- [ ] Tests have been added/updated as necessary (add the `needs-tests` label)
- [ ] Documentation has been updated as necessary (add the `needs-docs` label)
- [ ] An ADR has been written as necessary (add the `needs-adr` label) [ [1](https://github.com/joelparkerhenderson/architecture-decision-record) [2](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) [3](https://adr.github.io/) ]
- [ ] (Optional) Changes have been linted locally with [golangci-lint](https://github.com/golangci/golangci-lint). (NOTE: We haven't turned on lint checks in the pipeline yet so linting may be hard if it shows a lot of lint errors in places that weren't touched by changes. Thus, linting is optional right now.)
