### PR TITLE
Add a generate PKI command

### DIFF
--- a/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools.md
+++ b/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools.md
@@ -29,3 +29,4 @@ Collection of additional tools to make airgap easier
 * [zarf tools monitor](zarf_tools_monitor.md)	 - Launch K9s tool for managing K8s clusters
 * [zarf tools registry](zarf_tools_registry.md)	 - Collection of registry commands provided by Crane
 * [zarf tools sbom](zarf_tools_sbom.md)	 - SBOM tools provided by Anchore Syft
+

--- a/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools.md
+++ b/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools.md
@@ -24,8 +24,8 @@ Collection of additional tools to make airgap easier
 * [zarf](zarf.md)	 - DevSecOps Airgap Toolkit
 * [zarf tools archiver](zarf_tools_archiver.md)	 - Compress/Decompress tools for Zarf packages
 * [zarf tools clear-cache](zarf_tools_clear-cache.md)	 - Clears the configured git and image cache directory
+* [zarf tools gen-pki](zarf_tools_gen-pki.md)	 - Generates a Certificate Authority and PKI chain of trust for the given host
 * [zarf tools get-git-password](zarf_tools_get-git-password.md)	 - Returns the push user's password for the Git server
 * [zarf tools monitor](zarf_tools_monitor.md)	 - Launch K9s tool for managing K8s clusters
 * [zarf tools registry](zarf_tools_registry.md)	 - Collection of registry commands provided by Crane
 * [zarf tools sbom](zarf_tools_sbom.md)	 - SBOM tools provided by Anchore Syft
-

--- a/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools_archiver.md
+++ b/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools_archiver.md
@@ -24,3 +24,4 @@ Compress/Decompress tools for Zarf packages
 * [zarf tools](zarf_tools.md)	 - Collection of additional tools to make airgap easier
 * [zarf tools archiver compress](zarf_tools_archiver_compress.md)	 - Compress a collection of sources based off of the destination file extension
 * [zarf tools archiver decompress](zarf_tools_archiver_decompress.md)	 - Decompress an archive (package) to a specified location
+

--- a/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools_archiver.md
+++ b/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools_archiver.md
@@ -23,5 +23,4 @@ Compress/Decompress tools for Zarf packages
 
 * [zarf tools](zarf_tools.md)	 - Collection of additional tools to make airgap easier
 * [zarf tools archiver compress](zarf_tools_archiver_compress.md)	 - Compress a collection of sources based off of the destination file extension
-* [zarf tools archiver decompress](zarf_tools_archiver_decompress.md)	 - Decompress an archive (package) to a specified location.
-
+* [zarf tools archiver decompress](zarf_tools_archiver_decompress.md)	 - Decompress an archive (package) to a specified location

--- a/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools_archiver_compress.md
+++ b/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools_archiver_compress.md
@@ -26,3 +26,4 @@ zarf tools archiver compress {SOURCES} {ARCHIVE} [flags]
 ### SEE ALSO
 
 * [zarf tools archiver](zarf_tools_archiver.md)	 - Compress/Decompress tools for Zarf packages
+

--- a/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools_archiver_decompress.md
+++ b/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools_archiver_decompress.md
@@ -1,9 +1,9 @@
 ## zarf tools archiver decompress
 
-Decompress an archive (package) to a specified location.
+Decompress an archive (package) to a specified location
 
 ```
-zarf tools archiver decompress [ARCHIVE] [DESTINATION] [flags]
+zarf tools archiver decompress {ARCHIVE} {DESTINATION} [flags]
 ```
 
 ### Options
@@ -26,4 +26,3 @@ zarf tools archiver decompress [ARCHIVE] [DESTINATION] [flags]
 ### SEE ALSO
 
 * [zarf tools archiver](zarf_tools_archiver.md)	 - Compress/Decompress tools for Zarf packages
-

--- a/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools_archiver_decompress.md
+++ b/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools_archiver_decompress.md
@@ -26,3 +26,4 @@ zarf tools archiver decompress {ARCHIVE} {DESTINATION} [flags]
 ### SEE ALSO
 
 * [zarf tools archiver](zarf_tools_archiver.md)	 - Compress/Decompress tools for Zarf packages
+

--- a/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools_gen-pki.md
+++ b/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools_gen-pki.md
@@ -1,15 +1,16 @@
-## zarf tools archiver compress
+## zarf tools gen-pki
 
-Compress a collection of sources based off of the destination file extension
+Generates a Certificate Authority and PKI chain of trust for the given host
 
 ```
-zarf tools archiver compress {SOURCES} {ARCHIVE} [flags]
+zarf tools gen-pki {HOST} [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for compress
+  -h, --help                       help for gen-pki
+      --sub-alt-name stringArray   Specify Subject Alternative Names for the certificate
 ```
 
 ### Options inherited from parent commands
@@ -25,4 +26,4 @@ zarf tools archiver compress {SOURCES} {ARCHIVE} [flags]
 
 ### SEE ALSO
 
-* [zarf tools archiver](zarf_tools_archiver.md)	 - Compress/Decompress tools for Zarf packages
+* [zarf tools](zarf_tools.md)	 - Collection of additional tools to make airgap easier

--- a/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools_gen-pki.md
+++ b/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_tools_gen-pki.md
@@ -27,3 +27,4 @@ zarf tools gen-pki {HOST} [flags]
 ### SEE ALSO
 
 * [zarf tools](zarf_tools.md)	 - Collection of additional tools to make airgap easier
+

--- a/src/cmd/tools.go
+++ b/src/cmd/tools.go
@@ -8,11 +8,14 @@ import (
 	"github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/internal/k8s"
 	"github.com/defenseunicorns/zarf/src/internal/message"
+	"github.com/defenseunicorns/zarf/src/internal/pki"
 	k9s "github.com/derailed/k9s/cmd"
 	craneCmd "github.com/google/go-containerregistry/cmd/crane/cmd"
 	"github.com/mholt/archiver/v3"
 	"github.com/spf13/cobra"
 )
+
+var subAltNames []string
 
 var toolsCmd = &cobra.Command{
 	Use:     "tools",
@@ -28,7 +31,7 @@ var archiverCmd = &cobra.Command{
 }
 
 var archiverCompressCmd = &cobra.Command{
-	Use:     "compress [SOURCES] [ARCHIVE]",
+	Use:     "compress {SOURCES} {ARCHIVE}",
 	Aliases: []string{"c"},
 	Short:   "Compress a collection of sources based off of the destination file extension",
 	Args:    cobra.MinimumNArgs(2),
@@ -42,9 +45,9 @@ var archiverCompressCmd = &cobra.Command{
 }
 
 var archiverDecompressCmd = &cobra.Command{
-	Use:     "decompress [ARCHIVE] [DESTINATION]",
+	Use:     "decompress {ARCHIVE} {DESTINATION}",
 	Aliases: []string{"d"},
-	Short:   "Decompress an archive (package) to a specified location.",
+	Short:   "Decompress an archive (package) to a specified location",
 	Args:    cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		sourceArchive, destinationPath := args[0], args[1]
@@ -104,6 +107,27 @@ var clearCacheCmd = &cobra.Command{
 		if err := os.RemoveAll(config.GetAbsCachePath()); err != nil {
 			message.Fatalf("Unable to clear the cache driectory %s: %s", config.GetAbsCachePath(), err.Error())
 		}
+		message.SuccessF("Successfully cleared the cache from %s", config.GetAbsCachePath())
+	},
+}
+
+var generatePKICmd = &cobra.Command{
+	Use:     "gen-pki {HOST}",
+	Aliases: []string{"pki"},
+	Short:   "Generates a Certificate Authority and PKI chain of trust for the given host",
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		pki := pki.GeneratePKI(args[0], subAltNames...)
+		if err := os.WriteFile("tls.ca", pki.CA, 0644); err != nil {
+			message.Fatalf(err, "Failed to write the CA file: %s", err.Error())
+		}
+		if err := os.WriteFile("tls.crt", pki.Cert, 0644); err != nil {
+			message.Fatalf(err, "Failed to write the Certificate file: %s", err.Error())
+		}
+		if err := os.WriteFile("tls.key", pki.Key, 0600); err != nil {
+			message.Fatalf(err, "Failed to write the Key file: %s", err.Error())
+		}
+		message.SuccessF("Successfully created a chain of trust for %s", args[0])
 	},
 }
 
@@ -116,6 +140,9 @@ func init() {
 
 	toolsCmd.AddCommand(clearCacheCmd)
 	clearCacheCmd.Flags().StringVar(&config.CommonOptions.CachePath, "zarf-cache", config.ZarfDefaultCachePath, "Specify the location of the Zarf  artifact cache (images and git repositories)")
+
+	toolsCmd.AddCommand(generatePKICmd)
+	generatePKICmd.Flags().StringArrayVar(&subAltNames, "sub-alt-name", []string{}, "Specify Subject Alternative Names for the certificate")
 
 	archiverCmd.AddCommand(archiverCompressCmd)
 	archiverCmd.AddCommand(archiverDecompressCmd)

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -114,5 +114,22 @@ func TestUseCLI(t *testing.T) {
 		assert.EqualError(t, err, msg, "Did not receive expected error when reading a directory that should not exist")
 	}
 
-	e2e.cleanFiles(shasumTestFilePath, cachePath, otherTmpPath, pkgName)
+	// Test generation of PKI
+	tlsCA := "tls.ca"
+	tlsCert := "tls.crt"
+	tlsKey := "tls.key"
+	stdOut, stdErr, err = e2e.execZarfCommand("tools", "gen-pki", "github.com", "--sub-alt-name", "google.com")
+	require.NoError(t, err, stdOut, stdErr)
+	require.Contains(t, stdErr, "Successfully created a chain of trust for github.com")
+
+	_, err = os.ReadFile(tlsCA)
+	require.NoError(t, err)
+
+	_, err = os.ReadFile(tlsCert)
+	require.NoError(t, err)
+
+	_, err = os.ReadFile(tlsKey)
+	require.NoError(t, err)
+
+	e2e.cleanFiles(shasumTestFilePath, cachePath, otherTmpPath, pkgName, tlsCA, tlsCert, tlsKey)
 }


### PR DESCRIPTION
## Description

This adds a new tools command to generate a PKI chain of trust.

## Related Issue

Fixes #915

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist before merging

- [X] Tests have been added/updated as necessary (add the `needs-tests` label)
- [X] Documentation has been updated as necessary (add the `needs-docs` label)
- [X] (Optional) Changes have been linted locally with [golangci-lint](https://github.com/golangci/golangci-lint). (NOTE: We haven't turned on lint checks in the pipeline yet so linting may be hard if it shows a lot of lint errors in places that weren't touched by changes. Thus, linting is optional right now.)
