### PR TITLE
1324 images tar now expanded

### DIFF
--- a/examples/component-actions/.gitignore
+++ b/examples/component-actions/.gitignore
@@ -1,0 +1,2 @@
+test-create-after.txt
+test-create-before.txt

--- a/src/internal/packager/images/common.go
+++ b/src/internal/packager/images/common.go
@@ -4,7 +4,17 @@
 // Package images provides functions for building and pushing images.
 package images
 
-import "github.com/defenseunicorns/zarf/src/types"
+import (
+	"fmt"
+	"os"
+
+	"github.com/defenseunicorns/zarf/src/config"
+	"github.com/defenseunicorns/zarf/src/types"
+	"github.com/google/go-containerregistry/pkg/crane"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
 
 // ImgConfig is the main struct for managing container images.
 type ImgConfig struct {
@@ -17,4 +27,41 @@ type ImgConfig struct {
 	NoChecksum bool
 
 	Insecure bool
+}
+
+// GetLegacyImgTarballPath returns the ImagesPath as if it were a path to a tarball instead of a directory.
+func (i *ImgConfig) GetLegacyImgTarballPath() string {
+	return fmt.Sprintf("%s.tar", i.ImagesPath)
+}
+
+// LoadImageFromPackage returns a v1.Image from the image tag specified, or an error if the image cannot be found.
+func (i ImgConfig) LoadImageFromPackage(imgTag string) (v1.Image, error) {
+	var err error
+
+	if _, statErr := os.Stat(i.GetLegacyImgTarballPath()); statErr == nil {
+		// The package still has a images.tar that contains all of the images, use crane to load the specific tag we want
+		return crane.LoadTag(i.GetLegacyImgTarballPath(), imgTag, config.GetCraneOptions(i.Insecure)...)
+	} else {
+		// Use the manifest within the index.json to load the specific image we want
+		layoutPath := layout.Path(i.ImagesPath)
+		imgIdx, err := layoutPath.ImageIndex()
+		if err != nil {
+			return nil, err
+		}
+
+		idxManifest, err := imgIdx.IndexManifest()
+		if err != nil {
+			return nil, err
+		}
+
+		// Search through all the manifests within this package until we find the annotation that matches our tag
+		for _, manifest := range idxManifest.Manifests {
+			if manifest.Annotations[ocispec.AnnotationBaseImageName] == imgTag {
+				// This is the image we are looking for, load it and then return
+				return layoutPath.Image(manifest.Digest)
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("unable to find image %s in the package: %v", imgTag, err)
 }

--- a/src/internal/packager/images/common.go
+++ b/src/internal/packager/images/common.go
@@ -8,7 +8,7 @@ import "github.com/defenseunicorns/zarf/src/types"
 
 // ImgConfig is the main struct for managing container images.
 type ImgConfig struct {
-	TarballPath string
+	ImagesPath string
 
 	ImgList []string
 

--- a/src/internal/packager/images/pull.go
+++ b/src/internal/packager/images/pull.go
@@ -76,7 +76,7 @@ func (i *ImgConfig) PullAll() error {
 	)
 
 	go func() {
-		_ = tarball.MultiWriteToFile(i.TarballPath, tagToImage, tarball.WithProgress(progress))
+		_ = tarball.MultiWriteToFile(i.ImagesPath, tagToImage, tarball.WithProgress(progress))
 	}()
 
 	for update := range progress {

--- a/src/internal/packager/images/pull.go
+++ b/src/internal/packager/images/pull.go
@@ -6,9 +6,11 @@ package images
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -21,18 +23,19 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/cache"
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
-	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/moby/moby/client"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pterm/pterm"
 )
 
 // PullAll pulls all of the images in the provided tag map.
 func (i *ImgConfig) PullAll() error {
 	var (
-		longer     string
-		imgCount   = len(i.ImgList)
-		imageMap   = map[string]v1.Image{}
-		tagToImage = map[name.Tag]v1.Image{}
+		longer      string
+		imgCount    = len(i.ImgList)
+		imageMap    = map[string]v1.Image{}
+		tagToImage  = map[name.Tag]v1.Image{}
+		digestToTag = make(map[string]string)
 	)
 
 	// Give some additional user feedback on larger image sets
@@ -60,6 +63,12 @@ func (i *ImgConfig) PullAll() error {
 		imageMap[src] = img
 	}
 
+	// Create the ImagePath directory
+	err := os.Mkdir(i.ImagesPath, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create image path %s: %w", i.ImagesPath, err)
+	}
+
 	for src, img := range imageMap {
 		tag, err := name.NewTag(src, name.WeakValidation)
 		if err != nil {
@@ -69,38 +78,19 @@ func (i *ImgConfig) PullAll() error {
 	}
 	spinner.Updatef("Preparing image sources and cache for image pulling")
 
-	var (
-		progress    = make(chan v1.Update, 200)
-		progressBar *message.ProgressBar
-		title       string
-	)
-
-	go func() {
-		_ = tarball.MultiWriteToFile(i.ImagesPath, tagToImage, tarball.WithProgress(progress))
-	}()
-
-	for update := range progress {
-		switch {
-		case update.Error != nil && errors.Is(update.Error, io.EOF):
-			progressBar.Success("Pulling %d images (%s)", len(imageMap), utils.ByteFormat(float64(update.Total), 2))
-			return nil
-		case update.Error != nil && strings.HasPrefix(update.Error.Error(), "archive/tar: missed writing "):
-			// Handle potential image cache corruption with a more helpful error. See L#54 in libexec/src/archive/tar/writer.go
-			message.Warnf("Potential image cache corruption: %s of %v bytes - try clearing cache with \"zarf tools clear-cache\"", update.Error.Error(), update.Total)
-			return fmt.Errorf("failed to write image tarball: %w", update.Error)
-		case update.Error != nil:
-			return fmt.Errorf("failed to write image tarball: %w", update.Error)
-		default:
-			title = fmt.Sprintf("Pulling %d images (%s of %s)", len(imageMap),
-				utils.ByteFormat(float64(update.Complete), 2),
-				utils.ByteFormat(float64(update.Total), 2),
-			)
-			if progressBar == nil {
-				spinner.Success()
-				progressBar = message.NewProgressBar(update.Total, title)
-			}
-			progressBar.Update(update.Complete, title)
+	for tag, img := range tagToImage {
+		err := crane.SaveOCI(img, i.ImagesPath)
+		if err != nil {
+			fmt.Errorf("error when trying to save the img (%s): %w", tag.Name(), err)
 		}
+
+		// Get the image digest
+		imgDigest, _ := img.Digest()
+		digestToTag[imgDigest.String()] = tag.String()
+	}
+
+	if err := addImageNameAnnotation(i.ImagesPath, digestToTag); err != nil {
+		return fmt.Errorf("unable to format OCI layout: %w", err)
 	}
 
 	return nil
@@ -167,4 +157,60 @@ func (i *ImgConfig) PullImage(src string, spinner *message.Spinner) (img v1.Imag
 	img = cache.Image(img, cache.NewFilesystemCache(imageCachePath))
 
 	return img, nil
+}
+
+// IndexJSON represents the index.json file in an OCI layout.
+type IndexJSON struct {
+	SchemaVersion int `json:"schemaVersion"`
+	Manifests     []struct {
+		MediaType   string            `json:"mediaType"`
+		Size        int               `json:"size"`
+		Digest      string            `json:"digest"`
+		Annotations map[string]string `json:"annotations"`
+	} `json:"manifests"`
+}
+
+// addImageNameAnnotation adds an annotation to the index.json file so that the deploying code can figure out what the image tag <-> digest shasum will be.
+func addImageNameAnnotation(ociPath string, digestToTag map[string]string) error {
+	// Add an 'org.opencontainers.image.base.name' annotation so we can figure out what the image tag/digest shasum will be during deploy time
+	indexJSON, err := os.Open(path.Join(ociPath, "index.json"))
+	if err != nil {
+		message.Errorf(err, "Unable to open %s/index.json", ociPath)
+		return err
+	}
+
+	var index IndexJSON
+	byteValue, _ := io.ReadAll(indexJSON)
+	indexJSON.Close()
+	_ = json.Unmarshal(byteValue, &index)
+	for idx, manifest := range index.Manifests {
+		if manifest.Annotations == nil {
+			manifest.Annotations = make(map[string]string)
+		}
+		manifest.Annotations[ocispec.AnnotationBaseImageName] = digestToTag[manifest.Digest]
+		index.Manifests[idx] = manifest
+	}
+
+	indexPath := filepath.Join(ociPath, "index.json")
+
+	// Remove any file that might already exist
+	_ = os.Remove(indexPath)
+
+	// Create the index.json file and save the data to it
+	indexJSON, err = os.Create(indexPath)
+	if err != nil {
+		return err
+	}
+
+	indexJSONBytes, err := json.Marshal(index)
+	if err != nil {
+		return err
+	}
+
+	_, err = indexJSON.Write(indexJSONBytes)
+	if err != nil {
+		return err
+	}
+
+	return indexJSON.Close()
 }

--- a/src/internal/packager/images/pull.go
+++ b/src/internal/packager/images/pull.go
@@ -79,12 +79,9 @@ func (i *ImgConfig) PullAll() error {
 
 	spinner.Success()
 	title := fmt.Sprintf("Pulling %d images (%s of %d)", imgCount, "0", imgCount)
-	progressBar := message.NewProgressBar(int64(imgCount), title)
+	spinner = message.NewProgressSpinner(title)
 
 	for tag, img := range tagToImage {
-		// Update the progress bar
-		title = fmt.Sprintf("Pulling %d images (%d of %d)", imgCount, len(digestToTag)+1, imgCount)
-		progressBar.Update(int64(len(digestToTag)), title)
 
 		// Save the image
 		err := crane.SaveOCI(img, i.ImagesPath)
@@ -98,11 +95,14 @@ func (i *ImgConfig) PullAll() error {
 			return err
 		}
 		digestToTag[imgDigest.String()] = tag.String()
+		spinner.Updatef("Pulling image (%d of %d): %s", len(digestToTag), imgCount, tag.Name())
 	}
 
 	if err := addImageNameAnnotation(i.ImagesPath, digestToTag); err != nil {
 		return fmt.Errorf("unable to format OCI layout: %w", err)
 	}
+
+	spinner.Successf("Finished pulling %d images", imgCount)
 
 	return nil
 }

--- a/src/internal/packager/images/pull.go
+++ b/src/internal/packager/images/pull.go
@@ -78,13 +78,23 @@ func (i *ImgConfig) PullAll() error {
 	}
 	spinner.Updatef("Preparing image sources and cache for image pulling")
 
+	spinner.Success()
+	title := fmt.Sprintf("Pulling %d images (%s of %d)", imgCount, "0", imgCount)
+	progressBar := message.NewProgressBar(int64(imgCount), title)
+
 	for tag, img := range tagToImage {
+		// Update the progress bar
+		title = fmt.Sprintf("Pulling %d images (%d of %d)", imgCount, len(digestToTag)+1, imgCount)
+		progressBar.Update(int64(len(digestToTag)), title)
+
+		// Save the image
 		err := crane.SaveOCI(img, i.ImagesPath)
 		if err != nil {
 			fmt.Errorf("error when trying to save the img (%s): %w", tag.Name(), err)
 		}
 
 		// Get the image digest
+		// NOTE: This digest/tag map is used to set an annotation on the image index.json later
 		imgDigest, _ := img.Digest()
 		digestToTag[imgDigest.String()] = tag.String()
 	}

--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -58,7 +58,7 @@ func (i *ImgConfig) PushToZarfRegistry() error {
 	message.Debugf("crane pushOptions = %#v", pushOptions)
 	for _, src := range i.ImgList {
 		spinner.Updatef("Updating image %s", src)
-		img, err := crane.LoadTag(i.TarballPath, src, config.GetCraneOptions(i.Insecure)...)
+		img, err := crane.LoadTag(i.ImagesPath, src, config.GetCraneOptions(i.Insecure)...)
 		if err != nil {
 			return err
 		}
@@ -70,7 +70,7 @@ func (i *ImgConfig) PushToZarfRegistry() error {
 				return err
 			}
 
-			message.Debugf("crane.Push() %s:%s -> %s)", i.TarballPath, src, offlineNameCRC)
+			message.Debugf("crane.Push() %s:%s -> %s)", i.ImagesPath, src, offlineNameCRC)
 
 			if err = crane.Push(img, offlineNameCRC, pushOptions...); err != nil {
 				return err
@@ -84,7 +84,7 @@ func (i *ImgConfig) PushToZarfRegistry() error {
 			return err
 		}
 
-		message.Debugf("crane.Push() %s:%s -> %s)", i.TarballPath, src, offlineName)
+		message.Debugf("crane.Push() %s:%s -> %s)", i.ImagesPath, src, offlineName)
 
 		if err = crane.Push(img, offlineName, pushOptions...); err != nil {
 			return err

--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -5,16 +5,11 @@
 package images
 
 import (
-	"fmt"
-
 	"github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/internal/cluster"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/google/go-containerregistry/pkg/crane"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/layout"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // PushToZarfRegistry pushes a provided image into the configured Zarf registry
@@ -61,30 +56,13 @@ func (i *ImgConfig) PushToZarfRegistry() error {
 	pushOptions = append(pushOptions, config.GetCraneAuthOption(i.RegInfo.PushUsername, i.RegInfo.PushPassword))
 
 	message.Debugf("crane pushOptions = %#v", pushOptions)
-	layoutPath := layout.Path(i.ImagesPath)
-	imgIdx, err := layoutPath.ImageIndex()
-	if err != nil {
-		return err
-	}
-
-	idxManifest, err := imgIdx.IndexManifest()
-	if err != nil {
-		return err
-	}
 
 	for _, src := range i.ImgList {
 		spinner.Updatef("Updating image %s", src)
-		// Load the v1.Image
-		var img v1.Image
-		for _, manifest := range idxManifest.Manifests {
-			if manifest.Annotations[ocispec.AnnotationBaseImageName] == src {
-				// This is the image we are looking for, load it and then break out of the loop
-				img, err = layoutPath.Image(manifest.Digest)
-				break
-			}
-		}
-		if img == nil || err != nil {
-			return fmt.Errorf("unable to find image %s in the package: %v", src, err)
+
+		img, err := i.LoadImageFromPackage(src)
+		if err != nil {
+			return err
 		}
 
 		// If this is not a no checksum image push it for use with the Zarf agent

--- a/src/internal/packager/sbom/catalog.go
+++ b/src/internal/packager/sbom/catalog.go
@@ -68,9 +68,6 @@ func Catalog(componentSBOMs map[string]*types.ComponentSBOM, imgList []string, t
 		builder.spinner.Errorf(err, "Unable to generate the SBOM image list")
 		return err
 	}
-	// else {
-	// builder.jsonList = json
-	// }
 	builder.jsonList = json
 
 	// Generate SBOM for each image
@@ -81,15 +78,12 @@ func Catalog(componentSBOMs map[string]*types.ComponentSBOM, imgList []string, t
 		// Get the image that we are creating an SBOM for
 		img, err := images.LoadImage(tmpPaths.Images, tag)
 		if err != nil {
-			// <<<<<<< HEAD
 			builder.spinner.Errorf(err, "Unable to load the image to generate an SBOM")
 			return err
 		}
 
 		jsonData, err := builder.createImageSBOM(img, tag)
 		if err != nil {
-			// =======
-			// >>>>>>> 3ee26b04 (save sboms to a tar.zst file instead of keeping them in a directory)
 			builder.spinner.Errorf(err, "Unable to create SBOM for image %s", tag)
 			return err
 		}

--- a/src/internal/packager/sbom/catalog.go
+++ b/src/internal/packager/sbom/catalog.go
@@ -71,11 +71,11 @@ func Catalog(componentSBOMs map[string]*types.ComponentSBOM, imgList []string, i
 	// Generate SBOM for each image
 	layoutPath := layout.Path(imagesPath)
 	imgIndex, _ := layoutPath.ImageIndex()
-	idxManifest, _ := imgIndex.IndexManifest()
 	for _, tag := range imgList {
 		builder.spinner.Updatef("Creating image SBOMs (%d of %d): %s", currImage, imageCount, tag)
 
 		var img v1.Image
+		idxManifest, _ := imgIndex.IndexManifest()
 		for _, manifest := range idxManifest.Manifests {
 			if manifest.Annotations[ocispec.AnnotationBaseImageName] == tag {
 				img, _ = imgIndex.Image(manifest.Digest)

--- a/src/internal/packager/sbom/tools.go
+++ b/src/internal/packager/sbom/tools.go
@@ -14,11 +14,13 @@ import (
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/defenseunicorns/zarf/src/pkg/utils/exec"
 	"github.com/defenseunicorns/zarf/src/types"
+	"github.com/mholt/archiver/v3"
 )
 
 // ViewSBOMFiles opens a browser to view the SBOM files and pauses for user input.
 func ViewSBOMFiles(tmp types.TempPaths) {
-	sbomViewFiles, _ := filepath.Glob(filepath.Join(tmp.Sboms, "sbom-viewer-*"))
+	sbomFilePath := filepath.Join(tmp.Base, "sboms")
+	sbomViewFiles, _ := filepath.Glob(filepath.Join(sbomFilePath, "sbom-viewer-*"))
 
 	if len(sbomViewFiles) > 0 {
 		link := sbomViewFiles[0]
@@ -49,5 +51,9 @@ func OutputSBOMFiles(tmp types.TempPaths, outputDir string, packageName string) 
 		return err
 	}
 
-	return utils.CreatePathAndCopy(tmp.Sboms, packagePath)
+	if err := utils.CreateDirectory(packagePath, 0700); err != nil {
+		return err
+	}
+
+	return archiver.Unarchive(tmp.SbomTar, packagePath)
 }

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -159,7 +159,7 @@ func createPaths() (paths types.TempPaths, err error) {
 		SeedImage:    filepath.Join(basePath, "seed-image"),
 		Images:       filepath.Join(basePath, "images"),
 		Components:   filepath.Join(basePath, "components"),
-		Sboms:        filepath.Join(basePath, "sboms"),
+		SbomTar:      filepath.Join(basePath, "sboms.tar.zst"),
 		ZarfYaml:     filepath.Join(basePath, config.ZarfYAML),
 	}
 
@@ -224,10 +224,14 @@ func (p *Packager) loadZarfPkg() error {
 	}
 
 	// If SBOM files exist, temporarily place them in the deploy directory
-	p.cfg.SBOMViewFiles, _ = filepath.Glob(filepath.Join(p.tmp.Sboms, "sbom-viewer-*"))
-	if err := sbom.OutputSBOMFiles(p.tmp, config.ZarfSBOMDir, ""); err != nil {
-		// Don't stop the deployment, let the user decide if they want to continue the deployment
-		spinner.Errorf(err, "Unable to process the SBOM files for this package")
+	if _, err := os.Stat(filepath.Join(p.tmp.Base, "sboms.tar.zst")); err == nil {
+		_ = archiver.Unarchive(filepath.Join(p.tmp.Base, "sboms.tar.zst"), p.tmp.Base)
+
+		p.cfg.SBOMViewFiles, _ = filepath.Glob(filepath.Join(p.tmp.Base, "sbom-viewer-*"))
+		if err := sbom.OutputSBOMFiles(p.tmp, config.ZarfSBOMDir, ""); err != nil {
+			// Don't stop the deployment, let the user decide if they want to continue the deployment
+			spinner.Errorf(err, "Unable to process the SBOM files for this package")
+		}
 	}
 
 	// Handle component configuration deprecations

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -156,8 +156,8 @@ func createPaths() (paths types.TempPaths, err error) {
 		Base: basePath,
 
 		InjectBinary: filepath.Join(basePath, "zarf-injector"),
-		SeedImage:    filepath.Join(basePath, "seed-image.tar"),
-		Images:       filepath.Join(basePath, "images.tar"),
+		SeedImage:    filepath.Join(basePath, "seed-image"),
+		Images:       filepath.Join(basePath, "images"),
 		Components:   filepath.Join(basePath, "components"),
 		Sboms:        filepath.Join(basePath, "sboms"),
 		ZarfYaml:     filepath.Join(basePath, config.ZarfYAML),

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -161,7 +161,7 @@ func (p *Packager) Create(baseDir string) error {
 	if p.cfg.CreateOpts.SkipSBOM {
 		message.Debug("Skipping image SBOM processing per --skip-sbom flag")
 	} else {
-		if err := sbom.Catalog(componentSBOMs, imgList, p.tmp.Images, p.tmp.Sboms); err != nil {
+		if err := sbom.Catalog(componentSBOMs, imgList, p.tmp); err != nil {
 			return fmt.Errorf("unable to create an SBOM catalog for the package: %w", err)
 		}
 	}

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -144,9 +144,9 @@ func (p *Packager) Create(baseDir string) error {
 
 		doPull := func() error {
 			imgConfig := images.ImgConfig{
-				TarballPath: p.tmp.Images,
-				ImgList:     imgList,
-				Insecure:    config.CommonOptions.Insecure,
+				ImagesPath: p.tmp.Images,
+				ImgList:    imgList,
+				Insecure:   config.CommonOptions.Insecure,
 			}
 
 			return imgConfig.PullAll()

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -161,7 +161,9 @@ func (p *Packager) Create(baseDir string) error {
 	if p.cfg.CreateOpts.SkipSBOM {
 		message.Debug("Skipping image SBOM processing per --skip-sbom flag")
 	} else {
-		sbom.Catalog(componentSBOMs, imgList, p.tmp.Images, p.tmp.Sboms)
+		if err := sbom.Catalog(componentSBOMs, imgList, p.tmp.Images, p.tmp.Sboms); err != nil {
+			return fmt.Errorf("unable to create an SBOM catalog for the package: %w", err)
+		}
 	}
 
 	// Process the component directories into compressed tarballs

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -387,11 +387,11 @@ func (p *Packager) pushImagesToRegistry(componentImages []string, noImgChecksum 
 	}
 
 	imgConfig := images.ImgConfig{
-		TarballPath: p.tmp.Images,
-		ImgList:     componentImages,
-		NoChecksum:  noImgChecksum,
-		RegInfo:     p.cfg.State.RegistryInfo,
-		Insecure:    config.CommonOptions.Insecure,
+		ImagesPath: p.tmp.Images,
+		ImgList:    componentImages,
+		NoChecksum: noImgChecksum,
+		RegInfo:    p.cfg.State.RegistryInfo,
+		Insecure:   config.CommonOptions.Insecure,
 	}
 
 	return utils.Retry(func() error {

--- a/src/types/runtime.go
+++ b/src/types/runtime.go
@@ -84,6 +84,6 @@ type TempPaths struct {
 	SeedImage    string
 	Images       string
 	Components   string
-	Sboms        string
+	SbomTar      string
 	ZarfYaml     string
 }


### PR DESCRIPTION
**Work Remaining:**
- [x] Find a good way to test backwards compatibility
    - backwards compatibility for this features is implicitly tested within `27_cosign_deploy_test.go` as that is deploying an older zarf package that still has the images in an `images.tar` tarball when deploying the `zarf-hello-world` games package.
- [x] Look into improving the progress bar spinner when pulling the images when building a package
- [x] Clean up some places where I got lazy with error handling (dogsledding errors from functions)