### PR TITLE
deletes tar.zst of components after unarchive

### DIFF
--- a/src/cmd/tools/archiver.go
+++ b/src/cmd/tools/archiver.go
@@ -61,6 +61,10 @@ var archiverDecompressCmd = &cobra.Command{
 				if strings.HasSuffix(file.Name(), "tar.zst") {
 					if err := archiver.Unarchive(filepath.Join(layersDir, file.Name()), layersDir); err != nil {
 						message.Fatalf(err, "failed to decompress the component layer")
+					} else {
+						// Without unarchive error, delete original tar.zst in component folder
+						// This will leave the tar.zst if their is a failure for post mortem check
+						_ = os.Remove(filepath.Join(layersDir, file.Name()))
 					}
 				}
 			}


### PR DESCRIPTION
## Description
Upon a successful unarchive, delete the `tar.zst` that is no longer needed when using `zarf tools archiver decompress <package> <dest> --decompress-all`. 
...

Before behavior:
```
ocipkg/
├── components
│   ├── keyval
│   │   └── manifests
│   │       └── k3s
│   │           ├── hornstash-deploy.yaml
│   │           └── zarf-service.yaml
│   └── keyval.tar.zst
├── images.tar
├── sboms
│   ├── compare.html
│   ├── registry.gitlab.com_buzzdeploy_apps_horn-stash_main-amd64.json
│   └── sbom-viewer-registry.gitlab.com_buzzdeploy_apps_horn-stash_main-amd64.html
├── zarf-1135963779
└── zarf.yaml

```

After:
```
ocipkg/
├── components
│   └── keyval
│       └── manifests
│           └── k3s
│               ├── hornstash-deploy.yaml
│               └── zarf-service.yaml
├── images.tar
├── sboms
│   ├── compare.html
│   ├── registry.gitlab.com_buzzdeploy_apps_horn-stash_main-amd64.json
│   └── sbom-viewer-registry.gitlab.com_buzzdeploy_apps_horn-stash_main-amd64.html
├── zarf-1135963779
└── zarf.yaml
```

## Related Issue

Fixes #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
