### PR TITLE
Add error checking to surveys

### DIFF
--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -79,7 +79,9 @@ var initCmd = &cobra.Command{
 					prompt := &survey.Confirm{
 						Message: "Do you want to download this init package?",
 					}
-					_ = survey.AskOne(prompt, &confirmDownload)
+					if err := survey.AskOne(prompt, &confirmDownload); err != nil {
+						message.Fatalf(nil, "Confirm selection canceled: %s", err.Error())
+					}
 				}
 
 				// If the user wants to download the init-package, download it

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -89,7 +89,11 @@ func choosePackage(args []string) string {
 			return files
 		},
 	}
-	_ = survey.AskOne(prompt, &path, survey.WithValidator(survey.Required))
+
+	if err := survey.AskOne(prompt, &path, survey.WithValidator(survey.Required)); err != nil {
+		message.Fatalf(nil, "Package path selection canceled: %s", err.Error())
+	}
+
 	return path
 }
 

--- a/src/cmd/prepare.go
+++ b/src/cmd/prepare.go
@@ -44,7 +44,9 @@ var prepareTransformGitLinks = &cobra.Command{
 		prompt := &survey.Confirm{
 			Message: "Overwrite the file " + fileName + " with these changes?",
 		}
-		_ = survey.AskOne(prompt, &confirm)
+		if err := survey.AskOne(prompt, &confirm); err != nil {
+			message.Fatalf(nil, "Confirm selection canceled: %s", err.Error())
+		}
 
 		if confirm {
 			// Overwrite the file

--- a/src/internal/packager/common.go
+++ b/src/internal/packager/common.go
@@ -108,7 +108,9 @@ func confirmAction(userMessage string, sbomViewFiles []string) bool {
 		prompt := &survey.Confirm{
 			Message: userMessage + " this Zarf package?",
 		}
-		_ = survey.AskOne(prompt, &confirmFlag)
+		if err := survey.AskOne(prompt, &confirmFlag); err != nil {
+			message.Fatalf(nil, "Confirm selection canceled: %s", err.Error())
+		}
 	}
 
 	return confirmFlag

--- a/src/internal/packager/components.go
+++ b/src/internal/packager/components.go
@@ -167,7 +167,9 @@ func confirmOptionalComponent(component types.ZarfComponent) (confirmComponent b
 		Message: fmt.Sprintf("Deploy the %s component?", component.Name),
 		Default: component.Default,
 	}
-	_ = survey.AskOne(prompt, &confirmComponent)
+	if err := survey.AskOne(prompt, &confirmComponent); err != nil {
+		message.Fatalf(nil, "Confirm selection canceled: %s", err.Error())
+	}
 	return confirmComponent
 }
 

--- a/src/internal/packager/components.go
+++ b/src/internal/packager/components.go
@@ -203,7 +203,10 @@ func confirmChoiceGroup(componentGroup []types.ZarfComponent) types.ZarfComponen
 		Message: "Select a component to deploy:",
 		Options: options,
 	}
-	_ = survey.AskOne(prompt, &chosen)
+
+	if err := survey.AskOne(prompt, &chosen); err != nil {
+		message.Fatalf(nil, "Component selection canceled: %s", err.Error())
+	}
 
 	return componentGroup[chosen]
 }


### PR DESCRIPTION
## Description

This adds error checks around the surveys that ask for things other than confirm

## Related Issue

Fixes #664 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging

- [X] (Optional) Changes have been linted locally with [golangci-lint](https://github.com/golangci/golangci-lint). (NOTE: We haven't turned on lint checks in the pipeline yet so linting may be hard if it shows a lot of lint errors in places that weren't touched by changes. Thus, linting is optional right now.)
