### PR TITLE
Fix the connect command usage info

### DIFF
--- a/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_connect.md
+++ b/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_connect.md
@@ -13,7 +13,7 @@ Packages can provide service manifests that define their own shortcut connection
 Even if the packages you deploy don't define their own shortcut connection options, you can use the command flags to connect into specific resources. You can read the command flag descriptions below to get a better idea how to connect to whatever resource you are trying to connect to.
 
 ```
-zarf connect <REGISTRY|LOGGING|GIT> [flags]
+zarf connect {REGISTRY|LOGGING|GIT|connect-name} [flags]
 ```
 
 ### Options

--- a/src/cmd/connect.go
+++ b/src/cmd/connect.go
@@ -14,7 +14,7 @@ var (
 	cliOnly             bool
 
 	connectCmd = &cobra.Command{
-		Use:     "connect <REGISTRY|LOGGING|GIT>",
+		Use:     "connect {REGISTRY|LOGGING|GIT|connect-name}",
 		Aliases: []string{"c"},
 		Short:   "Access services or pods deployed in the cluster.",
 		Long: "Uses a k8s port-forward to connect to resources within the cluster referenced by your kube-context.\n" +


### PR DESCRIPTION
## Description

Makes the connect command respect linux (and cobra) conventions

## Related Issue

Fixes # N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging

- [X] Documentation has been updated as necessary (add the `needs-docs` label)
- [X] (Optional) Changes have been linted locally with [golangci-lint](https://github.com/golangci/golangci-lint). (NOTE: We haven't turned on lint checks in the pipeline yet so linting may be hard if it shows a lot of lint errors in places that weren't touched by changes. Thus, linting is optional right now.)
