### PR TITLE
Include kustomizations in manifest count

### DIFF
--- a/src/internal/packager/create.go
+++ b/src/internal/packager/create.go
@@ -173,6 +173,7 @@ func addComponent(tempPath tempPaths, component types.ZarfComponent) {
 		manifestCount := 0
 		for _, manifest := range component.Manifests {
 			manifestCount += len(manifest.Files)
+			manifestCount += len(manifest.Kustomizations)
 		}
 
 		spinner := message.NewProgressSpinner("Loading %d K8s manifests", manifestCount)


### PR DESCRIPTION
Hotfix PR #670, when counting manifests, also include the # of kustomizations.