### PR TITLE
use examples capability of cobra for zarf init examples, results in b…

### DIFF
--- a/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_init.md
+++ b/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_init.md
@@ -12,7 +12,15 @@ This command looks for a zarf-init package in the local directory that the comma
 
 
 
-Example Usage:
+
+
+```
+zarf init [flags]
+```
+
+## Examples
+
+```
 # Initializing without any optional components:
 zarf init
 
@@ -31,10 +39,6 @@ zarf init --registry-push-password={PASSWORD} --registry-push-username={USERNAME
 # Initializing w/ an external git server:
 zarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-url={URL}
 
-
-
-```
-zarf init [flags]
 ```
 
 ## Options

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -28,7 +28,7 @@ var initCmd = &cobra.Command{
 	Aliases: []string{"i"},
 	Short:   lang.CmdInitShort,
 	Long:    lang.CmdInitLong,
-
+	Example: lang.CmdInitExample,
 	Run: func(cmd *cobra.Command, args []string) {
 		zarfLogo := message.GetLogo()
 		_, _ = fmt.Fprintln(os.Stderr, zarfLogo)

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -96,14 +96,26 @@ const (
 		"This command looks for a zarf-init package in the local directory that the command was executed " +
 		"from. If no package is found in the local directory and the Zarf CLI exists somewhere outside of " +
 		"the current directory, Zarf will failover and attempt to find a zarf-init package in the directory " +
-		"that the Zarf binary is located in.\n\n\n\n" +
-		"Example Usage:\n" +
-		"# Initializing without any optional components:\nzarf init\n\n" +
-		"# Initializing w/ Zarfs internal git server:\nzarf init --components=git-server\n\n" +
-		"# Initializing w/ Zarfs internal git server and PLG stack:\nzarf init --components=git-server,logging\n\n" +
-		"# Initializing w/ an internal registry but with a different nodeport:\nzarf init --nodeport=30333\n\n" +
-		"# Initializing w/ an external registry:\nzarf init --registry-push-password={PASSWORD} --registry-push-username={USERNAME} --registry-url={URL}\n\n" +
-		"# Initializing w/ an external git server:\nzarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-url={URL}\n\n"
+		"that the Zarf binary is located in.\n\n\n\n"
+
+	CmdInitExample = `# Initializing without any optional components:
+zarf init
+
+# Initializing w/ Zarfs internal git server:
+zarf init --components=git-server
+
+# Initializing w/ Zarfs internal git server and PLG stack:
+zarf init --components=git-server,logging
+
+# Initializing w/ an internal registry but with a different nodeport:
+zarf init --nodeport=30333
+
+# Initializing w/ an external registry:
+zarf init --registry-push-password={PASSWORD} --registry-push-username={USERNAME} --registry-url={URL}
+
+# Initializing w/ an external git server:
+zarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-url={URL}
+`
 
 	CmdInitErrFlags             = "Invalid command flags were provided."
 	CmdInitErrDownload          = "failed to download the init package: %s"


### PR DESCRIPTION
## Description

This moves the `zarf init` examples to use cobra's built-in capability for examples.  This results in a cleaner experience on the cli and the resulting documentation Markdown formatting.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
