### PR TITLE
Update progress bar message

### DIFF
--- a/src/pkg/utils/bytes.go
+++ b/src/pkg/utils/bytes.go
@@ -82,7 +82,7 @@ func RenderProgressBarForLocalDirWrite(filepath string, expectedTotal int64, wg 
 			}
 
 			// Update the progress bar with the current size
-			title := fmt.Sprintf("%s (%s of %s)", updateText, ByteFormat(float64(expectedTotal), 2), ByteFormat(float64(currentBytes), 2))
+			title := fmt.Sprintf("%s (%s of %s)", updateText, ByteFormat(float64(currentBytes), 2), ByteFormat(float64(expectedTotal), 2))
 			progressBar.Update(currentBytes, title)
 			time.Sleep(200 * time.Millisecond)
 		}


### PR DESCRIPTION
## Description

The commit swaps the message in the `title` variable to show the current bytes pulled in the progress bar instead of the expected total bytes. This improves the clarity of the message for the user.

https://github.com/defenseunicorns/zarf/issues/1439

## Related Issue

Fixes #1439

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
