### PR TITLE
Fix typo on header for core concepts doc

### DIFF
--- a/docs/2-core-concepts.md
+++ b/docs/2-core-concepts.md
@@ -2,7 +2,7 @@
 
 Now, assuming you're familiar with Kubernetes, the AirGap, and GitOps from [Understanding the Basics](./1-understand-the-basics.md), we can get started on the core concepts of Zarf.
 
-##Zarf Concepts
+## Zarf Concepts
 
 - [**Zarf Package**](./4-user-guide/2-zarf-packages/1-zarf-packages.md) - A binary file that contains the instructions and dependencies necessary to install an application on a system.
 - [**Zarf Component**](./4-user-guide/2-zarf-packages/2-zarf-components.md) - A set of defined functionality and resources that build up a package.


### PR DESCRIPTION
## Description

Fixes a missing space on the header (reference current docs page - https://docs.zarf.dev/docs/core-concepts ).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging

- [x] Documentation has been updated as necessary (add the `needs-docs` label)
