### PR TITLE
create cache dir during zarf init if it does not exist

### DIFF
--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -74,6 +74,13 @@ func findInitPackage(initPackageName string) (string, error) {
 		return filepath.Join(executableDir, initPackageName), nil
 	}
 
+	// Create the cache directory if it doesn't exist
+	if utils.InvalidPath(config.GetAbsCachePath()) {
+		if err := os.MkdirAll(config.GetAbsCachePath(), 0755); err != nil {
+			message.Fatalf(err, "Unable to create cache directory: %s", config.GetAbsCachePath())
+		}
+	}
+
 	// Next, look in the cache directory
 	if !utils.InvalidPath(filepath.Join(config.GetAbsCachePath(), initPackageName)) {
 		return filepath.Join(config.GetAbsCachePath(), initPackageName), nil


### PR DESCRIPTION
Carry over from #1027 , w/ updates from MZAL.  Did not feel like fixing merge conflicts.

Fixes #985 

Handles creation of `~/.zarf-cache` during `zarf init` if it does not exist.
