### PR TITLE
Use GoReleaser for GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,4 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.ZARF_ORG_PROJECT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_GOV_SECRET_ACCESS_KEY }}
           aws-region: us-gov-west-1
 
+      # Builds init packages since GoReleaser won't handle this for us
+      - name: "Build init-packages For Release"
+        run: |
+          make build-cli-linux-amd init-package
+
+      # Create the GitHub release notes, upload artifact backups to S3, publish homebrew recipe
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-actions@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install GoLang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
-      
+
       - name: Checkout Repo
-        uses: actions/checkout@v2
-      
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: "Setup caching"
         uses: actions/cache@v3
         with:
@@ -25,30 +27,21 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-        
-     
-      - name: Build Things For Release
-        run: make build-cli init-package
-      
+            ${{ runner.os }}-go-
+
+      # Set up AWS credentials for GoReleaser to upload backups of artifacts to S3
       - name: Set AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_GOV_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_GOV_SECRET_ACCESS_KEY }}
           aws-region: us-gov-west-1
-      
-      - name: Push Release Artifacts to S3 Bucket
-        run: aws s3 cp build s3://zarf-public/release/${{ github.ref_name }} --region us-gov-west-1 --recursive
-      
-      - name: Create a Release For This Tag
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-actions@v3
         with:
-          generate_release_notes: true    # Generates basic release notes that we can edit later
-          files: |
-            build/zarf
-            build/zarf-mac-intel
-            build/zarf-mac-apple
-            build/zarf-init-amd64.tar.zst
-            build/zarf-init-arm64.tar.zst
-            build/zarf.sha256
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ zarf-pki
 .scratch/
 zarf-sbom/
 clidocs/
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,6 +50,7 @@ brews:
     tap:
       owner: defenseunicorns
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     homepage: "https://zarf.dev/"
     description: "An airgap delivery tool!"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,61 @@
+# TODO @JPERRY REMOVE THESE LINES AND ENSURE THE 'GITHUB_TOKEN' token is populated in the repo.
+# .goreleaser.yaml
+env_files:
+  github_token: ~/.path/to/my/github_token
+
+
+# Make sure to check the documentation at https://goreleaser.com
+before:
+  hooks:
+    - go mod tidy
+
+universal_binaries:
+  - replace: false
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    dir: src
+    ldflags:
+      - -s -w -X github.com/defenseunicorns/zarf/src/config.CLIVersion={{.Version}}
+    goarch:
+      - amd64
+      - arm64
+archives:
+  -
+    format: binary
+    replacements:
+      darwin: Darwin
+      linux: Linux
+
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  use: github-native
+
+release:
+  github:
+    owner: defenseunicorns
+    name: zarf
+  prerelease: auto
+  mode: append
+
+brews:
+  - name: zarf
+    tap:
+      owner: defenseunicorns
+      name: homebrew-tap
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    homepage: "https://zarf.dev/"
+    description: "An airgap delivery tool!"
+
+blobs:
+  provider: s3
+  region: us-gov-west-1
+  bucket: zarf-public
+  folder: "release/{{.Version}}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,19 +1,15 @@
-# TODO @JPERRY REMOVE THESE LINES AND ENSURE THE 'GITHUB_TOKEN' token is populated in the repo.
-# .goreleaser.yaml
-env_files:
-  github_token: ~/.path/to/my/github_token
-
-
-# Make sure to check the documentation at https://goreleaser.com
 before:
   hooks:
     - go mod tidy
 
+# Build a universal macOS binary
 universal_binaries:
   - replace: false
 
+# Build the different combination of goos/arch binaries
 builds:
-  - env:
+  -
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
@@ -24,6 +20,12 @@ builds:
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: linux
+        goarch: arm64
+
+
+# Save the built artifacts as binaries (instead of wrapping them in a tarball)
 archives:
   -
     format: binary
@@ -31,20 +33,33 @@ archives:
       darwin: Darwin
       linux: Linux
 
+# generate a sha256 checksum of all release artifacts
+# NOTE: We are explicitly adding the init-packages that are built prior to GoReleaser stage in the GitHub Actions workflow
 checksum:
   name_template: 'checksums.txt'
+  extra_files:
+    - glob: ./build/zarf-init-*
+  algorithm: sha256
+
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  name_template: "{{ incpatch .Version }}-snapshot"
+
+# Use the auto-generated changlog github provides
 changelog:
   use: github-native
 
+# Generate a GitHub release and publish the release for the tag
+# NOTE: We are explicitly adding the init-packages that are built prior to GoReleaser stage in the GitHub Actions workflow
 release:
   github:
     owner: defenseunicorns
     name: zarf
   prerelease: auto
   mode: append
+  extra_files:
+    - glob: ./build/zarf-init-*
 
+# Create a brew tap recipe that uses the new binary artifacts and push it to our tap
 brews:
   - name: zarf
     tap:
@@ -55,8 +70,10 @@ brews:
     homepage: "https://zarf.dev/"
     description: "An airgap delivery tool!"
 
+# Upload artifact backups to s3
 blobs:
-  provider: s3
-  region: us-gov-west-1
-  bucket: zarf-public
-  folder: "release/{{.Version}}"
+  -
+    provider: s3
+    region: us-gov-west-1
+    bucket: zarf-public
+    folder: "release/{{.Version}}"

--- a/README.md
+++ b/README.md
@@ -297,7 +297,8 @@ Zarf is written entirely in [go](https://go.dev/), except for a single 400Kb bin
   - An init container runs the rust binary to re-assemble and extract the zarf binary and registry image
   - The container then starts and runs the zarf binary to host the registry image in an embedded docker registry
   - After this, the main docker registry chart is deployed, pulls the image from the ephemeral pod, and finally destroys the created configmaps, pod, and service
-
+- We have published a [Homebrew Tap](https://github.com/defenseunicorns/homebrew-tap) for this project that you can install with `brew tap defenseunicorns/tap && brew install zarf`
+  - This recipe is updated with each new version release via [GoReleaser](https://goreleaser.com/customization/homebrew/) as part of the release pipeline that runs on GitHub Actions.
 &nbsp;
 ### Zarf Architecture
 ![Architecture Diagram](./docs/architecture.drawio.svg)

--- a/src/internal/utils/io.go
+++ b/src/internal/utils/io.go
@@ -136,3 +136,17 @@ func CreatePathAndCopy(source string, destination string) {
 	}
 	pterm.Success.Printfln("Copying %s", source)
 }
+
+// GetFinalExecutablePath returns the absolute path to the zarf executable, following any symlinks along the way
+func GetFinalExecutablePath() (string, error) {
+	message.Debug("utils.GetExecutablePath()")
+
+	binaryPath, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	// In case the binary is symlinked somewhere else, get the final destination!!
+	linkedPath, err := filepath.EvalSymlinks(binaryPath)
+	return linkedPath, err
+}


### PR DESCRIPTION
Uses GoReleaser to build, release, and publish the tagged releases pushed to the repo.

Through this pipeline update, GoReleaser will publish a brew recipe to the [Defense Unicorns Tap](https://github.com/defenseunicorns/homebrew-tap) for the tagged release.