### PR TITLE
update linter to only report new issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,3 +16,5 @@ linters:
     - wsl
 issues:
   exclude-use-default: false
+  new: true
+  new-from-rev: HEAD


### PR DESCRIPTION
Super small QoL improvement to update our pre-commit hook to only report issues for new changes that are being introduced.

I'll be honest, since the pre-commit linter was always checking and reporting against the entire codebase I would **always** commit any Go changes with the `--no-verify` flag, I probably contributed a lot of small linting no-no's because of that.

Because of the nature of `golangci-lint` this will still **run** against the entire project (so it might take a couple seconds to run until we cleanup the repo more) but this change should hopefully get us working towards that better direction.