### PR TITLE
Add some extra manifest annotations on publish

### DIFF
--- a/docs/4-user-guide/3-zarf-schema.md
+++ b/docs/4-user-guide/3-zarf-schema.md
@@ -187,6 +187,70 @@ Must be one of:
 </blockquote>
 </details>
 
+<details>
+<summary>
+<strong> <a name="metadata_authors"></a>authors</strong>
+</summary>
+&nbsp;
+<blockquote>
+
+**Description:** List of package authors (including contact info)
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="metadata_documentation"></a>documentation</strong>
+</summary>
+&nbsp;
+<blockquote>
+
+**Description:** Link to package documentation when online
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="metadata_source"></a>source</strong>
+</summary>
+&nbsp;
+<blockquote>
+
+**Description:** Link to package source code when online
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="metadata_vendor"></a>vendor</strong>
+</summary>
+&nbsp;
+<blockquote>
+
+**Description:** Name of the distributing entity
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
+
+</blockquote>
+</details>
+
 </blockquote>
 </details>
 

--- a/docs/4-user-guide/3-zarf-schema.md
+++ b/docs/4-user-guide/3-zarf-schema.md
@@ -242,7 +242,7 @@ Must be one of:
 &nbsp;
 <blockquote>
 
-**Description:** Name of the distributing entity
+**Description:** Name of the distributing entity, organization or individual.
 
 |          |          |
 | -------- | -------- |

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -275,9 +275,21 @@ func (p *Packager) generateAnnotations() map[string]string {
 		ocispec.AnnotationTitle:       p.cfg.Pkg.Metadata.Name,
 		ocispec.AnnotationDescription: p.cfg.Pkg.Metadata.Description,
 	}
-	url := p.cfg.Pkg.Metadata.URL
-	if url != "" {
-		annotations[ocispec.AnnotationSource] = url
+
+	if url := p.cfg.Pkg.Metadata.URL; url != "" {
+		annotations[ocispec.AnnotationURL] = url
+	}
+	if authors := p.cfg.Pkg.Metadata.Authors; authors != "" {
+		annotations[ocispec.AnnotationAuthors] = authors
+	}
+	if documentation := p.cfg.Pkg.Metadata.Documentation; documentation != "" {
+		annotations[ocispec.AnnotationDocumentation] = documentation
+	}
+	if source := p.cfg.Pkg.Metadata.Source; source != "" {
+		annotations[ocispec.AnnotationSource] = source
+	}
+	if vendor := p.cfg.Pkg.Metadata.Vendor; vendor != "" {
+		annotations[ocispec.AnnotationVendor] = vendor
 	}
 
 	return annotations

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -272,7 +272,8 @@ func (p *Packager) publishImage(dst *utils.OrasRemote, src *file.Store, descs []
 
 func (p *Packager) generateAnnotations() map[string]string {
 	annotations := map[string]string{
-		"org.opencontainers.image.description": p.cfg.Pkg.Metadata.Description,
+		ocispec.AnnotationTitle:       p.cfg.Pkg.Metadata.Name,
+		ocispec.AnnotationDescription: p.cfg.Pkg.Metadata.Description,
 	}
 	url := p.cfg.Pkg.Metadata.URL
 	if url != "" {
@@ -294,8 +295,8 @@ func (p *Packager) generateManifestConfigFile() (ocispec.Descriptor, []byte, err
 	}
 
 	annotations := map[string]string{
-		"org.opencontainers.image.title":       p.cfg.Pkg.Metadata.Name,
-		"org.opencontainers.image.description": p.cfg.Pkg.Metadata.Description,
+		ocispec.AnnotationTitle:       p.cfg.Pkg.Metadata.Name,
+		ocispec.AnnotationDescription: p.cfg.Pkg.Metadata.Description,
 	}
 
 	manifestConfig := OCIConfigPartial{

--- a/src/types/package.go
+++ b/src/types/package.go
@@ -16,14 +16,18 @@ type ZarfPackage struct {
 
 // ZarfMetadata lists information about the current ZarfPackage.
 type ZarfMetadata struct {
-	Name         string `json:"name" jsonschema:"description=Name to identify this Zarf package,pattern=^[a-z0-9\\-]+$"`
-	Description  string `json:"description,omitempty" jsonschema:"description=Additional information about this package"`
-	Version      string `json:"version,omitempty" jsonschema:"description=Generic string to track the package version by a package author"`
-	URL          string `json:"url,omitempty" jsonschema:"description=Link to package information when online"`
-	Image        string `json:"image,omitempty" jsonschema:"description=An image URL to embed in this package (Reserved for future use in Zarf UI)"`
-	Uncompressed bool   `json:"uncompressed,omitempty" jsonschema:"description=Disable compression of this package"`
-	Architecture string `json:"architecture,omitempty" jsonschema:"description=The target cluster architecture for this package,example=arm64,example=amd64"`
-	YOLO         bool   `json:"yolo,omitempty" jsonschema:"description=Yaml OnLy Online (YOLO): True enables deploying a Zarf package without first running zarf init against the cluster. This is ideal for connected environments where you want to use existing VCS and container registries."`
+	Name          string `json:"name" jsonschema:"description=Name to identify this Zarf package,pattern=^[a-z0-9\\-]+$"`
+	Description   string `json:"description,omitempty" jsonschema:"description=Additional information about this package"`
+	Version       string `json:"version,omitempty" jsonschema:"description=Generic string to track the package version by a package author"`
+	URL           string `json:"url,omitempty" jsonschema:"description=Link to package information when online"`
+	Image         string `json:"image,omitempty" jsonschema:"description=An image URL to embed in this package (Reserved for future use in Zarf UI)"`
+	Uncompressed  bool   `json:"uncompressed,omitempty" jsonschema:"description=Disable compression of this package"`
+	Architecture  string `json:"architecture,omitempty" jsonschema:"description=The target cluster architecture for this package,example=arm64,example=amd64"`
+	YOLO          bool   `json:"yolo,omitempty" jsonschema:"description=Yaml OnLy Online (YOLO): True enables deploying a Zarf package without first running zarf init against the cluster. This is ideal for connected environments where you want to use existing VCS and container registries."`
+	Authors       string `json:"authors,omitempty" jsonschema:"description=List of package authors (including contact info)"`
+	Documentation string `json:"documentation,omitempty" jsonschema:"description=Link to package documentation when online"`
+	Source        string `json:"source,omitempty" jsonschema:"description=Link to package source code when online"`
+	Vendor        string `json:"vendor,omitempty" jsonschema:"description=Name of the distributing entity, organization or individual."`
 }
 
 // ZarfBuildData is written during the packager.Create() operation to track details of the created package.

--- a/src/types/package.go
+++ b/src/types/package.go
@@ -27,7 +27,7 @@ type ZarfMetadata struct {
 	Authors       string `json:"authors,omitempty" jsonschema:"description=List of package authors (including contact info)"`
 	Documentation string `json:"documentation,omitempty" jsonschema:"description=Link to package documentation when online"`
 	Source        string `json:"source,omitempty" jsonschema:"description=Link to package source code when online"`
-	Vendor        string `json:"vendor,omitempty" jsonschema:"description=Name of the distributing entity, organization or individual."`
+	Vendor        string `json:"vendor,omitempty" jsonschema_description:"Name of the distributing entity, organization or individual."`
 }
 
 // ZarfBuildData is written during the packager.Create() operation to track details of the created package.

--- a/src/ui/lib/api-types.ts
+++ b/src/ui/lib/api-types.ts
@@ -749,9 +749,17 @@ export interface ZarfMetadata {
      */
     architecture?: string;
     /**
+     * List of package authors (including contact info)
+     */
+    authors?: string;
+    /**
      * Additional information about this package
      */
     description?: string;
+    /**
+     * Link to package documentation when online
+     */
+    documentation?: string;
     /**
      * An image URL to embed in this package (Reserved for future use in Zarf UI)
      */
@@ -761,6 +769,10 @@ export interface ZarfMetadata {
      */
     name: string;
     /**
+     * Link to package source code when online
+     */
+    source?: string;
+    /**
      * Disable compression of this package
      */
     uncompressed?: boolean;
@@ -768,6 +780,10 @@ export interface ZarfMetadata {
      * Link to package information when online
      */
     url?: string;
+    /**
+     * Name of the distributing entity
+     */
+    vendor?: string;
     /**
      * Generic string to track the package version by a package author
      */
@@ -1287,11 +1303,15 @@ const typeMap: any = {
     ], false),
     "ZarfMetadata": o([
         { json: "architecture", js: "architecture", typ: u(undefined, "") },
+        { json: "authors", js: "authors", typ: u(undefined, "") },
         { json: "description", js: "description", typ: u(undefined, "") },
+        { json: "documentation", js: "documentation", typ: u(undefined, "") },
         { json: "image", js: "image", typ: u(undefined, "") },
         { json: "name", js: "name", typ: "" },
+        { json: "source", js: "source", typ: u(undefined, "") },
         { json: "uncompressed", js: "uncompressed", typ: u(undefined, true) },
         { json: "url", js: "url", typ: u(undefined, "") },
+        { json: "vendor", js: "vendor", typ: u(undefined, "") },
         { json: "version", js: "version", typ: u(undefined, "") },
         { json: "yolo", js: "yolo", typ: u(undefined, true) },
     ], false),

--- a/src/ui/lib/api-types.ts
+++ b/src/ui/lib/api-types.ts
@@ -781,7 +781,7 @@ export interface ZarfMetadata {
      */
     url?: string;
     /**
-     * Name of the distributing entity
+     * Name of the distributing entity, organization or individual.
      */
     vendor?: string;
     /**

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -758,7 +758,7 @@
         },
         "vendor": {
           "type": "string",
-          "description": "Name of the distributing entity"
+          "description": "Name of the distributing entity, organization or individual."
         }
       },
       "additionalProperties": false,

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -743,6 +743,22 @@
         "yolo": {
           "type": "boolean",
           "description": "Yaml OnLy Online (YOLO): True enables deploying a Zarf package without first running zarf init against the cluster. This is ideal for connected environments where you want to use existing VCS and container registries."
+        },
+        "authors": {
+          "type": "string",
+          "description": "List of package authors (including contact info)"
+        },
+        "documentation": {
+          "type": "string",
+          "description": "Link to package documentation when online"
+        },
+        "source": {
+          "type": "string",
+          "description": "Link to package source code when online"
+        },
+        "vendor": {
+          "type": "string",
+          "description": "Name of the distributing entity"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Fixes #1450 

This also adds `metadata.[]` of `authors`, `documentation`, `source`, `vendor`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed

Proof (showing README now appears + description)

![Screenshot 2023-03-17 at 4 40 35 PM](https://user-images.githubusercontent.com/50058333/226058375-ca765c7d-e128-4ea1-b701-4fdb183f6d44.png)

![Screenshot 2023-03-17 at 4 40 46 PM](https://user-images.githubusercontent.com/50058333/226058380-37e8fe15-b401-4a5d-bc21-fb6177a9a8ed.png)

