### PR TITLE
Injector stability improvements

### DIFF
--- a/src/internal/k8s/images.go
+++ b/src/internal/k8s/images.go
@@ -10,11 +10,10 @@ import (
 )
 
 type ImageMap map[string]bool
+type ImageNodeMap map[string][]string
 
-// GetAllImages returns a list of images found in pods in the cluster.
-func GetAllImages() ([]string, error) {
-	var images []string
-	var err error
+// GetAllImages returns a list of images and their nodes found in pods in the cluster.
+func GetAllImages() (ImageNodeMap, error) {
 	timeout := time.After(5 * time.Minute)
 
 	for {
@@ -24,13 +23,12 @@ func GetAllImages() ([]string, error) {
 
 		// on timeout abort
 		case <-timeout:
-			message.Debug("get image list timed-out")
-			return images, nil
+			return nil, fmt.Errorf("get image list timed-out")
 
 		// after delay, try running
 		default:
 			// If no images or an error, log and loop
-			if images, err = GetImages(corev1.NamespaceAll); len(images) < 1 || err != nil {
+			if images, err := GetImagesWithNodes(corev1.NamespaceAll); len(images) < 1 || err != nil {
 				message.Debug(err)
 			} else {
 				// Otherwise, return the image list
@@ -38,6 +36,31 @@ func GetAllImages() ([]string, error) {
 			}
 		}
 	}
+}
+
+// GetImagesWithNodes returns all images and their nodes in a given namespace.
+func GetImagesWithNodes(namespace string) (ImageNodeMap, error) {
+	result := make(ImageNodeMap)
+
+	pods, err := GetPods(namespace)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get the list of pods in the cluster")
+	}
+
+	for _, pod := range pods.Items {
+		node := pod.Spec.NodeName
+		for _, container := range pod.Spec.InitContainers {
+			result[container.Image] = append(result[container.Image], node)
+		}
+		for _, container := range pod.Spec.Containers {
+			result[container.Image] = append(result[container.Image], node)
+		}
+		for _, container := range pod.Spec.EphemeralContainers {
+			result[container.Image] = append(result[container.Image], node)
+		}
+	}
+
+	return result, nil
 }
 
 // GetImages returns all images for in pods in a given namespace.

--- a/src/internal/k8s/images.go
+++ b/src/internal/k8s/images.go
@@ -63,22 +63,6 @@ func GetImagesWithNodes(namespace string) (ImageNodeMap, error) {
 	return result, nil
 }
 
-// GetImages returns all images for in pods in a given namespace.
-func GetImages(namespace string) ([]string, error) {
-	images := make(ImageMap)
-
-	pods, err := GetPods(namespace)
-	if err != nil {
-		return []string{}, fmt.Errorf("unable to get the list of pods in the cluster")
-	}
-
-	for _, pod := range pods.Items {
-		images = BuildImageMap(images, pod.Spec)
-	}
-
-	return SortImages(images, nil), nil
-}
-
 // BuildImageMap looks for init container, ephemeral and regular container images.
 func BuildImageMap(images ImageMap, pod corev1.PodSpec) ImageMap {
 	for _, container := range pod.InitContainers {


### PR DESCRIPTION
## Description
- Switch to default image pull policy to simplify connected-cloud deployments
- Add more code comments to clarify podspec in the code
- Add node affinity for more reliable image mounting with multi-node clusters
- Extend the configmap push interval 100ms -> 250ms to reduce mount failures/control plane pressure (cost is slightly slower configmap apply)

## Related Issue
#501 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
