### PR TITLE
Publish versioned homebrew releases without a 'v' in the VersionName

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -69,7 +69,10 @@ brews:
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     homepage: "https://zarf.dev/"
     description: "DevSecOps for Air Gap"
-  - name: "zarf@{{ .Tag }}"
+
+  # NOTE: We are using .Version instead of .Tag because homebrew has weird semver parsing rules and won't be able to
+  #       install versioned releases that has a `v` character before the version number.
+  - name: "zarf@{{ .Version }}"
     tap:
       owner: defenseunicorns
       name: homebrew-tap


### PR DESCRIPTION
Brew does not understand how to install `zarf@v0.22.2.rb` but does understand how to install `zarf@0.22.2.rb` 