### PR TITLE
Variabalize Git Server configs

### DIFF
--- a/packages/gitea/gitea-values.yaml
+++ b/packages/gitea/gitea-values.yaml
@@ -1,5 +1,8 @@
 persistence:
   storageClass: "###ZARF_STORAGE_CLASS###"
+  existingClaim: "###ZARF_VAR_GIT_SERVER_EXISTING_PVC###"
+  size: "###ZARF_VAR_GIT_SERVER_PVC_SIZE###"
+
 gitea:
   admin:
     username: "###ZARF_GIT_PUSH###"
@@ -24,11 +27,11 @@ gitea:
       FORCE_PRIVATE: true
 resources:
   requests:
-    cpu: "200m"
-    memory: "512Mi"
+    cpu: "###ZARF_VAR_GIT_SERVER_CPU_REQ###"
+    memory: "###ZARF_VAR_GIT_SERVER_MEM_REQ###"
   limits:
-    cpu: "1"
-    memory: "2Gi"
+    cpu: "###ZARF_VAR_GIT_SERVER_CPU_LIMIT###"
+    memory: "###ZARF_VAR_GIT_SERVER_MEM_LIMIT###"
 
 memcached:
   enabled: false

--- a/packages/gitea/zarf.yaml
+++ b/packages/gitea/zarf.yaml
@@ -2,6 +2,31 @@ kind: ZarfPackageConfig
 metadata:
   name: "init-package-git-server"
 
+variables:
+  - name: GIT_SERVER_EXISTING_PVC
+    description: "Optional: Use an existing PVC for the git server instead of creating a new one. If this is set, the GIT_SERVER_PVC_SIZE variable will be ignored."
+    default: ""
+
+  - name: GIT_SERVER_PVC_SIZE
+    description: "The size of the persistent volume claim for git server"
+    default: "10Gi"
+
+  - name: GIT_SERVER_CPU_REQ
+    description: "The CPU request for git server"
+    default: "200m"
+
+  - name: GIT_SERVER_MEM_REQ
+    description: "The memory request for git server"
+    default: "512Mi"
+
+  - name: GIT_SERVER_CPU_LIMIT
+    description: "The CPU limit for git server"
+    default: "3"
+
+  - name: GIT_SERVER_MEM_LIMIT
+    description: "The memory limit for git server"
+    default: "2Gi"
+
 components:
   - name: git-server
     description: "Add Gitea for serving gitops-based clusters in an airgap"


### PR DESCRIPTION
This PR exposes variables for the Git Server in the init package to match the Zarf Registry:

- GIT_SERVER_EXISTING_PVC
- GIT_SERVER_PVC_SIZE
- GIT_SERVER_CPU_REQ
- GIT_SERVER_MEM_REQ
- GIT_SERVER_CPU_LIMIT
- GIT_SERVER_MEM_LIMIT

Fixes #1122 
Related to #1123 