### PR TITLE
546. Fixed broken bigbang link in examples README.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@ To test create a virtual area to test all examples, you can run `make all` or `m
 
 | Example                                                          |      Description      |
 |------------------------------------------------------------------|-------------|
-| [big-bang](./big-bang-umbrella/README.md)                        |  Demo BigBang v1.33.0 with all of its core services |
+| [big-bang](../packages/big-bang-core/README.md)                        |  Demo BigBang v1.33.0 with all of its core services |
 | [composable-packages](./composable-packages/README.md)           |  Demo building packages using components from other packages   |
 | [data-injection](./data-injection/README.md)                     |  Demo injecting data into a pod running on cluster  |
 | [game](./game/README.md)                                         |  Demo deploying old-school DOS games |

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@ To test create a virtual area to test all examples, you can run `make all` or `m
 
 | Example                                                          |      Description      |
 |------------------------------------------------------------------|-------------|
-| [big-bang](./big-bang/README.md)                                 |  Demo BigBang v1.33.0 with all of its core services |
+| [big-bang](./big-bang-umbrella/README.md)                        |  Demo BigBang v1.33.0 with all of its core services |
 | [composable-packages](./composable-packages/README.md)           |  Demo building packages using components from other packages   |
 | [data-injection](./data-injection/README.md)                     |  Demo injecting data into a pod running on cluster  |
 | [game](./game/README.md)                                         |  Demo deploying old-school DOS games |


### PR DESCRIPTION
## Description

The BigBang link in the examples README was leading to a 404 on github. This is a problem since the first example when going to the examples on https://zarf.dev is the bigbang link. 

## Related Issue
#546 

## Type of change
- [x] Update to documentation. 
- [x] Bug fix (non-breaking change which fixes an issue)
