### PR TITLE
update calculation for the expected bytes during image layer pulls

### DIFF
--- a/src/pkg/packager/network.go
+++ b/src/pkg/packager/network.go
@@ -252,8 +252,13 @@ func getOCIPackageSize(src *utils.OrasRemote, ref registry.Reference) (int64, er
 		layers = manifest.Layers
 	}
 
+	processedLayers := make(map[string]bool)
 	for _, layer := range layers {
-		total += layer.Size
+		// Only include this layer's size if we haven't already processed it
+		if !processedLayers[layer.Digest.String()] {
+			total += layer.Size
+			processedLayers[layer.Digest.String()] = true
+		}
 	}
 
 	return total, nil


### PR DESCRIPTION
## Description

The progress bar 'expected bytes' now takes duplicate layers into account

Fixes #1488 