### PR TITLE
fix kustomize path for big-bang core package

### DIFF
--- a/packages/big-bang-core/kustomization/core-light/kustomization.yaml
+++ b/packages/big-bang-core/kustomization/core-light/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
-  - ../core-prod
+  - ../core-standard
 
 configMapGenerator:
   - name: environment


### PR DESCRIPTION
A small typo was introduced with the big bang core example -> packages move in #488, this corrects that.  Since we do not have the ability to run this in E2E right now due to IB credentials and how SUPER long it would take to fully test, including screenshots in the PR after testing from M1 -> Ubuntu AMD64 remote machine using https://github.com/alexellis/k3sup.