### PR TITLE
Fix OCI pulling of helm chart versions

### DIFF
--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -104,6 +104,8 @@ func (h *Helm) DownloadPublishedChart(destination string) {
 			spinner.Fatalf(err, "Unable to create a new registry client")
 		}
 		chartURL = h.Chart.URL
+		// Explicitly set the pull version for OCI
+		pull.Version = h.Chart.Version
 	} else {
 		// Perform simple chart download
 		chartURL, err = repo.FindChartInRepoURL(h.Chart.URL, h.Chart.Name, h.Chart.Version, pull.CertFile, pull.KeyFile, pull.CaFile, getter.All(pull.Settings))

--- a/src/test/e2e/25_helm_test.go
+++ b/src/test/e2e/25_helm_test.go
@@ -54,6 +54,10 @@ func testHelmLocalChart(t *testing.T) {
 	stdOut, stdErr, err := e2e.execZarfCommand("package", "deploy", path, "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 
+	// Verify that nginx successfully deploys in the cluster
+	kubectlOut, _, _ := e2e.execZarfCommand("tools", "kubectl", "-n=local-chart", "rollout", "status", "deployment/local-demo")
+	assert.Contains(t, string(kubectlOut), "successfully rolled out")
+
 	// Remove the package.
 	stdOut, stdErr, err = e2e.execZarfCommand("package", "remove", "test-helm-local-chart", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
@@ -92,6 +96,10 @@ func testHelmOCIChart(t *testing.T) {
 	// Deploy the package.
 	stdOut, stdErr, err := e2e.execZarfCommand("package", "deploy", path, "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
+
+	// Verify that podinfo successfully deploys in the cluster
+	kubectlOut, _, _ := e2e.execZarfCommand("tools", "kubectl", "-n=helm-oci-demo", "rollout", "status", "deployment/podinfo")
+	assert.Contains(t, string(kubectlOut), "successfully rolled out")
 
 	// Remove the package.
 	stdOut, stdErr, err = e2e.execZarfCommand("package", "remove", "helm-oci-chart", "--confirm")


### PR DESCRIPTION
## Description

This resolves an issue where Zarf erroneously pulls the latest helm chart when pulling via OCI.

## Related Issue

Fixes #1422 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
