### PR TITLE
Update goreleaser build path

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,7 +14,6 @@ builds:
     goos:
       - linux
       - darwin
-    dir: src
     ldflags:
       - -s -w -X github.com/defenseunicorns/zarf/src/config.CLIVersion={{.Tag}}
     goarch:


### PR DESCRIPTION
## Description
Hotfix update goreleaser path to use root directory after #550 
