### PR TITLE
Made show all namespace default for k9 dash

### DIFF
--- a/src/cmd/tools.go
+++ b/src/cmd/tools.go
@@ -94,7 +94,7 @@ var k9sCmd = &cobra.Command{
 	Short:   lang.CmdToolsMonitorShort,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Hack to make k9s think it's all alone
-		os.Args = []string{os.Args[0], "-n", "zarf"}
+		os.Args = []string{os.Args[0]}
 		k9s.Execute()
 	},
 }


### PR DESCRIPTION
## Description

This issue makes show all namespace the default for the K9 dash. It was made based on user insights and a few user errors that led to users believing their pods were note deployed due to not using the zarf namespace. 

This may also be important for packages that use the big-bang namespace or that deploy other resources that use a namespace other than Zarf

## Related Issue

Fixes #1195 1195 (issue)

## Type of change

<!-- Please delete options that are not relevant -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist before merging

- [x] Documentation has been updated as necessary (add the `needs-docs` label)
