### PR TITLE
Upgrade K3s package to v1.24.1+k3s1

### DIFF
--- a/packages/distros/k3s/zarf.yaml
+++ b/packages/distros/k3s/zarf.yaml
@@ -24,8 +24,8 @@ components:
         - "systemctl enable --now k3s"
     files:
       # Include the actual K3s binary
-      - source: https://github.com/k3s-io/k3s/releases/download/v1.23.6+k3s1/k3s
-        shasum: a60e039130faf2f0d349a79738e185616fd8e74ab9e0e356ce8127216fd8f9c4
+      - source: https://github.com/k3s-io/k3s/releases/download/v1.24.1+k3s1/k3s
+        shasum: ca398d83fee8f9f52b05fb184582054be3c0285a1b9e8fb5c7305c7b9a91448a
         target: /usr/sbin/k3s
         executable: true
         # K3s magic provides these tools when symlinking
@@ -34,8 +34,8 @@ components:
           - /usr/sbin/ctr
           - /usr/sbin/crictl
       # Transfer the K3s images for containerd to pick them up
-      - source: https://github.com/k3s-io/k3s/releases/download/v1.23.6+k3s1/k3s-airgap-images-amd64.tar.zst
-        shasum: c6b720bc0048d38a187236bc799ed7390422fb278ae7e8b119f81f4795ea33e5
+      - source: https://github.com/k3s-io/k3s/releases/download/v1.24.1+k3s1/k3s-airgap-images-amd64.tar.zst
+        shasum: 6736f9fa4d5754d60b0508bafb2f888170cb99a2d93a3a1617a919ca4ee74034
         target: /var/lib/rancher/k3s/agent/images/k3s.tar.zst
       # K3s removal script
       - source: assets/zarf-clean-k3s.sh


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Any relevant motivation or context is also helpful, as well as any dependencies that are required for this change -->

Upgrades the version of K3s used in the init package from v1.23.6+k3s1 to v1.24.1+k3s1

## Related Issue

<!--- This project prefers to accept pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

Fixes #538 

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before merging

<!-- Please delete options that are not relevant -->

- [ ] Tests have been added/updated as necessary (add the `needs-tests` label)
- [ ] Documentation has been updated as necessary (add the `needs-docs` label)
- [ ] An ADR has been written as necessary (add the `needs-adr` label) [ [1](https://github.com/joelparkerhenderson/architecture-decision-record) [2](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) [3](https://adr.github.io/) ]
- [ ] (Optional) Changes have been linted locally with [golangci-lint](https://github.com/golangci/golangci-lint). (NOTE: We haven't turned on lint checks in the pipeline yet so linting may be hard if it shows a lot of lint errors in places that weren't touched by changes. Thus, linting is optional right now.)
