### PR TITLE
create cache dir during zarf init if it does not exist

### DIFF
--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -69,6 +69,12 @@ var initCmd = &cobra.Command{
 
 				// If the init-package doesn't exist in the cache directory, suggest downloading it
 				if utils.InvalidPath(config.DeployOptions.PackagePath) {
+					if utils.InvalidPath(config.GetAbsCachePath()) {
+						err = os.MkdirAll(config.GetAbsCachePath(), 0755)
+						if err != nil {
+							message.Fatalf(err, "Unable to create cache directory: %s", config.GetAbsCachePath())
+						}
+					}
 					if err := downloadInitPackage(initPackageName); err != nil {
 						message.Fatal(err, "Failed to download the init package")
 					}


### PR DESCRIPTION
## Description

Handles creation of `~/.zarf-cache` during `zarf init` if it does not exist.

## Related Issue

<!--- This project prefers to accept pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

Fixes #985 

## Type of change

<!-- Please delete options that are not relevant -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging

<!-- Please delete options that are not relevant -->

