### PR TITLE
fixes link in docs

### DIFF
--- a/docs/4-user-guide/2-zarf-packages/1-zarf-packages.md
+++ b/docs/4-user-guide/2-zarf-packages/1-zarf-packages.md
@@ -80,7 +80,7 @@ Zarf packages are split into smaller chunks called 'components'. These component
 
 :::
 
-The process of defining a package is covered in the [Creating Your Own Package](https://google.com) page. Assuming you have a package already defined, building the package itself is fairly simple.
+The process of defining a package is covered in the [Creating Your Own Package](../../13-walkthroughs/0-creating-a-zarf-package.md) page. Assuming you have a package already defined, building the package itself is fairly simple.
 
 `zarf package create` will look for a `zarf.yaml` file in the current directory and build the package from that file. Behind the scenes, this is pulling down all the resources it needs from the internet and placing them in a temporary directory, once all the necessary resources of retrieved, Zarf will create the tarball of the temp directory and clean up the temp directory.
 


### PR DESCRIPTION
## Description
While going through the docs on the website I found a link to google.com, fixing it here in the docs



## Type of change

<!-- Please delete options that are not relevant -->

- [x] Docs

## Checklist before merging
- [x] Documentation has been updated as necessary (add the `needs-docs` label)

