### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,9 +2,9 @@
 
 # Docs & examples
 /adr/ @jeff-mccoy @YrrepNoj @Racer159
-/docs/ @Madeline-UX @JasonvanBrackel @RothAndrew @jeff-mccoy @YrrepNoj @Racer159 @wirewc
-/examples/ @JasonvanBrackel @RothAndrew @jeff-mccoy @YrrepNoj @Racer159 @wirewc
-*.md @Madeline-UX @JasonvanBrackel @RothAndrew @jeff-mccoy @YrrepNoj @Racer159 @wirewc
+/docs/ @Madeline-UX @JasonvanBrackel @jeff-mccoy @YrrepNoj @Racer159 @wirewc
+/examples/ @JasonvanBrackel @jeff-mccoy @YrrepNoj @Racer159 @wirewc
+*.md @Madeline-UX @JasonvanBrackel @jeff-mccoy @YrrepNoj @Racer159 @wirewc
 
 # Core code
 /src/ @jeff-mccoy @YrrepNoj @Racer159


### PR DESCRIPTION
Remove myself from CODEOWNERS. I'm not as involved in the development of Zarf as I used to be. I'll still be able to add input and PRs as necessary just not as a codeowner.