### PR TITLE
Fix package deploy error message when package and cluster architectures don't match

### DIFF
--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -371,9 +371,9 @@ func (p *Packager) getUpdatedValueTemplate(component types.ZarfComponent) (value
 
 	// Only check the architecture if the package has images
 	if len(component.Images) > 0 && state.Architecture != p.arch {
-		// If the package has images but the architectures don't match warn the user to avoid ugly hidden errors with image push/pull
+		// If the package has images but the architectures don't match, fail the deployment and warn the user to avoid ugly hidden errors with image push/pull
 		return values, fmt.Errorf("this package architecture is %s, but this cluster seems to be initialized with the %s architecture",
-			state.Architecture, p.arch)
+			p.arch, state.Architecture)
 	}
 
 	spinner.Success()


### PR DESCRIPTION
## Description
Fix package deploy error message when package and cluster architectures don't match

## Related Issue

Fixes https://github.com/defenseunicorns/zarf/issues/1493

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging

- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
