### PR TITLE
Remove helm releaseName 'zarf-' prefix

### DIFF
--- a/examples/helm-alt-release-name/zarf.yaml
+++ b/examples/helm-alt-release-name/zarf.yaml
@@ -7,7 +7,7 @@ components:
     required: true
     charts:
       - name: podinfo
-        releaseName: cool-name
+        releaseName: zarf-cool-name
         url: https://stefanprodan.github.io/podinfo
         version: 6.1.6
         namespace: helm-releasename

--- a/examples/helm-alt-release-name/zarf.yaml
+++ b/examples/helm-alt-release-name/zarf.yaml
@@ -7,7 +7,7 @@ components:
     required: true
     charts:
       - name: podinfo
-        releaseName: zarf-cool-name
+        releaseName: cool-name
         url: https://stefanprodan.github.io/podinfo
         version: 6.1.6
         namespace: helm-releasename

--- a/packages/gitea/zarf.yaml
+++ b/packages/gitea/zarf.yaml
@@ -14,6 +14,7 @@ components:
           - connect.yaml
     charts:
       - name: gitea
+        releaseName: zarf-gitea
         url: https://dl.gitea.io/charts
         version: 6.0.3
         namespace: zarf

--- a/packages/logging-pgl/zarf.yaml
+++ b/packages/logging-pgl/zarf.yaml
@@ -17,6 +17,7 @@ components:
           - connect.yaml
     charts:
       - name: loki-stack
+        releaseName: zarf-loki-stack
         url: https://grafana.github.io/helm-charts
         version: 2.8.2
         namespace: zarf

--- a/src/internal/helm/chart.go
+++ b/src/internal/helm/chart.go
@@ -48,6 +48,7 @@ func InstallOrUpgradeChart(options ChartOptions) (types.ConnectStrings, string) 
 	} else {
 		options.ReleaseName = options.Chart.Name
 	}
+
 	installedChartName = options.ReleaseName
 
 	// Do not wait for the chart to be ready if data injections are present

--- a/src/internal/helm/chart.go
+++ b/src/internal/helm/chart.go
@@ -48,7 +48,6 @@ func InstallOrUpgradeChart(options ChartOptions) (types.ConnectStrings, string) 
 	} else {
 		options.ReleaseName = options.Chart.Name
 	}
-
 	installedChartName = options.ReleaseName
 
 	// Do not wait for the chart to be ready if data injections are present

--- a/src/internal/helm/chart.go
+++ b/src/internal/helm/chart.go
@@ -43,9 +43,10 @@ func InstallOrUpgradeChart(options ChartOptions) (types.ConnectStrings, string) 
 
 	var output *release.Release
 
-	options.ReleaseName = fmt.Sprintf("zarf-%s", options.Chart.Name)
 	if options.Chart.ReleaseName != "" {
-		options.ReleaseName = fmt.Sprintf("zarf-%s", options.Chart.ReleaseName)
+		options.ReleaseName = options.Chart.ReleaseName
+	} else {
+		options.ReleaseName = options.Chart.Name
 	}
 	installedChartName = options.ReleaseName
 
@@ -142,9 +143,9 @@ func TemplateChart(options ChartOptions) (string, error) {
 	client.IncludeCRDs = true
 
 	if options.Chart.ReleaseName != "" {
-		client.ReleaseName = fmt.Sprintf("zarf-%s", options.Chart.ReleaseName)
+		client.ReleaseName = options.Chart.ReleaseName
 	} else {
-		client.ReleaseName = fmt.Sprintf("zarf-%s", options.Chart.Name)
+		client.ReleaseName = options.Chart.Name
 	}
 
 	// Namespace must be specified

--- a/src/test/e2e/25_helm_test.go
+++ b/src/test/e2e/25_helm_test.go
@@ -22,7 +22,7 @@ func TestHelm(t *testing.T) {
 
 	// Verify multiple helm installs of different release names were deployed
 	kubectlOut, _ := exec.Command("kubectl", "get", "pods", "-n=helm-releasename", "--no-headers").Output()
-	assert.Contains(t, string(kubectlOut), "zarf-cool-name-podinfo")
+	assert.Contains(t, string(kubectlOut), "cool-name-podinfo")
 
 	stdOut, stdErr, err = e2e.execZarfCommand("package", "remove", "test-helm-releasename", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)


### PR DESCRIPTION
## Description

This PR removes the `zarf -` prefix that is added to the chart's releaseName (or chart name if the releaseName is not present). 

The side effects of the prefix include inconsistent deployed resource names, especially when sub-charts are used, as illustrated in the related issue.

## Related Issue

Fixes #1020 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging

<!-- Please delete options that are not relevant -->

- [x] Tests have been added/updated as necessary (add the `needs-tests` label)