### PR TITLE
update gitea PATCH request to include 'login_name' key

### DIFF
--- a/src/internal/git/utils.go
+++ b/src/internal/git/utils.go
@@ -272,7 +272,7 @@ func CreateReadOnlyUser() error {
 
 	// Make sure the user can't create their own repos or orgs
 	updateUserBody := map[string]interface{}{
-		"email":                     "zarf-reader@localhost.local",
+		"login_name":                config.ZarfGitReadUser,
 		"max_repo_creation":         0,
 		"allow_create_organization": false,
 	}


### PR DESCRIPTION
Gitea updated their api and now the `login_name` key is required for PATCH requests.