### PR TITLE
Add insecure flag to zarf package create

### DIFF
--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -92,7 +92,8 @@ func init() {
 
 	packageCreateCmd.Flags().BoolVar(&config.DeployOptions.Confirm, "confirm", false, "Confirm package creation without prompting")
 	packageCreateCmd.Flags().StringVar(&zarfImageCache, "zarf-cache", config.ZarfDefaultImageCachePath, "Specify the location of the Zarf image cache")
-	packageCreateCmd.Flags().BoolVar(&config.SkipSBOM, "skip-sbom", false, "Skip generating SBOM for this package")
+	packageCreateCmd.Flags().BoolVar(&config.CreateOptions.SkipSBOM, "skip-sbom", false, "Skip generating SBOM for this package")
+	packageCreateCmd.Flags().BoolVar(&config.CreateOptions.Insecure, "insecure", false, "Allow insecure registry connections when pulling OCI images")
 
 	packageDeployCmd.Flags().BoolVar(&config.DeployOptions.Confirm, "confirm", false, "Confirm package deployment without prompting")
 	packageDeployCmd.Flags().StringVar(&config.DeployOptions.Components, "components", "", "Comma-separated list of components to install.  Adding this flag will skip the init prompts for which components to install")

--- a/src/cmd/tools.go
+++ b/src/cmd/tools.go
@@ -15,7 +15,6 @@ import (
 	"github.com/defenseunicorns/zarf/src/internal/utils"
 	k9s "github.com/derailed/k9s/cmd"
 	craneCmd "github.com/google/go-containerregistry/cmd/crane/cmd"
-	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/mholt/archiver/v3"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -151,7 +150,7 @@ func init() {
 	archiverCmd.AddCommand(archiverCompressCmd)
 	archiverCmd.AddCommand(archiverDecompressCmd)
 
-	cranePlatformOptions := []crane.Option{config.GetCraneOptions()}
+	cranePlatformOptions := config.GetCraneOptions()
 	registryCmd.AddCommand(craneCmd.NewCmdAuthLogin())
 	registryCmd.AddCommand(craneCmd.NewCmdPull(&cranePlatformOptions))
 	registryCmd.AddCommand(craneCmd.NewCmdPush(&cranePlatformOptions))

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -46,6 +47,9 @@ var (
 	// CLIVersion track the version of the CLI
 	CLIVersion = "unset"
 
+	// CreeateOptions tracks the user-defined options used to create the package
+	CreateOptions types.ZarfCreateOptions
+
 	// DeployOptions tracks user-defined values for the active deployment
 	DeployOptions types.ZarfDeployOptions
 
@@ -53,13 +57,9 @@ var (
 
 	ZarfSeedPort string
 
-	// Do not process SBOM data
-	SkipSBOM bool
-
 	// Private vars
-	zarfImageCachePath = ZarfDefaultImageCachePath
-	active             types.ZarfPackage
-	state              types.ZarfState
+	active types.ZarfPackage
+	state  types.ZarfState
 )
 
 func IsZarfInitConfig() bool {
@@ -200,16 +200,15 @@ func BuildConfig(path string) error {
 }
 
 func SetImageCachePath(cachePath string) {
-	zarfImageCachePath = cachePath
+	CreateOptions.ImageCachePath = cachePath
 }
 
 func GetImageCachePath() string {
 	homePath, _ := os.UserHomeDir()
-	if zarfImageCachePath == ZarfDefaultImageCachePath {
-		return fmt.Sprintf("%s/%s", homePath, zarfImageCachePath)
+
+	if CreateOptions.ImageCachePath == "" {
+		return filepath.Join(homePath, ZarfDefaultImageCachePath)
 	}
-	if string(zarfImageCachePath[0]) == "~" {
-		return fmt.Sprintf("%s/%s", homePath, zarfImageCachePath[len("~/"):])
-	}
-	return zarfImageCachePath
+
+	return strings.Replace(CreateOptions.ImageCachePath, "~", homePath, 1)
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -84,11 +84,23 @@ func GetArch() string {
 	return runtime.GOARCH
 }
 
-func GetCraneOptions() crane.Option {
-	return crane.WithPlatform(&v1.Platform{
-		OS:           "linux",
-		Architecture: GetArch(),
-	})
+func GetCraneOptions() []crane.Option {
+	var options []crane.Option
+
+	// Handle insecure registry option
+	if CreateOptions.Insecure {
+		options = append(options, crane.Insecure)
+	}
+
+	// Add the image platform info
+	options = append(options,
+		crane.WithPlatform(&v1.Platform{
+			OS:           "linux",
+			Architecture: GetArch(),
+		}),
+	)
+
+	return options
 }
 
 func GetCraneAuthOption(username string, secret string) crane.Option {

--- a/src/internal/images/copy.go
+++ b/src/internal/images/copy.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Copy(src string, dest string) {
-	if err := crane.Copy(src, dest, config.GetCraneOptions()); err != nil {
+	if err := crane.Copy(src, dest, config.GetCraneOptions()...); err != nil {
 		message.Fatal(err, "Unable to copy the image")
 	}
 }

--- a/src/internal/images/pull.go
+++ b/src/internal/images/pull.go
@@ -42,7 +42,7 @@ func PullAll(buildImageList []string, imageTarballPath string) map[name.Tag]v1.I
 
 	for idx, src := range buildImageList {
 		spinner.Updatef("Fetching image metadata (%d of %d): %s", idx+1, imageCount, src)
-		img, err := crane.Pull(src, config.GetCraneOptions())
+		img, err := crane.Pull(src, config.GetCraneOptions()...)
 		if err != nil {
 			spinner.Fatalf(err, "Unable to pull the image %s", src)
 		}

--- a/src/internal/images/push.go
+++ b/src/internal/images/push.go
@@ -24,7 +24,7 @@ func PushToZarfRegistry(imageTarballPath string, buildImageList []string) {
 
 	for _, src := range buildImageList {
 		spinner.Updatef("Updating image %s", src)
-		img, err := crane.LoadTag(imageTarballPath, src, config.GetCraneOptions())
+		img, err := crane.LoadTag(imageTarballPath, src, config.GetCraneOptions()...)
 		if err != nil {
 			spinner.Errorf(err, "Unable to load the image from the update package")
 			return

--- a/src/internal/packager/injector.go
+++ b/src/internal/packager/injector.go
@@ -221,7 +221,7 @@ func hasSeedImages(spinner *message.Spinner) bool {
 		// After delay, try running
 		default:
 			// Check for the existence of the image in the injection pod registry, on error continue
-			if _, err := crane.Manifest(ref, config.GetCraneOptions()); err != nil {
+			if _, err := crane.Manifest(ref, config.GetCraneOptions()...); err != nil {
 				message.Debugf("Could not get image ref %s: %v", ref, err)
 			} else {
 				// If not error, return true, there image is present

--- a/src/internal/packager/prepare.go
+++ b/src/internal/packager/prepare.go
@@ -170,7 +170,7 @@ func FindImages(repoHelmChartPath string) {
 		if sortedImages := k8s.SortImages(maybeImages, matchedImages); len(sortedImages) > 0 {
 			var realImages []string
 			for _, image := range sortedImages {
-				if descriptor, err := crane.Head(image, config.GetCraneOptions()); err != nil {
+				if descriptor, err := crane.Head(image, config.GetCraneOptions()...); err != nil {
 					// Test if this is a real image, if not just quiet log to debug, this is normal
 					message.Debugf("Suspected image does not appear to be valid: %w", err)
 				} else {

--- a/src/internal/sbom/catalog.go
+++ b/src/internal/sbom/catalog.go
@@ -26,7 +26,7 @@ var tranformRegex = regexp.MustCompile(`(?m)[^a-zA-Z0-9\.\-]`)
 
 func CatalogImages(tagToImage map[name.Tag]v1.Image, sbomDir, tarPath string) {
 	// Ignore SBOM creation if there the flag is set
-	if config.SkipSBOM {
+	if config.CreateOptions.SkipSBOM {
 		message.Debug("Skipping SBOM processing per --skip-sbom flag")
 		return
 	}

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -165,6 +165,13 @@ type ZarfDeployOptions struct {
 	NodePort     string
 }
 
+// ZarfCreeateOptions tracks the user-defined options used to create the package
+type ZarfCreateOptions struct {
+	SkipSBOM       bool
+	ImageCachePath string
+	Insecure       bool
+}
+
 // ZarfImport structure for including imported zarf components
 type ZarfComponentImport struct {
 	ComponentName string `yaml:"name,omitempty"`


### PR DESCRIPTION
## Description
Adds a `--insecure` flag to `zarf package create` to allow creating packages from insecure registries.

Fixes #497 

## Type of change

<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist before merging

<!-- Please delete options that are not relevant -->

- [x] Tests have been added/updated as necessary (add the `needs-tests` label)
