### PR TITLE
Add init package downloader

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
       # Create the GitHub release notes, upload artifact backups to S3, publish homebrew recipe
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-actions@v3
+        uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser
           version: latest

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -51,17 +51,20 @@ var initCmd = &cobra.Command{
 					}
 				}
 
-				confirmDownload := false
+				confirmDownload := config.DeployOptions.Confirm
 				url := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", config.GithubProject, config.CLIVersion, initPackageName)
-				
+
 				// Give the user the choice to download the init-package and note that this does require an internet connection
 				message.Question("It seems the init package could not be found locally, Zarf can download this for you if you still have internet connectivity.")
 				message.Question(url)
 
-				prompt := &survey.Confirm{
-					Message: "Do you want to download this init package?",
+				// Prompt the user if --confirm not specified
+				if !confirmDownload {
+					prompt := &survey.Confirm{
+						Message: "Do you want to download this init package?",
+					}
+					_ = survey.AskOne(prompt, &confirmDownload)
 				}
-				_ = survey.AskOne(prompt, &confirmDownload)
 
 				// If the user wants to download the init-package, download it
 				if confirmDownload {

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -45,7 +45,7 @@ var initCmd = &cobra.Command{
 		if utils.InvalidPath(config.DeployOptions.PackagePath) {
 			executablePath, err := utils.GetFinalExecutablePath()
 			if err != nil {
-				message.Errorf(err, "Unable to get the directory where the zarf cli is located.")
+				message.Error(err, "Unable to get the directory where the zarf cli is located.")
 			}
 
 			executableDir := path.Dir(executablePath)

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -6,6 +6,8 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/Masterminds/semver/v3"
 	"github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/internal/message"
 	"github.com/defenseunicorns/zarf/src/internal/packager"
@@ -28,16 +30,50 @@ var initCmd = &cobra.Command{
 		initPackageName := fmt.Sprintf("zarf-init-%s.tar.zst", config.GetArch())
 		config.DeployOptions.PackagePath = initPackageName
 
-		// Use an init-package in the executable directory if none exist in current working directory
+		// Try to use an init-package in the executable directory if none exist in current working directory
 		if utils.InvalidPath(config.DeployOptions.PackagePath) {
 			executablePath, err := utils.GetFinalExecutablePath()
 			if err != nil {
-				message.Fatal(err, "Unable to get the directory where the zarf cli executable lives")
+				message.Error(err, "Unable to get the directory where the zarf cli executable lives")
 			}
 
 			executableDir := path.Dir(executablePath)
 			config.DeployOptions.PackagePath = filepath.Join(executableDir, initPackageName)
+
+			// If the init-package doesn't exist in the executable directory, suggest trying to download
+			if utils.InvalidPath(config.DeployOptions.PackagePath) {
+
+				// If no CLI version exists (should only occur in dev or CI), try to get the latest release tag from Githhub
+				if _, err := semver.StrictNewVersion(config.CLIVersion); err != nil {
+					config.CLIVersion, err = utils.GetLatestReleaseTag(config.GithubProject)
+					if err != nil {
+						message.Fatal(err, "No CLI version found and unable to get the latest release tag for the zarf cli.")
+					}
+				}
+
+				confirmDownload := false
+				url := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", config.GithubProject, config.CLIVersion, initPackageName)
+				
+				// Give the user the choice to download the init-package and note that this does require an internet connection
+				message.Question("It seems the init package could not be found locally, Zarf can download this for you if you still have internet connectivity.")
+				message.Question(url)
+
+				prompt := &survey.Confirm{
+					Message: "Do you want to download this init package?",
+				}
+				_ = survey.AskOne(prompt, &confirmDownload)
+
+				// If the user wants to download the init-package, download it
+				if confirmDownload {
+					utils.DownloadToFile(url, config.DeployOptions.PackagePath, "")
+				} else {
+					// Otherwise, exit and tell the user to manually download the init-package
+					message.Warn("You must download the init package manually and place it in the current working directory")
+					os.Exit(0)
+				}
+			}
 		}
+
 		// Run everything
 		packager.Deploy()
 	},

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -18,6 +18,7 @@ import (
 )
 
 const (
+	GithubProject = "defenseunicorns/zarf"
 	IPV4Localhost = "127.0.0.1"
 
 	PackagePrefix = "zarf-package"

--- a/src/internal/utils/github.go
+++ b/src/internal/utils/github.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/defenseunicorns/zarf/src/internal/message"
+)
+
+// GetLatestReleaseTag returns the latest release tag for the given github project
+func GetLatestReleaseTag(project string) (string, error) {
+	message.Debugf("utils.GetLatestReleaseTag(%s)", project)
+
+	// We only need the tag from the JSON response
+	// See https://github.com/google/go-github/blob/v45.1.0/github/repos_releases.go#L21 for complete reference
+	ghRelease := struct {
+		TagName string `json:"tag_name"`
+	}{}
+
+	// Get the latest release from the GitHub API for the given project
+	resp, err := http.Get(fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", project))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	// Decode the JSON response into the ghRelease struct
+	if err := json.NewDecoder(resp.Body).Decode(&ghRelease); err != nil {
+		return "", err
+	}
+
+	return ghRelease.TagName, nil
+}


### PR DESCRIPTION
## Description
Enhanced the quick start process for testing Zarf by prompting users to download the init package if it can't be found locally. 

## Related Issue
Closes #502

## Type of change
- [x] New feature (non-breaking change which adds functionality)

