### PR TITLE
1087 prepare find images doesnt work on local helm chart paths

### DIFF
--- a/src/pkg/packager/prepare.go
+++ b/src/pkg/packager/prepare.go
@@ -116,8 +116,10 @@ func (p *Packager) FindImages(baseDir, repoHelmChartPath string) error {
 					path := helmCfg.DownloadChartFromGit(componentPath.Charts)
 					// track the actual chart path
 					chartNames[chart.Name] = path
-				} else {
+				} else if chart.Url != "" {
 					helmCfg.DownloadPublishedChart(componentPath.Charts)
+				} else {
+					helmCfg.CreateChartFromLocalFiles(componentPath.Charts)
 				}
 
 				for idx, path := range chart.ValuesFiles {

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -55,6 +55,16 @@ func TestUseCLI(t *testing.T) {
 	assert.NotEqual(t, len(stdOut), 0, "Zarf version should not be an empty string")
 	assert.NotEqual(t, stdOut, "UnknownVersion", "Zarf version should not be the default value")
 
+	// Test `zarf prepare find-images` for a remote asset
+	stdOut, stdErr, err = e2e.execZarfCommand("prepare", "find-images", "examples/helm-alt-release-name")
+	assert.NoError(t, err, stdOut, stdErr)
+	assert.Contains(t, stdOut, "ghcr.io/stefanprodan/podinfo:6.1.6", "The chart image should be found by Zarf")
+
+	// Test `zarf prepare find-images` for a local asset
+	stdOut, stdErr, err = e2e.execZarfCommand("prepare", "find-images", "examples/helm-local-chart")
+	assert.NoError(t, err, stdOut, stdErr)
+	assert.Contains(t, stdOut, "nginx:1.16.0", "The chart image should be found by Zarf")
+
 	// Test for expected failure when given a bad component input
 	_, _, err = e2e.execZarfCommand("init", "--confirm", "--components=k3s,foo,logging")
 	assert.Error(t, err)


### PR DESCRIPTION
## Description

Fixes an issue where Zarf could not look at images from local paths.

## Related Issue

Fixes #1087

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging

- [X] Tests have been added/updated as necessary (add the `needs-tests` label)
