### PR TITLE
Update zarf.schema.json location URL

### DIFF
--- a/docs/4-user-guide/4-vscode.md
+++ b/docs/4-user-guide/4-vscode.md
@@ -15,7 +15,7 @@ The [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.
 
 ```json
   "yaml.schemas": {
-    "https://github.com/defenseunicorns/zarf/raw/main/zarf.schema.json": "zarf.yaml"
+    "https://raw.githubusercontent.com/defenseunicorns/zarf/main/zarf.schema.json": "zarf.yaml"
   }
 ```
 
@@ -26,7 +26,7 @@ In some cases, it may be beneficial to lock a `zarf.yaml`'s validation to a spec
 This can be accomplished by adding the below to the **first** line of any given `zarf.yaml`.
 
 ```yaml
-# yaml-language-server: $schema=https://github.com/defenseunicorns/zarf/raw/<VERSION>/zarf.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/zarf/<VERSION>/zarf.schema.json
 ```
 
 Where `<VERSION>` is one of [Zarf's releases](https://github.com/defenseunicorns/zarf/releases).


### PR DESCRIPTION
The zarf.schema.json URL is incorrect on this page; it is now found in raw.githubsercontent.com

