### PR TITLE
Remove test now covered by zarf init usage of config file

### DIFF
--- a/src/test/e2e/30_config_file_test.go
+++ b/src/test/e2e/30_config_file_test.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,23 +25,19 @@ func TestConfigFile(t *testing.T) {
 		config = "zarf-config.toml"
 	)
 
-	e2e.cleanFiles(path, config)
+	e2e.cleanFiles(path)
 
 	// Test the config file environment variable
 	os.Setenv("ZARF_CONFIG", filepath.Join(dir, config))
 	configFileTests(t, dir, path)
 	os.Unsetenv("ZARF_CONFIG")
 
-	// Test the config file auto-discovery
-	utils.CreatePathAndCopy(filepath.Join(dir, config), config)
-	configFileTests(t, dir, path)
-
 	configFileDefaultTests(t)
 
 	stdOut, stdErr, err := e2e.execZarfCommand("package", "remove", path, "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 
-	e2e.cleanFiles(path, config)
+	e2e.cleanFiles(path)
 }
 
 func configFileTests(t *testing.T, dir, path string) {


### PR DESCRIPTION
Removes a test that was previously needed to make sure a package in a default path was read. Now that #1039 is merged, we have this covered on init package create / deploy + it was was trampling over that file during this test.