### PR TITLE
Make the corruption error more clear and fix zarf tools cache-clear

### DIFF
--- a/src/cmd/tools.go
+++ b/src/cmd/tools.go
@@ -100,8 +100,9 @@ var clearCacheCmd = &cobra.Command{
 	Aliases: []string{"c"},
 	Short:   "Clears the configured git and image cache directory",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := os.RemoveAll(config.CreateOptions.CachePath); err != nil {
-			message.Fatalf("Unable to clear the cache driectory %s: %s", config.CreateOptions.CachePath, err.Error())
+		message.Debugf("Cache directory set to: %s", config.GetAbsCachePath())
+		if err := os.RemoveAll(config.GetAbsCachePath()); err != nil {
+			message.Fatalf("Unable to clear the cache driectory %s: %s", config.GetAbsCachePath(), err.Error())
 		}
 	},
 }

--- a/src/internal/images/pull.go
+++ b/src/internal/images/pull.go
@@ -45,7 +45,7 @@ func PullAll(buildImageList []string, imageTarballPath string) map[name.Tag]v1.I
 		spinner.Updatef("Fetching image metadata (%d of %d): %s", idx+1, imageCount, src)
 		img, err := crane.Pull(src, config.GetCraneOptions()...)
 		if err != nil {
-			spinner.Fatalf(err, "Unable to pull the image %s", src)
+			spinner.Fatalf(err, "Unable to pull the image \"%s\"", src)
 		}
 		imageCachePath := filepath.Join(config.GetAbsCachePath(), config.ZarfImageCacheDir)
 		img = cache.Image(img, cache.NewFilesystemCache(imageCachePath))

--- a/src/internal/images/pull.go
+++ b/src/internal/images/pull.go
@@ -90,7 +90,7 @@ func PullAll(buildImageList []string, imageTarballPath string) map[name.Tag]v1.I
 			return tagToImage
 		case update.Error != nil && strings.HasPrefix(update.Error.Error(), "archive/tar: missed writing "):
 			// Handle potential image cache corruption with a more helpful error. See L#54 in libexec/src/archive/tar/writer.go
-			message.Fatalf(update.Error, "potential image cache corruption: %s of %v bytes", update.Error.Error(), update.Total)
+			message.Fatalf(update.Error, "potential image cache corruption: %s of %v bytes - try clearing cache with \"zarf tools clear-cache\"", update.Error.Error(), update.Total)
 		case update.Error != nil:
 			message.Fatalf(update.Error, "error writing image tarball: %s", update.Error.Error())
 		default:


### PR DESCRIPTION
## Description

This adds a more descriptive error and fixes issues with the cache clear command

## Related Issue

Fixes #813

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging

- [X] (Optional) Changes have been linted locally with [golangci-lint](https://github.com/golangci/golangci-lint). (NOTE: We haven't turned on lint checks in the pipeline yet so linting may be hard if it shows a lot of lint errors in places that weren't touched by changes. Thus, linting is optional right now.)
