### PR TITLE
typo: Fix duplicate link

### DIFF
--- a/docs/4-user-guide/2-zarf-packages/1-zarf-packages.md
+++ b/docs/4-user-guide/2-zarf-packages/1-zarf-packages.md
@@ -10,7 +10,7 @@ Zarf packages are built while 'online' and connected to whatever is hosting the 
 
 The `zarf.yaml` file, which the package builds from, defines declarative instructions on how the capabilities of the package should be deployed. The declarative nature of the package means everything is represented by code and automatically runs as it is configured, instead of having to give manual steps that might not be reproducible on all systems.
 
-Zarf Packages are made up of functionality blocks called components which are described more on the [Zarf](./2-zarf-components.md) Components page](./2-zarf-components.md). These components can be optional, giving more flexibility to how packages can be used.
+Zarf Packages are made up of functionality blocks called components which are described more on the [Zarf Components page](./2-zarf-components.md). These components can be optional, giving more flexibility to how packages can be used.
 
 ## Deploying on to Airgapped Systems
 


### PR DESCRIPTION
## Description

The documentation has a typo, where the markdown-link is missing the opening bracket

## Related Issue

No related issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
