### PR TITLE
fix init pkg deploy via ui

### DIFF
--- a/src/internal/api/packages/deploy.go
+++ b/src/internal/api/packages/deploy.go
@@ -3,27 +3,63 @@ package packages
 import (
 	"encoding/json"
 	"net/http"
+	"path"
+	"path/filepath"
 
 	"github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/internal/api/common"
 	"github.com/defenseunicorns/zarf/src/internal/message"
 	"github.com/defenseunicorns/zarf/src/internal/packager"
+	"github.com/defenseunicorns/zarf/src/internal/utils"
 	"github.com/defenseunicorns/zarf/src/types"
 )
 
 // DeployPackage deploys a package to the Zarf cluster.
 func DeployPackage(w http.ResponseWriter, r *http.Request) {
-	// Decode the body of the request
-	var deployClusterRequest = types.ZarfDeployOptions{}
-	err := json.NewDecoder(r.Body).Decode(&deployClusterRequest)
-	if err != nil {
-		message.ErrorWebf(err, w, "Unable to decode the request to deploy the cluster")
+	isInitPkg := r.URL.Query().Get("isInitPkg") == "true"
 
-		return
+	if isInitPkg {
+		var body = types.ZarfInitOptions{}
+		err := json.NewDecoder(r.Body).Decode(&body)
+		if err != nil {
+			message.ErrorWebf(err, w, "Unable to decode the request to deploy the cluster")
+			return
+		}
+		config.InitOptions = body
+		initPackageName := config.GetInitPackageName()
+		config.DeployOptions.PackagePath = initPackageName
+
+		// Try to use an init-package in the executable directory if none exist in current working directory
+		if utils.InvalidPath(config.DeployOptions.PackagePath) {
+			// Get the path to the executable
+			if executablePath, err := utils.GetFinalExecutablePath(); err != nil {
+				message.Errorf(err, "Unable to get the path to the executable")
+			} else {
+				executableDir := path.Dir(executablePath)
+				config.DeployOptions.PackagePath = filepath.Join(executableDir, initPackageName)
+			}
+
+			// If the init-package doesn't exist in the executable directory, try the cache directory
+			if err != nil || utils.InvalidPath(config.DeployOptions.PackagePath) {
+				config.DeployOptions.PackagePath = filepath.Join(config.GetAbsCachePath(), initPackageName)
+
+				// If the init-package doesn't exist in the cache directory, return an error
+				if utils.InvalidPath(config.DeployOptions.PackagePath) {
+					common.WriteJSONResponse(w, false, http.StatusBadRequest)
+					return
+				}
+			}
+		}
+	} else {
+		var body = types.ZarfDeployOptions{}
+		err := json.NewDecoder(r.Body).Decode(&body)
+		if err != nil {
+			message.ErrorWebf(err, w, "Unable to decode the request to deploy the cluster")
+			return
+		}
+		config.DeployOptions = body
 	}
 
-	// Set the deploy options and deploy!
-	config.DeployOptions = deployClusterRequest
 	config.CommonOptions.Confirm = true
 	packager.Deploy()
 

--- a/src/types/api.go
+++ b/src/types/api.go
@@ -6,6 +6,7 @@ type RestAPI struct {
 	ZarfCommonOptions ZarfCommonOptions `json:"zarfCommonOptions"`
 	ZarfCreateOptions ZarfCreateOptions `json:"zarfCreateOptions"`
 	ZarfDeployOptions ZarfDeployOptions `json:"zarfDeployOptions"`
+	ZarfInitOptions   ZarfInitOptions   `json:"zarfInitOptions"`
 	ConnectStrings    ConnectStrings    `json:"connectStrings"`
 	ClusterSummary    ClusterSummary    `json:"clusterSummary"`
 	DeployedPackage   DeployedPackage   `json:"deployedPackage"`

--- a/src/ui/lib/api-types.ts
+++ b/src/ui/lib/api-types.ts
@@ -15,6 +15,7 @@ export interface APITypes {
     zarfCommonOptions: ZarfCommonOptions;
     zarfCreateOptions: ZarfCreateOptions;
     zarfDeployOptions: ZarfDeployOptions;
+    zarfInitOptions:   ZarfInitOptions;
     zarfPackage:       ZarfPackage;
     zarfState:         ZarfState;
 }
@@ -454,6 +455,8 @@ export interface GeneratedPKI {
 
 /**
  * Information about the repository Zarf is configured to use
+ *
+ * Information about the repository Zarf is going to be using
  */
 export interface GitServerInfo {
     /**
@@ -486,6 +489,8 @@ export interface GitServerInfo {
 
 /**
  * Information about the registry Zarf is configured to use
+ *
+ * Information about the registry Zarf is going to be using
  */
 export interface RegistryInfo {
     /**
@@ -607,6 +612,29 @@ export interface ZarfDeployOptions {
      * Location where the public key component of a cosign key-pair can be found
      */
     sGetKeyPath: string;
+}
+
+export interface ZarfInitOptions {
+    /**
+     * Indicates if Zarf was initialized while deploying its own k8s cluster
+     */
+    applianceMode: boolean;
+    /**
+     * Comma separated list of optional components to deploy
+     */
+    components: string;
+    /**
+     * Information about the repository Zarf is going to be using
+     */
+    gitServer: GitServerInfo;
+    /**
+     * Information about the registry Zarf is going to be using
+     */
+    registryInfo: RegistryInfo;
+    /**
+     * StorageClass of the k8s cluster Zarf is initializing
+     */
+    storageClass: string;
 }
 
 // Converts JSON strings to/from your types
@@ -762,6 +790,7 @@ const typeMap: any = {
         { json: "zarfCommonOptions", js: "zarfCommonOptions", typ: r("ZarfCommonOptions") },
         { json: "zarfCreateOptions", js: "zarfCreateOptions", typ: r("ZarfCreateOptions") },
         { json: "zarfDeployOptions", js: "zarfDeployOptions", typ: r("ZarfDeployOptions") },
+        { json: "zarfInitOptions", js: "zarfInitOptions", typ: r("ZarfInitOptions") },
         { json: "zarfPackage", js: "zarfPackage", typ: r("ZarfPackage") },
         { json: "zarfState", js: "zarfState", typ: r("ZarfState") },
     ], false),
@@ -951,6 +980,13 @@ const typeMap: any = {
         { json: "packagePath", js: "packagePath", typ: "" },
         { json: "setVariables", js: "setVariables", typ: m("") },
         { json: "sGetKeyPath", js: "sGetKeyPath", typ: "" },
+    ], false),
+    "ZarfInitOptions": o([
+        { json: "applianceMode", js: "applianceMode", typ: true },
+        { json: "components", js: "components", typ: "" },
+        { json: "gitServer", js: "gitServer", typ: r("GitServerInfo") },
+        { json: "registryInfo", js: "registryInfo", typ: r("RegistryInfo") },
+        { json: "storageClass", js: "storageClass", typ: "" },
     ], false),
     "Architecture": [
         "amd64",

--- a/src/ui/lib/api.ts
+++ b/src/ui/lib/api.ts
@@ -4,6 +4,7 @@ import type {
 	DeployedComponent,
 	DeployedPackage,
 	ZarfDeployOptions,
+	ZarfInitOptions,
 	ZarfState
 } from './api-types';
 import { HTTP } from './http';
@@ -35,7 +36,8 @@ const Packages = {
 	findInit: () => http.get<string[]>('/packages/find-init'),
 	read: (name: string) => http.get<APIZarfPackage>(`/packages/read/${encodeURIComponent(name)}`),
 	getDeployedPackages: () => http.get<DeployedPackage[]>('/packages/list'),
-	deploy: (body: ZarfDeployOptions) => http.put<boolean>('/packages/deploy', body),
+	deploy: (body: ZarfDeployOptions | ZarfInitOptions, isInitPkg:boolean) =>
+		http.put<boolean>(`/packages/deploy?isInitPkg=${encodeURIComponent(isInitPkg)}`, body),
 	remove: (name: string) => http.del(`/packages/remove/${encodeURIComponent(name)}`)
 };
 

--- a/src/ui/lib/api.ts
+++ b/src/ui/lib/api.ts
@@ -36,8 +36,8 @@ const Packages = {
 	findInit: () => http.get<string[]>('/packages/find-init'),
 	read: (name: string) => http.get<APIZarfPackage>(`/packages/read/${encodeURIComponent(name)}`),
 	getDeployedPackages: () => http.get<DeployedPackage[]>('/packages/list'),
-	deploy: (body: ZarfDeployOptions | ZarfInitOptions, isInitPkg:boolean) =>
-		http.put<boolean>(`/packages/deploy?isInitPkg=${encodeURIComponent(isInitPkg)}`, body),
+	deploy: (body: ZarfDeployOptions | ZarfInitOptions, isInitPkg: boolean) =>
+		http.put<boolean>(isInitPkg ? `/packages/deploy?isInitPkg=true` : `/packages/deploy`, body),
 	remove: (name: string) => http.del(`/packages/remove/${encodeURIComponent(name)}`)
 };
 

--- a/src/ui/routes/initialize/deploy/+page.svelte
+++ b/src/ui/routes/initialize/deploy/+page.svelte
@@ -21,6 +21,7 @@
 		$pkgStore.zarfPackage.components,
 		$pkgComponentDeployStore
 	);
+	// comma-delimited string that contains only optional components that were enabled via UI
 	const requestedComponents: string = $pkgStore.zarfPackage.components
 		.filter((c, idx) => $pkgComponentDeployStore.includes(idx) && !c.required)
 		.map((c) => c.name)

--- a/src/ui/routes/initialize/deploy/+page.svelte
+++ b/src/ui/routes/initialize/deploy/+page.svelte
@@ -35,9 +35,9 @@
 			components: requestedComponents,
 			gitServer: {
 				address: '',
-				pushUsername: '',
+				pushUsername: 'zarf-git-user',
 				pushPassword: '',
-				pullUsername: '',
+				pullUsername: 'zarf-git-read-user',
 				pullPassword: '',
 				internalServer: true
 			},
@@ -47,9 +47,9 @@
 				internalRegistry: true,
 				nodePort: 0,
 				pullPassword: '',
-				pullUsername: '',
+				pullUsername: 'zarf-pull',
 				pushPassword: '',
-				pushUsername: '',
+				pushUsername: 'zarf-push',
 				secret: ''
 			}
 		};


### PR DESCRIPTION
## Description

There is currently a disconnect between the UI and the CLI experience when `zarf init`ing.  This is because the flow of `zarf init` does not strictly follow the same flow that `zarf package deploy` does.  `ZarfDeployOptions != ZarfInitOptions`.

This PR patches the overall API request flow, but does not add the missing options from `ZarfInitOptions` to the UI. Further discussion is needed in that area.

<!-- Please include a summary of the change. Any relevant motivation or context is also helpful, as well as any dependencies that are required for this change -->

## Related Issue

<!--- This project prefers to accept pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

Fixes #882 

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

