### PR TITLE
Add support for package deploy via cosign sget 

### DIFF
--- a/.hooks/verify-zarf-schema.sh
+++ b/.hooks/verify-zarf-schema.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-go run src/main.go tools config-schema > zarf.schema.json
+go run main.go tools config-schema > zarf.schema.json

--- a/Makefile
+++ b/Makefile
@@ -41,16 +41,16 @@ clean: ## Clean the build dir
 	rm -rf build
 
 build-cli-linux-amd: build-injector-registry
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="$(BUILD_ARGS)" -o build/zarf src/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="$(BUILD_ARGS)" -o build/zarf main.go
 
 build-cli-linux-arm: build-injector-registry
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="$(BUILD_ARGS)" -o build/zarf-arm src/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="$(BUILD_ARGS)" -o build/zarf-arm main.go
 
 build-cli-mac-intel: build-injector-registry
-	GOOS=darwin GOARCH=amd64 go build -ldflags="$(BUILD_ARGS)" -o build/zarf-mac-intel src/main.go
+	GOOS=darwin GOARCH=amd64 go build -ldflags="$(BUILD_ARGS)" -o build/zarf-mac-intel main.go
 
 build-cli-mac-apple: build-injector-registry
-	GOOS=darwin GOARCH=arm64 go build -ldflags="$(BUILD_ARGS)" -o build/zarf-mac-apple src/main.go
+	GOOS=darwin GOARCH=arm64 go build -ldflags="$(BUILD_ARGS)" -o build/zarf-mac-apple main.go
 
 build-cli-linux: build-cli-linux-amd build-cli-linux-arm
 
@@ -64,7 +64,7 @@ build-injector-registry:
 dev-agent-image:
 	$(eval tag := defenseunicorns/dev-zarf-agent:$(shell date +%s))
 	$(eval arch := $(shell uname -m))
-	CGO_ENABLED=0 GOOS=linux go build -o build/zarf-linux-$(arch) src/main.go
+	CGO_ENABLED=0 GOOS=linux go build -o build/zarf-linux-$(arch) main.go
 	DOCKER_BUILDKIT=1 docker build --tag $(tag) --build-arg TARGETARCH=$(arch) . && \
 	kind load docker-image zarf-agent:$(tag) && \
 	kubectl -n zarf set image deployment/agent-hook server=$(tag)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifneq ($(UNAME_S),Linux)
 endif
 
 CLI_VERSION := $(if $(shell git describe --tags), $(shell git describe --tags), "UnknownVersion")
-BUILD_ARGS := -s -w -X 'github.com/defenseunicorns/zarf/src/config.CLIVersion=$(CLI_VERSION)'       # TODO: Add some way to pass the sget string as a value here too
+BUILD_ARGS := -s -w -X 'github.com/defenseunicorns/zarf/src/config.CLIVersion=$(CLI_VERSION)'
 .DEFAULT_GOAL := help
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifneq ($(UNAME_S),Linux)
 endif
 
 CLI_VERSION := $(if $(shell git describe --tags), $(shell git describe --tags), "UnknownVersion")
-BUILD_ARGS := -s -w -X 'github.com/defenseunicorns/zarf/src/config.CLIVersion=$(CLI_VERSION)'
+BUILD_ARGS := -s -w -X 'github.com/defenseunicorns/zarf/src/config.CLIVersion=$(CLI_VERSION)'       # TODO: Add some way to pass the sget string as a value here too
 .DEFAULT_GOAL := help
 
 .PHONY: help
@@ -52,7 +52,7 @@ build-cli-mac-intel: build-injector-registry
 build-cli-mac-apple: build-injector-registry
 	GOOS=darwin GOARCH=arm64 go build -ldflags="$(BUILD_ARGS)" -o build/zarf-mac-apple src/main.go
 
-build-cli-linux: build-cli-linux-amd build-cli-linux-arm 
+build-cli-linux: build-cli-linux-amd build-cli-linux-arm
 
 build-cli: build-cli-linux-amd build-cli-linux-arm build-cli-mac-intel build-cli-mac-apple ## Build the CLI
 

--- a/main.go
+++ b/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	_ "embed"
+
+	"github.com/defenseunicorns/zarf/src/cmd"
+	"github.com/defenseunicorns/zarf/src/config"
+)
+
+//go:embed cosign.pub
+var cosignPublicKey string
+
+func main() {
+	config.SGetPublicKey = cosignPublicKey
+	cmd.Execute()
+}

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -109,5 +109,5 @@ func init() {
 	packageDeployCmd.Flags().BoolVar(&insecureDeploy, "insecure", false, "Skip shasum validation of remote package. Required if deploying a remote package and `--shasum` is not provided")
 	packageDeployCmd.Flags().StringVar(&shasum, "shasum", "", "Shasum of the package to deploy. Required if deploying a remote package and `--insecure` is not provided")
 
-	packageDeployCmd.Flags().StringVar(&config.DeployOptions.SGetKeyPath, "sget", "", "path to public sget key for remote packages deployed via sget")
+	packageDeployCmd.Flags().StringVar(&config.DeployOptions.SGetKeyPath, "sget", "", "Path to public sget key file for remote packages signed via cosign")
 }

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -108,4 +108,6 @@ func init() {
 	packageDeployCmd.Flags().StringVar(&config.DeployOptions.Components, "components", "", "Comma-separated list of components to install.  Adding this flag will skip the init prompts for which components to install")
 	packageDeployCmd.Flags().BoolVar(&insecureDeploy, "insecure", false, "Skip shasum validation of remote package. Required if deploying a remote package and `--shasum` is not provided")
 	packageDeployCmd.Flags().StringVar(&shasum, "shasum", "", "Shasum of the package to deploy. Required if deploying a remote package and `--insecure` is not provided")
+
+	packageDeployCmd.Flags().StringVar(&config.DeployOptions.SGetKeyPath, "sget", "", "path to public sget key for remote packages deployed via sget")
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -61,6 +61,8 @@ var (
 	// Private vars
 	active types.ZarfPackage
 	state  types.ZarfState
+
+	SGetPublicKey string
 )
 
 func IsZarfInitConfig() bool {

--- a/src/internal/packager/common.go
+++ b/src/internal/packager/common.go
@@ -1,6 +1,7 @@
 package packager
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -79,10 +80,10 @@ func confirmAction(configPath, userMessage string, sbomViewFiles []string) bool 
 	if err != nil {
 		message.Fatal(err, "Unable to open the package config file")
 	}
-	
+
 	// Convert []byte to string and print to screen
 	text := string(content)
-	
+
 	pterm.Println()
 	utils.ColorPrintYAML(text)
 
@@ -116,6 +117,11 @@ func HandleIfURL(packagePath string, shasum string, insecureDeploy bool) (string
 	providedURL, err := url.Parse(packagePath)
 	if err != nil || providedURL.Scheme == "" || providedURL.Host == "" {
 		return packagePath, func() {}
+	}
+
+	// Handle case where deploying remote package validated via sget
+	if strings.HasPrefix(packagePath, "sget://") {
+		return handleSgetPackage(packagePath)
 	}
 
 	if !insecureDeploy && shasum == "" {
@@ -158,6 +164,32 @@ func HandleIfURL(packagePath string, shasum string, insecureDeploy bool) (string
 			_ = os.Remove(localPackagePath)
 			message.Fatalf(nil, "Provided shasum (%s) of the package did not match what was downloaded (%s)\n", shasum, value)
 		}
+	}
+
+	return localPackagePath, tempPath.clean
+}
+
+func handleSgetPackage(sgetPackagePath string) (string, func()) {
+	sgetPackageName := strings.Split(sgetPackagePath, "sget://")[1]
+	// Write the package to a local file
+	tempPath := createPaths()
+
+	// Create the file
+	localPackagePath := tempPath.base + sgetPackageName
+	destinationFile, err := os.Create(localPackagePath)
+	if err != nil {
+		message.Fatal(err, "Unable to create the destination file")
+	}
+	defer destinationFile.Close()
+
+	// If this is a DefenseUnicorns package, use an internal sget public key
+	if strings.HasPrefix(sgetPackagePath, "sget://defenseunicorns") {
+		os.Setenv("DU_SGET_KEY", config.SGetPublicKey)
+		config.DeployOptions.SGetKeyPath = "env://DU_SGET_KEY"
+	}
+	err = utils.Sget(sgetPackagePath, config.DeployOptions.SGetKeyPath, destinationFile, context.TODO())
+	if err != nil {
+		message.Fatal(err, "Unable to get the remote package via sget")
 	}
 
 	return localPackagePath, tempPath.clean

--- a/src/internal/packager/common.go
+++ b/src/internal/packager/common.go
@@ -170,12 +170,12 @@ func HandleIfURL(packagePath string, shasum string, insecureDeploy bool) (string
 }
 
 func handleSgetPackage(sgetPackagePath string) (string, func()) {
-	sgetPackageName := strings.Split(sgetPackagePath, "sget://")[1]
-	// Write the package to a local file
+	// Write the package to a local file in a temp path
 	tempPath := createPaths()
 
-	// Create the file
-	localPackagePath := tempPath.base + sgetPackageName
+	// Create the local file for the package
+	sgetPackagePathSplit := strings.Split(sgetPackagePath, "/")
+	localPackagePath := filepath.Join(tempPath.base, sgetPackagePathSplit[len(sgetPackagePathSplit)-1]) + ".tar.zst"
 	destinationFile, err := os.Create(localPackagePath)
 	if err != nil {
 		message.Fatal(err, "Unable to create the destination file")
@@ -187,6 +187,11 @@ func handleSgetPackage(sgetPackagePath string) (string, func()) {
 		os.Setenv("DU_SGET_KEY", config.SGetPublicKey)
 		config.DeployOptions.SGetKeyPath = "env://DU_SGET_KEY"
 	}
+
+	// Remove the 'sget://' header for the actual sget call
+	sgetPackagePath = strings.Split(sgetPackagePath, "sget://")[1]
+
+	// Sget the package
 	err = utils.Sget(sgetPackagePath, config.DeployOptions.SGetKeyPath, destinationFile, context.TODO())
 	if err != nil {
 		message.Fatal(err, "Unable to get the remote package via sget")

--- a/src/internal/packager/common.go
+++ b/src/internal/packager/common.go
@@ -174,8 +174,7 @@ func handleSgetPackage(sgetPackagePath string) (string, func()) {
 	tempPath := createPaths()
 
 	// Create the local file for the package
-	sgetPackagePathSplit := strings.Split(sgetPackagePath, "/")
-	localPackagePath := filepath.Join(tempPath.base, sgetPackagePathSplit[len(sgetPackagePathSplit)-1]) + ".tar.zst"
+	localPackagePath := filepath.Join(tempPath.base, "remote.tar.zst")
 	destinationFile, err := os.Create(localPackagePath)
 	if err != nil {
 		message.Fatal(err, "Unable to create the destination file")

--- a/src/internal/packager/common.go
+++ b/src/internal/packager/common.go
@@ -189,7 +189,7 @@ func handleSgetPackage(sgetPackagePath string) (string, func()) {
 	}
 
 	// Remove the 'sget://' header for the actual sget call
-	sgetPackagePath = strings.Split(sgetPackagePath, "sget://")[1]
+	sgetPackagePath = strings.TrimPrefix(sgetPackagePath, "sget://")
 
 	// Sget the package
 	err = utils.Sget(sgetPackagePath, config.DeployOptions.SGetKeyPath, destinationFile, context.TODO())

--- a/src/main.go
+++ b/src/main.go
@@ -1,9 +1,0 @@
-package main
-
-import (
-	"github.com/defenseunicorns/zarf/src/cmd"
-)
-
-func main() {
-	cmd.Execute()
-}

--- a/src/test/e2e/e2e_remote_sget_test.go
+++ b/src/test/e2e/e2e_remote_sget_test.go
@@ -1,0 +1,22 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestE2eRemoteSgete(t *testing.T) {
+	defer e2e.cleanupAfterTest(t)
+
+	//run `zarf init`
+	output, err := e2e.execZarfCommand("init", "--confirm")
+	require.NoError(t, err, output)
+
+	path := fmt.Sprintf("sget://defenseunicorns/zarf-hello-world:%s", e2e.arch)
+
+	// Deploy the game
+	output, err = e2e.execZarfCommand("package", "deploy", path, "--confirm")
+	require.NoError(t, err, output)
+}

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -155,6 +155,7 @@ type ZarfDeployOptions struct {
 	PackagePath string
 	Confirm     bool
 	Components  string
+	SGetKeyPath string
 
 	// Zarf init is installing the k3s component
 	ApplianceMode bool


### PR DESCRIPTION
Provides support for specifying a remote signed package (via cosign/sget) to deploy.  Initial use will be for https://zarf.dev/install/