### PR TITLE
Fix goreleaser version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,7 @@ builds:
 archives:
   -
     format: binary
+    name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
     replacements:
       darwin: Darwin
       linux: Linux

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,7 @@ builds:
       - darwin
     dir: src
     ldflags:
-      - -s -w -X github.com/defenseunicorns/zarf/src/config.CLIVersion={{.Version}}
+      - -s -w -X github.com/defenseunicorns/zarf/src/config.CLIVersion={{.Tag}}
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
Apparently goreleaser thought it would be swell to strip the (perfectly legal) v prefix from the version tag....

https://goreleaser.com/customization/templates/#fn:1
