### PR TITLE
Disable docker for k3s test

### DIFF
--- a/.github/workflows/test-k3s.yml
+++ b/.github/workflows/test-k3s.yml
@@ -24,6 +24,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: "Disable Docker"
+        run: sudo systemctl stop docker --now
+
       - name: "Build CLI"
         run: make build-cli-linux
       


### PR DESCRIPTION
## Description
Ensure docker isn't called from Zarf or Crane

## Related Issue
Fixes #580

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before merging

<!-- Please delete options that are not relevant -->

- [ ] Tests have been added/updated as necessary (add the `needs-tests` label)
- [ ] Documentation has been updated as necessary (add the `needs-docs` label)
