### PR TITLE
Adding Gitea Virtual Service to Big Bang example

### DIFF
--- a/examples/big-bang/virtualservices/gitea.yaml
+++ b/examples/big-bang/virtualservices/gitea.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: gitea
+  namespace: zarf
+spec:
+  gateways:
+    - istio-system/public
+  hosts:
+    - gitea.bigbang.dev
+  http:
+    - route:
+        - destination:
+            host: zarf-gitea-http.zarf.svc.cluster.local
+            port:
+              number: 3000

--- a/examples/big-bang/zarf.yaml
+++ b/examples/big-bang/zarf.yaml
@@ -27,3 +27,10 @@ components:
           - config/loki.yaml
           # Values are merged in order, so this would override the above and disable everything if uncommented
           # - config/disable-all.yaml
+  - name: extra-virtual-services
+    required: true
+    manifests:
+      - name: gitea
+        namespace: zarf
+        files:
+          - virtualservices/gitea.yaml


### PR DESCRIPTION
## Description

I thought I would expand the example by showing a relevant and useful addition.  Since Gitlab is typically deployed with Big Bang, this would give somewhat of an equivalent feel to be able to not have to worry about setting up a proxy forward for the service for Gitea.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
