### PR TITLE
Use TransformURL over MutateGitURLsInText for the agent

### DIFF
--- a/src/internal/agent/hooks/flux.go
+++ b/src/internal/agent/hooks/flux.go
@@ -81,7 +81,10 @@ func mutateGitRepo(r *v1.AdmissionRequest) (result *operations.Result, err error
 	// Mutate the git URL if necessary
 	if isCreate || (isUpdate && !isPatched) {
 		// Mutate the git URL so that the hostname matches the hostname in the Zarf state
-		patchedURL = git.New(state.GitServer).MutateGitURLsInText(patchedURL)
+		patchedURL, err = git.New(state.GitServer).TransformURL(patchedURL)
+		if err != nil {
+			message.Warnf("Unable to transform the git url, using the original url we have: %s", patchedURL)
+		}
 		message.Debugf("original git URL of (%s) got mutated to (%s)", src.Spec.URL, patchedURL)
 	}
 

--- a/src/internal/packager/git/push.go
+++ b/src/internal/packager/git/push.go
@@ -76,7 +76,7 @@ func (g *Git) prepRepoForPush() (*git.Repository, error) {
 	}
 
 	remoteURL := remote.Config().URLs[0]
-	targetURL, err := g.transformURL(remoteURL)
+	targetURL, err := g.TransformURL(remoteURL)
 	if err != nil {
 		return nil, fmt.Errorf("unable to transform the git url: %w", err)
 	}

--- a/src/internal/packager/git/url.go
+++ b/src/internal/packager/git/url.go
@@ -19,10 +19,9 @@ var gitURLRegex = regexp.MustCompile(`^(?P<proto>[a-z]+:\/\/)(?P<hostPath>.+?)\/
 func (g *Git) MutateGitURLsInText(text string) string {
 	extractPathRegex := regexp.MustCompilePOSIX(`https?://[^/]+/(.*\.git)`)
 	output := extractPathRegex.ReplaceAllStringFunc(text, func(match string) string {
-		output, err := g.transformURL(match)
+		output, err := g.TransformURL(match)
 		if err != nil {
 			message.Warnf("Unable to transform the git url, using the original url we have: %s", match)
-			output = match
 		}
 		return output
 	})
@@ -52,10 +51,11 @@ func (g *Git) TransformURLtoRepoName(url string) (string, error) {
 	return newRepoName, nil
 }
 
-func (g *Git) transformURL(url string) (string, error) {
+// TransformURL takes a git url and returns a Zarf-compatible url.
+func (g *Git) TransformURL(url string) (string, error) {
 	repoName, err := g.TransformURLtoRepoName(url)
 	if err != nil {
-		return "", err
+		return url, err
 	}
 	output := fmt.Sprintf("%s/%s/%s", g.Server.Address, g.Server.PushUsername, repoName)
 	message.Debugf("Rewrite git URL: %s -> %s", url, output)


### PR DESCRIPTION
## Description

This removes the requirement for a git url to end in .git

## Related Issue

Fixes #482

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging

- [ ] Tests have been added/updated as necessary (add the `needs-tests` label)
- [ ] Documentation has been updated as necessary (add the `needs-docs` label)
- [ ] An ADR has been written as necessary (add the `needs-adr` label) [ [1](https://github.com/joelparkerhenderson/architecture-decision-record) [2](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) [3](https://adr.github.io/) ]
