### PR TITLE
Fully remove zarf secrets from all namespaces

### DIFF
--- a/src/cmd/destroy.go
+++ b/src/cmd/destroy.go
@@ -74,12 +74,8 @@ var destroyCmd = &cobra.Command{
 			// If Zarf didn't deploy the cluster, only delete the ZarfNamespace
 			k8s.DeleteZarfNamespace()
 
-			// Remove zarf agent labels from namespaces Zarf doesn't manage
-			k8s.StripZarfAgentLabelFromNamespaces()
-
-			// Delete the private-registry secret in the default namespace
-			defaultSecret, _ := k8s.GetSecret("default", config.ZarfImagePullSecretName)
-			k8s.DeleteSecret(defaultSecret)
+			// Remove zarf agent labels and secrets from namespaces Zarf doesn't manage
+			k8s.StripZarfLabelsAndSecretsFromNamespaces()
 		}
 	},
 }

--- a/src/internal/k8s/namespace.go
+++ b/src/internal/k8s/namespace.go
@@ -91,25 +91,3 @@ func DeleteZarfNamespace() {
 		time.Sleep(1 * time.Second)
 	}
 }
-
-func StripZarfAgentLabelFromNamespaces() {
-	spinner := message.NewProgressSpinner("Removing zarf metadata from existing namespaces not managed by Zarf")
-	defer spinner.Stop()
-
-	if namespaces, err := GetNamespaces(); err != nil {
-		spinner.Errorf(err, "Unable to get k8s namespaces")
-	} else {
-		for _, namespace := range namespaces.Items {
-			if _, ok := namespace.Labels["zarf.dev/agent"]; ok {
-				spinner.Updatef("Removing Zarf Agent label for namespace %v", namespace.Name)
-				delete(namespace.Labels, "zarf.dev/agent")
-				if _, err = UpdateNamespace(&namespace); err != nil {
-					// This is not a hard failure, but we should log it
-					spinner.Errorf(err, "Unable to update the namespace labels for %s", namespace.Name)
-				}
-			}
-		}
-	}
-
-	spinner.Success()
-}

--- a/src/internal/k8s/zarf.go
+++ b/src/internal/k8s/zarf.go
@@ -1,0 +1,47 @@
+package k8s
+
+import (
+	"context"
+
+	"github.com/defenseunicorns/zarf/src/config"
+	"github.com/defenseunicorns/zarf/src/internal/message"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func StripZarfLabelsAndSecretsFromNamespaces() {
+	spinner := message.NewProgressSpinner("Removing zarf metadata & secrtets from existing namespaces not managed by Zarf")
+	defer spinner.Stop()
+
+	clientSet := getClientset()
+	deleteOptions := metav1.DeleteOptions{}
+	listOptions := metav1.ListOptions{
+		LabelSelector: config.ZarfManagedByLabel + "=zarf",
+	}
+
+	if namespaces, err := GetNamespaces(); err != nil {
+		spinner.Errorf(err, "Unable to get k8s namespaces")
+	} else {
+		for _, namespace := range namespaces.Items {
+			if _, ok := namespace.Labels["zarf.dev/agent"]; ok {
+				spinner.Updatef("Removing Zarf Agent label for namespace %v", namespace.Name)
+				delete(namespace.Labels, "zarf.dev/agent")
+				if _, err = UpdateNamespace(&namespace); err != nil {
+					// This is not a hard failure, but we should log it
+					spinner.Errorf(err, "Unable to update the namespace labels for %s", namespace.Name)
+				}
+			}
+
+			for _, namespace := range namespaces.Items {
+				spinner.Updatef("Removing Zarf secrets for namespace %v", namespace.Name)
+				err := clientSet.CoreV1().
+					Secrets(namespace.Name).
+					DeleteCollection(context.TODO(), deleteOptions, listOptions)
+				if err != nil {
+					spinner.Errorf(err, "Unable to delete secrets from namespace %s", namespace.Name)
+				}
+			}
+		}
+	}
+
+	spinner.Success()
+}


### PR DESCRIPTION
## Description

Properly purge secrets with the `app.kubernetes.io/managed-by=zarf` label from all namespaces, regardless of `--remove-components` flag.  These secrets will have no meaning once destroy is run and are not picked up by `--remove-components` currently because they are created out-of-band from helm during the `postRender` stage of the helm install to avoid collisions. 

## Related Issue
Fixes #520 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
