### PR TITLE
#986. Bump unicorn-ui to v0.0.21. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"yaml": "2.1.3"
 			},
 			"devDependencies": {
-				"@defense-unicorns/unicorn-ui": "0.0.18",
+				"@defense-unicorns/unicorn-ui": "^0.0.21",
 				"@fontsource/roboto": "4.5.8",
 				"@material/card": "14.0.0",
 				"@material/data-table": "14.0.0",
@@ -167,9 +167,9 @@
 			}
 		},
 		"node_modules/@defense-unicorns/unicorn-ui": {
-			"version": "0.0.18",
-			"resolved": "https://registry.npmjs.org/@defense-unicorns/unicorn-ui/-/unicorn-ui-0.0.18.tgz",
-			"integrity": "sha512-2vxrP6VUVDogAfX3e9tmvc5VQ6kGQONWkhg9S/TnDzdP0Li13ASmbwGQo3s0Lbk0QVkw/igsZsskfdtHleIXDA==",
+			"version": "0.0.21",
+			"resolved": "https://registry.npmjs.org/@defense-unicorns/unicorn-ui/-/unicorn-ui-0.0.21.tgz",
+			"integrity": "sha512-zYJjGA1rnPL7xjV9uArP2z7WL0udVWOspZm+M36mehynP3Ox01ISMjRkGcTOhfcNXaa0wnOqixopC8dsmOeHQA==",
 			"dev": true,
 			"dependencies": {
 				"@fontsource/roboto": "^4.5.8",
@@ -4232,9 +4232,9 @@
 			}
 		},
 		"@defense-unicorns/unicorn-ui": {
-			"version": "0.0.18",
-			"resolved": "https://registry.npmjs.org/@defense-unicorns/unicorn-ui/-/unicorn-ui-0.0.18.tgz",
-			"integrity": "sha512-2vxrP6VUVDogAfX3e9tmvc5VQ6kGQONWkhg9S/TnDzdP0Li13ASmbwGQo3s0Lbk0QVkw/igsZsskfdtHleIXDA==",
+			"version": "0.0.21",
+			"resolved": "https://registry.npmjs.org/@defense-unicorns/unicorn-ui/-/unicorn-ui-0.0.21.tgz",
+			"integrity": "sha512-zYJjGA1rnPL7xjV9uArP2z7WL0udVWOspZm+M36mehynP3Ox01ISMjRkGcTOhfcNXaa0wnOqixopC8dsmOeHQA==",
 			"dev": true,
 			"requires": {
 				"@fontsource/roboto": "^4.5.8",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		]
 	},
 	"devDependencies": {
-		"@defense-unicorns/unicorn-ui": "0.0.18",
+		"@defense-unicorns/unicorn-ui": "^0.0.21",
 		"@fontsource/roboto": "4.5.8",
 		"@material/card": "14.0.0",
 		"@material/data-table": "14.0.0",

--- a/src/ui/lib/components/package-component-accordion.svelte
+++ b/src/ui/lib/components/package-component-accordion.svelte
@@ -6,7 +6,7 @@
 
 	import type { ZarfComponent } from '$lib/api-types';
 	import { pkgComponentDeployStore } from '$lib/store';
-	import { Accordion, IconButton, Typography } from '@defense-unicorns/unicorn-ui';
+	import { Accordion, IconButton, Typography } from '@ui';
 
 	export let idx: number;
 	export let readOnly: boolean = true;
@@ -27,7 +27,7 @@
 	$: componentTitle = `${component.name} ${requiredText}`;
 </script>
 
-<Accordion id={`component-accordion-${idx}`} wrapperClass="package-component-accordion">
+<Accordion id={`component-accordion-${idx}`} class="package-component-accordion">
 	<div slot="headerContent" class="component-accordion-header">
 		<div style="flex: 1">
 			<Typography variant="subtitle2" element="div" class="component-title" title={componentTitle}>
@@ -51,7 +51,7 @@
 			<div style="gap: 5px;">
 				<IconButton
 					toggleable
-					className="deploy-component-toggle"
+					class="deploy-component-toggle"
 					iconColor="inherit"
 					iconContent="toggle_off"
 					toggledIconColor="primary"

--- a/src/ui/lib/components/package-details-card.svelte
+++ b/src/ui/lib/components/package-details-card.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Divider from './divider.svelte';
 	import type { ZarfPackage } from '$lib/api-types';
-	import { Typography } from '@defense-unicorns/unicorn-ui';
+	import { Typography } from '@ui';
 	export let pkg: ZarfPackage;
 </script>
 

--- a/src/ui/routes/packages/+page.svelte
+++ b/src/ui/routes/packages/+page.svelte
@@ -3,7 +3,7 @@
 	import Hero from '$lib/components/hero.svelte';
 	import PackageDetails from '$lib/components/package-details-card.svelte';
 	import Spinner from '$lib/components/spinner.svelte';
-	import { Button, ButtonIcon, Typography } from '@ui';
+	import { Button, Typography } from '@ui';
 	import Icon from '$lib/components/icon.svelte';
 </script>
 


### PR DESCRIPTION
## Description
Update Props in references to UI components specifically change from className and wrapperClass to instead use class. Update imports and removed unused import.

## Related Issue
#986 

## Type of change
- [x] dependency update to prevent breaking changes. 

