### PR TITLE
Hidden tool command for generating docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ cosign.key
 zarf-pki
 .scratch/
 zarf-sbom/
+clidocs/

--- a/go.mod
+++ b/go.mod
@@ -138,6 +138,7 @@ require (
 	github.com/containerd/containerd v1.6.2 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.10.1 // indirect
 	github.com/coreos/go-oidc/v3 v3.1.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20210823021906-dc406ceaf94b // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -297,6 +298,7 @@ require (
 	github.com/rs/zerolog v1.26.0 // indirect
 	github.com/rubenv/sql-migrate v0.0.0-20210614095031-55d5740dbbcc // indirect
 	github.com/russross/blackfriday v1.5.2 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sahilm/fuzzy v0.1.0 // indirect
 	github.com/sassoftware/relic v0.0.0-20210427151427-dfb082b79b74 // indirect

--- a/go.sum
+++ b/go.sum
@@ -645,7 +645,6 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/corpix/uarand v0.1.1 h1:RMr1TWc9F4n5jiPDzFHtmaUXLKLNUFK0SgCLo4BhX/U=
-github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=

--- a/src/cmd/tools.go
+++ b/src/cmd/tools.go
@@ -12,11 +12,13 @@ import (
 	"github.com/defenseunicorns/zarf/src/internal/git"
 	"github.com/defenseunicorns/zarf/src/internal/k8s"
 	"github.com/defenseunicorns/zarf/src/internal/message"
+	"github.com/defenseunicorns/zarf/src/internal/utils"
 	k9s "github.com/derailed/k9s/cmd"
 	craneCmd "github.com/google/go-containerregistry/cmd/crane/cmd"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/mholt/archiver/v3"
 	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
 )
 
 var toolsCmd = &cobra.Command{
@@ -124,8 +126,20 @@ var createReadOnlyGiteaUser = &cobra.Command{
 	},
 }
 
+var generateCLIDocs = &cobra.Command{
+	Use:    "generate-cli-docs",
+	Hidden: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.CreateDirectory("clidocs", 0700)
+
+		//Generate markdown of the Zarf command (and all of its child commands)
+		doc.GenMarkdownTree(rootCmd, "./clidocs")
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(toolsCmd)
+	rootCmd.AddCommand(generateCLIDocs)
 
 	toolsCmd.AddCommand(archiverCmd)
 	toolsCmd.AddCommand(readCredsCmd)


### PR DESCRIPTION
This PR adds a hidden `zarf tools` command for generating markdown documentation of the various cobra commands, including the descriptions, arguments, flags, child/parent commands.

This is useful as we start getting more involved with our documentation.