### PR TITLE
Docs: fixed broken links 

### DIFF
--- a/docs/1-understand-the-basics.md
+++ b/docs/1-understand-the-basics.md
@@ -10,7 +10,8 @@ Before you can effectively use Zarf, it is useful to have an understanding of th
 
 - [What is Kubernetes?](https://www.ibm.com/cloud/learn/kubernetes)
 - [Learn Kubernetes Basics](https://kubernetes.io/docs/tutorials/kubernetes-basics/)
-- [Free Introduction to Kubernetes Course]Supercharge[your Kubernetes](https://www.youtube.com/watch?v=N6UCKF7JD7k) deployments](https://www.youtube.com/watch?v=N6UCKF7JD7k)
+- [Free Introduction to Kubernetes Course](https://www.edx.org/course/introduction-to-kubernetes)
+- [Super charge your Kubernetes deployments](https://www.youtube.com/watch?v=N6UCKF7JD7k)
   
 ### AirGap Basics
 


### PR DESCRIPTION
## Description
Stumbled across some broken links in [this doc](https://github.com/defenseunicorns/zarf/blob/main/docs/1-understand-the-basics.md).  Dug through the [commit history](https://github.com/defenseunicorns/zarf/pull/1276/files#diff-53706aae2f95773ebd248f8d0d160403083ffc18ba649f08ebb35e806c5cd797) and pulled out the correct links.  Tossed the `documentation` label on the PR, not sure but hope that prevents any pipelines from kicking off.  I didn't see anything in the contributor's guide to tackle a doc update.  Please advise if this PR is suitable.

FYI @bdfinst 

## Related Issue

Fixes #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
