### PR TITLE
Fix registry user in credentials output

### DIFF
--- a/src/internal/packager/deploy.go
+++ b/src/internal/packager/deploy.go
@@ -125,7 +125,7 @@ func Deploy() {
 	if config.IsZarfInitConfig() {
 		loginTable := pterm.TableData{
 			{"     Application", "Username", "Password", "Connect"},
-			{"     Registry", "zarf-push-user", config.GetSecret(config.StateRegistryPush), "zarf connect registry"},
+			{"     Registry", config.ZarfRegistryPushUser, config.GetSecret(config.StateRegistryPush), "zarf connect registry"},
 		}
 		for _, component := range componentsToDeploy {
 			// Show message if including logging stack


### PR DESCRIPTION
## Description

Referenced `config.ZarfRegistryPushUser` instead of the hardcoded `zarf-push-user` which was incorrectly being displayed in the credentials output after a `zarf init`.

## Related Issue

<!--- This project prefers to accept pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

Fixes #577 

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before merging

<!-- Please delete options that are not relevant -->

- [ ] Tests have been added/updated as necessary (add the `needs-tests` label)
- [ ] Documentation has been updated as necessary (add the `needs-docs` label)
- [ ] An ADR has been written as necessary (add the `needs-adr` label) [ [1](https://github.com/joelparkerhenderson/architecture-decision-record) [2](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) [3](https://adr.github.io/) ]
- [x] (Optional) Changes have been linted locally with [golangci-lint](https://github.com/golangci/golangci-lint). (NOTE: We haven't turned on lint checks in the pipeline yet so linting may be hard if it shows a lot of lint errors in places that weren't touched by changes. Thus, linting is optional right now.)
