### PR TITLE
Cleanup UI imports

### DIFF
--- a/src/ui/lib/components/index.ts
+++ b/src/ui/lib/components/index.ts
@@ -1,0 +1,27 @@
+import AccordionGroup from './accordion-group.svelte';
+import Container from './container.svelte';
+import Divider from './divider.svelte';
+import Header from './header.svelte';
+import Hero from './hero.svelte';
+import Icon from './icon.svelte';
+import Modal from './modal.svelte';
+import PackageComponentAccordion from './package-component-accordion.svelte';
+import PackageDetailsCard from './package-details-card.svelte';
+import Spinner from './spinner.svelte';
+import ThemeToggle from './theme-toggle.svelte';
+import YamlCode from './yaml-code.svelte';
+
+export {
+	AccordionGroup,
+	Container,
+	Divider,
+	Header,
+	Hero,
+	Icon,
+	Modal,
+	PackageComponentAccordion,
+	PackageDetailsCard,
+	Spinner,
+	ThemeToggle,
+	YamlCode
+};

--- a/src/ui/lib/components/index.ts
+++ b/src/ui/lib/components/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
 import AccordionGroup from './accordion-group.svelte';
 import Container from './container.svelte';
 import Divider from './divider.svelte';

--- a/src/ui/routes/+layout.svelte
+++ b/src/ui/routes/+layout.svelte
@@ -8,7 +8,7 @@
 	import '@fontsource/roboto';
 	import { Cluster } from '$lib/api';
 	import { clusterStore } from '$lib/store';
-	import Header from '$lib/components/header.svelte';
+	import { Header } from '$lib/components';
 	import 'material-symbols/';
 	import { Theme } from '@ui';
 	import { ZarfPalettes } from '$lib/palette';

--- a/src/ui/routes/+page.svelte
+++ b/src/ui/routes/+page.svelte
@@ -6,8 +6,7 @@
 	import { goto } from '$app/navigation';
 	import { Button, Typography } from '@ui';
 	import { clusterStore } from '$lib/store';
-	import Hero from '$lib/components/hero.svelte';
-	import Spinner from '$lib/components/spinner.svelte';
+	import { Hero, Spinner } from '$lib/components';
 	import bigZarf from '@images/zarf-bubbles-right.png';
 </script>
 

--- a/src/ui/routes/auth/+page.svelte
+++ b/src/ui/routes/auth/+page.svelte
@@ -6,7 +6,7 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { Auth } from '$lib/api';
-	import Hero from '$lib/components/hero.svelte';
+	import { Hero } from '$lib/components';
 	import sadDay from '@images/sadness.png';
 
 	let authFailure = false;

--- a/src/ui/routes/initialize/configure/+page.svelte
+++ b/src/ui/routes/initialize/configure/+page.svelte
@@ -3,11 +3,12 @@
 // SPDX-FileCopyrightText: 2021-Present The Zarf Authors
  -->
 <script lang="ts">
-	import AccordionGroup from '../../../lib/components/accordion-group.svelte';
-
-	import Icon from '$lib/components/icon.svelte';
-	import PackageDetails from '$lib/components/package-details-card.svelte';
-	import PackageComponent from '$lib/components/package-component-accordion.svelte';
+	import {
+		AccordionGroup,
+		Icon,
+		PackageDetailsCard as PackageDetails,
+		PackageComponentAccordion as PackageComponent
+	} from '$lib/components';
 	import { pkgStore } from '$lib/store';
 	import { Button, Typography } from '@ui';
 </script>

--- a/src/ui/routes/initialize/finished/+page.svelte
+++ b/src/ui/routes/initialize/finished/+page.svelte
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: 2021-Present The Zarf Authors
  -->
 <script lang="ts">
-	import Modal from '$lib/components/modal.svelte';
+	import { Modal } from '$lib/components';
 	import zarfLogo from '@images/zarf-bubbles-right.png';
 </script>
 

--- a/src/ui/routes/initialize/review/+page.svelte
+++ b/src/ui/routes/initialize/review/+page.svelte
@@ -3,10 +3,12 @@
 // SPDX-FileCopyrightText: 2021-Present The Zarf Authors
  -->
 <script lang="ts">
-	import Icon from '$lib/components/icon.svelte';
-	import PackageDetails from '$lib/components/package-details-card.svelte';
-	import PackageComponent from '$lib/components/package-component-accordion.svelte';
-	import AccordionGroup from '$lib/components/accordion-group.svelte';
+	import {
+		Icon,
+		PackageDetailsCard as PackageDetails,
+		PackageComponentAccordion as PackageComponent,
+		AccordionGroup
+	} from '$lib/components';
 
 	import { pkgComponentDeployStore, pkgStore } from '$lib/store';
 	import { Button, Typography } from '@ui';

--- a/src/ui/routes/packages/+page.svelte
+++ b/src/ui/routes/packages/+page.svelte
@@ -4,11 +4,8 @@
  -->
 <script>
 	import { Packages } from '$lib/api';
-	import Hero from '$lib/components/hero.svelte';
-	import PackageDetails from '$lib/components/package-details-card.svelte';
-	import Spinner from '$lib/components/spinner.svelte';
+	import { Hero, PackageDetailsCard as PackageDetails, Spinner, Icon } from '$lib/components';
 	import { Button, Typography } from '@ui';
-	import Icon from '$lib/components/icon.svelte';
 </script>
 
 {#await Packages.getDeployedPackages()}


### PR DESCRIPTION
## Description

Cleans up Svelte imports of internal (from `$lib/components`). I find this to be easier to read, and can take up fewer space.
