### PR TITLE
Remove all spinner.Debugf messages

### DIFF
--- a/src/internal/cluster/tunnel.go
+++ b/src/internal/cluster/tunnel.go
@@ -356,7 +356,7 @@ func (tunnel *Tunnel) establish() (string, error) {
 		defer spinner.Stop()
 	}
 
-	kube, err := k8s.NewWithWait(spinner.Debugf, labels, defaultTimeout)
+	kube, err := k8s.NewWithWait(message.Debugf, labels, defaultTimeout)
 	if err != nil {
 		return "", fmt.Errorf("unable to connect to the cluster: %w", err)
 	}
@@ -366,7 +366,7 @@ func (tunnel *Tunnel) establish() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to find pod attached to given resource: %w", err)
 	}
-	spinner.Debugf("Selected pod %s to open port forward to", podName)
+	message.Debugf("Selected pod %s to open port forward to", podName)
 
 	// Build url to the port forward endpoint
 	// example: http://localhost:8080/api/v1/namespaces/helm/pods/tiller-deploy-9itlq/portforward
@@ -379,7 +379,7 @@ func (tunnel *Tunnel) establish() (string, error) {
 		SubResource("portforward").
 		URL()
 
-	spinner.Debugf("Using URL %s to create portforward", portForwardCreateURL)
+	message.Debugf("Using URL %s to create portforward", portForwardCreateURL)
 
 	// Construct the spdy client required by the client-go portforward library
 	transport, upgrader, err := spdy.RoundTripperFor(kube.RestConfig)

--- a/src/internal/packager/git/clone.go
+++ b/src/internal/packager/git/clone.go
@@ -44,7 +44,7 @@ func (g *Git) clone(gitDirectory string, gitURL string, onlyFetchRef bool) (*git
 
 		return repo, git.ErrRepositoryAlreadyExists
 	} else if err != nil {
-		g.Spinner.Debugf("Failed to clone repo: %s", err)
+		message.Debugf("Failed to clone repo: %s", err.Error())
 		message.Infof("Falling back to host git for %s", gitURL)
 
 		// If we can't clone with go-git, fallback to the host clone
@@ -57,7 +57,7 @@ func (g *Git) clone(gitDirectory string, gitURL string, onlyFetchRef bool) (*git
 
 		stdOut, stdErr, err := utils.ExecCommandWithContext(context.TODO(), false, "git", cmdArgs...)
 		g.Spinner.Updatef(stdOut)
-		g.Spinner.Debugf(stdErr)
+		message.Debug(stdErr)
 
 		if err != nil {
 			return nil, err

--- a/src/internal/packager/git/pull.go
+++ b/src/internal/packager/git/pull.go
@@ -66,13 +66,13 @@ func (g *Git) pull(gitURL, targetFolder string, repoName string) {
 	repo, err := g.clone(gitCachePath, gitURLNoRef, onlyFetchRef)
 
 	if err == git.ErrRepositoryAlreadyExists {
-		g.Spinner.Debugf("Repo already cloned, fetching upstream changes...")
+		message.Debug("Repo already cloned, fetching upstream changes...")
 
 		g.GitPath = gitCachePath
 		err = g.fetch()
 
 		if errors.Is(err, git.NoErrAlreadyUpToDate) {
-			g.Spinner.Debugf("Repo already up to date")
+			message.Debug("Repo already up to date")
 		} else if err != nil {
 			g.Spinner.Fatalf(err, "Not a valid git repo or unable to fetch")
 		}

--- a/src/internal/packager/git/push.go
+++ b/src/internal/packager/git/push.go
@@ -145,7 +145,7 @@ func (g *Git) push(repo *git.Repository, spinner *message.Spinner) error {
 	})
 
 	if errors.Is(err, git.NoErrAlreadyUpToDate) {
-		spinner.Debugf("Repo already up-to-date")
+		message.Debug("Repo already up-to-date")
 	} else if err != nil {
 		return fmt.Errorf("unable to push repo to the gitops service: %w", err)
 	}

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -105,7 +105,7 @@ func (h *Helm) InstallOrUpgradeChart() (types.ConnectStrings, string, error) {
 			// Simply wait for dust to settle and try again
 			time.Sleep(10 * time.Second)
 		} else {
-			spinner.Debugf(output.Info.Description)
+			message.Debug(output.Info.Description)
 			spinner.Success()
 			break
 		}

--- a/src/pkg/message/spinner.go
+++ b/src/pkg/message/spinner.go
@@ -65,18 +65,6 @@ func (p *Spinner) Updatef(format string, a ...any) {
 	p.spinner.UpdateText(text)
 }
 
-// Debugf prints a debug message.
-func (p *Spinner) Debugf(format string, a ...any) {
-	if logLevel >= DebugLevel {
-		text := fmt.Sprintf("Debug: "+format, a)
-		if NoProgress {
-			Debug(text)
-		} else {
-			p.spinner.UpdateText(text)
-		}
-	}
-}
-
 // Stop the spinner.
 func (p *Spinner) Stop() {
 	if p.spinner != nil && p.spinner.IsActive {

--- a/src/pkg/utils/sget.go
+++ b/src/pkg/utils/sget.go
@@ -112,11 +112,11 @@ func Sget(ctx context.Context, image, key string, out io.Writer) error {
 
 	for _, sig := range sp {
 		if cert, err := sig.Cert(); err == nil && cert != nil {
-			spinner.Debugf("Certificate subject: ", sigs.CertSubject(cert))
+			message.Debugf("Certificate subject: %s", sigs.CertSubject(cert))
 
 			ce := cosign.CertExtensions{Cert: cert}
 			if issuerURL := ce.GetIssuer(); issuerURL != "" {
-				spinner.Debugf("Certificate issuer URL: ", issuerURL)
+				message.Debugf("Certificate issuer URL: %s", issuerURL)
 			}
 		}
 
@@ -125,7 +125,7 @@ func Sget(ctx context.Context, image, key string, out io.Writer) error {
 			spinner.Errorf(err, "Error getting payload")
 			return err
 		}
-		spinner.Debugf(string(p))
+		message.Debug(string(p))
 	}
 
 	// TODO(mattmoor): Depending on what this is, use the higher-level stuff.


### PR DESCRIPTION
## Description

This is a hotfix to remove spinner.Debugf messages from Zarf.  This was a little used feature, but it would often result in missing logs for the places that did use it and had a conflicting purpose already with message.Debugf.

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

