### PR TITLE
Consolidate components flag

### DIFF
--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -77,7 +77,7 @@ func findInitPackage(initPackageName string) (string, error) {
 	// Create the cache directory if it doesn't exist
 	if utils.InvalidPath(config.GetAbsCachePath()) {
 		if err := os.MkdirAll(config.GetAbsCachePath(), 0755); err != nil {
-			message.Fatalf(err, "Unable to create cache directory: %s", config.GetAbsCachePath())
+			message.Fatalf(err, lang.CmdInitErrUnableCreateCache, config.GetAbsCachePath())
 		}
 	}
 
@@ -175,11 +175,11 @@ func init() {
 	v.SetDefault(V_INIT_REGISTRY_PULL_PASS, "")
 
 	// Init package set variable flags
-	initCmd.Flags().StringToStringVar(&pkgConfig.DeployOpts.SetVariables, "set", v.GetStringMapString(V_PKG_DEPLOY_SET), "Specify deployment variables to set on the command line (KEY=value)")
+	initCmd.Flags().StringToStringVar(&pkgConfig.DeployOpts.SetVariables, "set", v.GetStringMapString(V_PKG_DEPLOY_SET), lang.CmdInitFlagSet)
 
 	// Continue to require --confirm flag for init command to avoid accidental deployments
 	initCmd.Flags().BoolVar(&config.CommonOptions.Confirm, "confirm", false, lang.CmdInitFlagConfirm)
-	initCmd.Flags().StringVar(&pkgConfig.InitOpts.Components, "components", v.GetString(V_INIT_COMPONENTS), lang.CmdInitFlagComponents)
+	initCmd.Flags().StringVar(&pkgConfig.DeployOpts.Components, "components", v.GetString(V_INIT_COMPONENTS), lang.CmdInitFlagComponents)
 	initCmd.Flags().StringVar(&pkgConfig.InitOpts.StorageClass, "storage-class", v.GetString(V_INIT_STORAGE_CLASS), lang.CmdInitFlagStorageClass)
 
 	// Flags for using an external Git server

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -107,16 +107,19 @@ const (
 		"# Initializing w/ an external registry:\nzarf init --registry-push-password={PASSWORD} --registry-push-username={USERNAME} --registry-url={URL}\n\n" +
 		"# Initializing w/ an external git server:\nzarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-url={URL}\n\n"
 
-	CmdInitErrFlags            = "Invalid command flags were provided."
-	CmdInitErrDownload         = "failed to download the init package: %s"
-	CmdInitErrValidateGit      = "the 'git-push-username' and 'git-push-password' flags must be provided if the 'git-url' flag is provided"
-	CmdInitErrValidateRegistry = "the 'registry-push-username' and 'registry-push-password' flags must be provided if the 'registry-url' flag is provided "
+	CmdInitErrFlags             = "Invalid command flags were provided."
+	CmdInitErrDownload          = "failed to download the init package: %s"
+	CmdInitErrValidateGit       = "the 'git-push-username' and 'git-push-password' flags must be provided if the 'git-url' flag is provided"
+	CmdInitErrValidateRegistry  = "the 'registry-push-username' and 'registry-push-password' flags must be provided if the 'registry-url' flag is provided "
+	CmdInitErrUnableCreateCache = "Unable to create the cache directory: %s"
 
 	CmdInitDownloadAsk       = "It seems the init package could not be found locally, but can be downloaded from %s"
 	CmdInitDownloadNote      = "Note: This will require an internet connection."
 	CmdInitDownloadConfirm   = "Do you want to download this init package?"
 	CmdInitDownloadCancel    = "Confirm selection canceled: %s"
 	CmdInitDownloadErrManual = "download the init package manually and place it in the current working directory"
+
+	CmdInitFlagSet = "Specify deployment variables to set on the command line (KEY=value)"
 
 	CmdInitFlagConfirm      = "Confirm the install without prompting"
 	CmdInitFlagComponents   = "Specify which optional components to install.  E.g. --components=git-server,logging"

--- a/src/pkg/packager/components.go
+++ b/src/pkg/packager/components.go
@@ -32,11 +32,6 @@ func (p *Packager) getValidComponents() []types.ZarfComponent {
 	// The component list is comma-delimited list
 	requestedNames := getRequestedComponentList(p.cfg.DeployOpts.Components)
 
-	// Init packages use a different component list
-	if p.cfg.IsInitConfig {
-		requestedNames = getRequestedComponentList(p.cfg.InitOpts.Components)
-	}
-
 	// Break up components into choice groups
 	for _, component := range p.cfg.Pkg.Components {
 		key := component.Group

--- a/src/types/runtime.go
+++ b/src/types/runtime.go
@@ -31,8 +31,6 @@ type ZarfInitOptions struct {
 
 	RegistryInfo RegistryInfo `json:"registryInfo" jsonschema:"description=Information about the registry Zarf is going to be using"`
 
-	Components string `json:"components" jsonschema:"description=Comma separated list of optional components to deploy"`
-
 	StorageClass string `json:"storageClass" jsonschema:"description=StorageClass of the k8s cluster Zarf is initializing"`
 }
 

--- a/src/ui/lib/api-types.ts
+++ b/src/ui/lib/api-types.ts
@@ -653,10 +653,6 @@ export interface ZarfInitOptions {
      */
     applianceMode: boolean;
     /**
-     * Comma separated list of optional components to deploy
-     */
-    components: string;
-    /**
      * Information about the repository Zarf is going to be using
      */
     gitServer: GitServerInfo;
@@ -1043,7 +1039,6 @@ const typeMap: any = {
     ], false),
     "ZarfInitOptions": o([
         { json: "applianceMode", js: "applianceMode", typ: true },
-        { json: "components", js: "components", typ: "" },
         { json: "gitServer", js: "gitServer", typ: r("GitServerInfo") },
         { json: "registryInfo", js: "registryInfo", typ: r("RegistryInfo") },
         { json: "storageClass", js: "storageClass", typ: "" },


### PR DESCRIPTION
## Description

This consolidates the components flag (following the pattern from set) so that you can Zarf Package Deploy and init package again.

## Related Issue

Fixes #1182 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging

- [ ] Tests have been added/updated as necessary (add the `needs-tests` label)
- [ ] Documentation has been updated as necessary (add the `needs-docs` label)
- [ ] An ADR has been written as necessary (add the `needs-adr` label) [ [1](https://github.com/joelparkerhenderson/architecture-decision-record) [2](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) [3](https://adr.github.io/) ]
