### PR TITLE
Make viper keys uppercase

### DIFF
--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/defenseunicorns/zarf/src/config"
@@ -46,7 +47,9 @@ var initCmd = &cobra.Command{
 			message.Fatal(err, err.Error())
 		}
 
-		pkgConfig.DeployOpts.SetVariables = utils.MergeMap(v.GetStringMapString(V_PKG_DEPLOY_SET), pkgConfig.DeployOpts.SetVariables)
+		// Ensure uppercase keys from viper
+		viperConfig := utils.TransformMapKeys(v.GetStringMapString(V_PKG_DEPLOY_SET), strings.ToUpper)
+		pkgConfig.DeployOpts.SetVariables = utils.MergeMap(viperConfig, pkgConfig.DeployOpts.SetVariables)
 
 		// Configure the packager
 		pkgClient := packager.NewOrDie(&pkgConfig)

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/types"
@@ -57,7 +58,9 @@ var packageCreateCmd = &cobra.Command{
 			config.CommonOptions.CachePath = config.ZarfDefaultCachePath
 		}
 
-		pkgConfig.CreateOpts.SetVariables = utils.MergeMap(v.GetStringMapString(V_PKG_CREATE_SET), pkgConfig.CreateOpts.SetVariables)
+		// Ensure uppercase keys from viper
+		viperConfig := utils.TransformMapKeys(v.GetStringMapString(V_PKG_CREATE_SET), strings.ToUpper)
+		pkgConfig.CreateOpts.SetVariables = utils.MergeMap(viperConfig, pkgConfig.CreateOpts.SetVariables)
 
 		// Configure the packager
 		pkgClient := packager.NewOrDie(&pkgConfig)
@@ -79,7 +82,9 @@ var packageDeployCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		pkgConfig.DeployOpts.PackagePath = choosePackage(args)
 
-		pkgConfig.DeployOpts.SetVariables = utils.MergeMap(v.GetStringMapString(V_PKG_DEPLOY_SET), pkgConfig.DeployOpts.SetVariables)
+		// Ensure uppercase keys from viper
+		viperConfig := utils.TransformMapKeys(v.GetStringMapString(V_PKG_DEPLOY_SET), strings.ToUpper)
+		pkgConfig.DeployOpts.SetVariables = utils.MergeMap(viperConfig, pkgConfig.DeployOpts.SetVariables)
 
 		// Configure the packager
 		pkgClient := packager.NewOrDie(&pkgConfig)

--- a/src/cmd/prepare.go
+++ b/src/cmd/prepare.go
@@ -8,6 +8,7 @@ import (
 	"crypto"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/defenseunicorns/zarf/src/config"
@@ -98,7 +99,9 @@ var prepareFindImages = &cobra.Command{
 			baseDir = args[0]
 		}
 
-		pkgConfig.CreateOpts.SetVariables = utils.MergeMap(v.GetStringMapString(V_PKG_CREATE_SET), pkgConfig.CreateOpts.SetVariables)
+		// Ensure uppercase keys from viper
+		viperConfig := utils.TransformMapKeys(v.GetStringMapString(V_PKG_CREATE_SET), strings.ToUpper)
+		pkgConfig.CreateOpts.SetVariables = utils.MergeMap(viperConfig, pkgConfig.CreateOpts.SetVariables)
 
 		// Configure the packager
 		pkgClient := packager.NewOrDie(&pkgConfig)

--- a/src/pkg/packager/variables.go
+++ b/src/pkg/packager/variables.go
@@ -15,12 +15,8 @@ import (
 
 // fillActiveTemplate handles setting the active variables and reloading the base template.
 func (p *Packager) fillActiveTemplate() error {
-	setVariableMap := map[string]string{}
-
-	for key, value := range p.cfg.CreateOpts.SetVariables {
-		// Ensure uppercase keys
-		setVariableMap[strings.ToUpper(key)] = value
-	}
+	// Ensure uppercase keys
+	setVariableMap := utils.TransformMapKeys(p.cfg.CreateOpts.SetVariables, strings.ToUpper)
 
 	packageVariables, err := utils.FindYamlTemplates(&p.cfg.Pkg, "###ZARF_PKG_VAR_", "###")
 	if err != nil {
@@ -57,10 +53,8 @@ func (p *Packager) fillActiveTemplate() error {
 
 // setActiveVariables handles setting the active variables used to template component files.
 func (p *Packager) setActiveVariables() error {
-	for key, value := range p.cfg.DeployOpts.SetVariables {
-		// Ensure uppercase keys
-		p.setVariable(strings.ToUpper(key), value)
-	}
+	// Ensure uppercase keys
+	p.cfg.SetVariableMap = utils.TransformMapKeys(p.cfg.DeployOpts.SetVariables, strings.ToUpper)
 
 	for _, variable := range p.cfg.Pkg.Variables {
 		_, present := p.cfg.SetVariableMap[variable.Name]

--- a/src/pkg/utils/misc.go
+++ b/src/pkg/utils/misc.go
@@ -96,3 +96,14 @@ func MergeMap[T any](m1 map[string]T, m2 map[string]T) (r map[string]T) {
 
 	return r
 }
+
+// TransformMapKeys takes a map and transforms its keys using the provided function
+func TransformMapKeys[T any](m map[string]T, transform func(string) string) (r map[string]T) {
+	r = map[string]T{}
+
+	for key, value := range m {
+		r[transform(key)] = value
+	}
+
+	return r
+}


### PR DESCRIPTION
## Description

Fixes an issue where keys were not being properly merged from --set and viper

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
