### PR TITLE
Pass package architecture around through ImgConfigs

### DIFF
--- a/src/cmd/tools/crane.go
+++ b/src/cmd/tools/crane.go
@@ -14,6 +14,7 @@ import (
 )
 
 func init() {
+	// No package information is available so do not pass in a list of architectures
 	cranePlatformOptions := config.GetCraneOptions(false)
 
 	craneLogin := craneCmd.NewCmdAuthLogin()

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -117,7 +117,7 @@ func GetDataInjectionMarker() string {
 }
 
 // GetCraneOptions returns a crane option object with the correct options & platform.
-func GetCraneOptions(insecure bool) []crane.Option {
+func GetCraneOptions(insecure bool, archs ...string) []crane.Option {
 	var options []crane.Option
 
 	// Handle insecure registry option
@@ -133,7 +133,7 @@ func GetCraneOptions(insecure bool) []crane.Option {
 	options = append(options,
 		crane.WithPlatform(&v1.Platform{
 			OS:           "linux",
-			Architecture: GetArch(),
+			Architecture: GetArch(archs...),
 		}),
 	)
 

--- a/src/internal/packager/images/common.go
+++ b/src/internal/packager/images/common.go
@@ -27,6 +27,8 @@ type ImgConfig struct {
 	NoChecksum bool
 
 	Insecure bool
+
+	Architectures []string
 }
 
 // GetLegacyImgTarballPath returns the ImagesPath as if it were a path to a tarball instead of a directory.
@@ -38,7 +40,7 @@ func (i *ImgConfig) GetLegacyImgTarballPath() string {
 func (i ImgConfig) LoadImageFromPackage(imgTag string) (v1.Image, error) {
 	// If the package still has a images.tar that contains all of the images, use crane to load the specific tag we want
 	if _, statErr := os.Stat(i.GetLegacyImgTarballPath()); statErr == nil {
-		return crane.LoadTag(i.GetLegacyImgTarballPath(), imgTag, config.GetCraneOptions(i.Insecure)...)
+		return crane.LoadTag(i.GetLegacyImgTarballPath(), imgTag, config.GetCraneOptions(i.Insecure, i.Architectures...)...)
 	}
 
 	// Load the image from the OCI formatted images directory

--- a/src/internal/packager/images/pull.go
+++ b/src/internal/packager/images/pull.go
@@ -145,11 +145,11 @@ func (i *ImgConfig) PullImage(src string, spinner *message.Spinner) (img v1.Imag
 	// Load image tarballs from the local filesystem.
 	if strings.HasSuffix(src, ".tar") || strings.HasSuffix(src, ".tar.gz") || strings.HasSuffix(src, ".tgz") {
 		spinner.Updatef("Reading image tarball: %s", src)
-		return crane.Load(src, config.GetCraneOptions(true)...)
+		return crane.Load(src, config.GetCraneOptions(true, i.Architectures...)...)
 	}
 
 	// If crane is unable to pull the image, try to load it from the local docker daemon.
-	if _, err := crane.Manifest(src, config.GetCraneOptions(i.Insecure)...); err != nil {
+	if _, err := crane.Manifest(src, config.GetCraneOptions(i.Insecure, i.Architectures...)...); err != nil {
 		message.Debugf("crane unable to pull image %s: %s", src, err)
 		spinner.Updatef("Falling back to docker for %s. This may take some time.", src)
 
@@ -192,7 +192,7 @@ func (i *ImgConfig) PullImage(src string, spinner *message.Spinner) (img v1.Imag
 	}
 
 	// Manifest was found, so use crane to pull the image.
-	if img, err = crane.Pull(src, config.GetCraneOptions(i.Insecure)...); err != nil {
+	if img, err = crane.Pull(src, config.GetCraneOptions(i.Insecure, i.Architectures...)...); err != nil {
 		return nil, fmt.Errorf("failed to pull image %s: %w", src, err)
 	}
 

--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -52,7 +52,7 @@ func (i *ImgConfig) PushToZarfRegistry() error {
 	spinner := message.NewProgressSpinner("Storing images in the zarf registry")
 	defer spinner.Stop()
 
-	pushOptions := config.GetCraneOptions(i.Insecure)
+	pushOptions := config.GetCraneOptions(i.Insecure, i.Architectures...)
 	pushOptions = append(pushOptions, config.GetCraneAuthOption(i.RegInfo.PushUsername, i.RegInfo.PushPassword))
 
 	message.Debugf("crane pushOptions = %#v", pushOptions)

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -86,6 +86,7 @@ func NewOrDie(config *types.PackagerConfig) *Packager {
 func GetInitPackageName(arch string) string {
 	message.Debug("packager.GetInitPackageName()")
 	if arch == "" {
+		// No package has been loaded yet so lookup GetArch() with no package info
 		arch = config.GetArch()
 	}
 	return fmt.Sprintf("zarf-init-%s-%s.tar.zst", arch, config.CLIVersion)

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -101,7 +101,8 @@ func (p *Packager) Create(baseDir string) error {
 
 		ociPath := path.Join(p.tmp.Base, "seed-image")
 		imgConfig := images.ImgConfig{
-			Insecure: config.CommonOptions.Insecure,
+			Insecure:      config.CommonOptions.Insecure,
+			Architectures: []string{p.cfg.Pkg.Metadata.Architecture, p.cfg.Pkg.Build.Architecture},
 		}
 
 		image, err := imgConfig.PullImage(seedImage, spinner)
@@ -157,9 +158,10 @@ func (p *Packager) Create(baseDir string) error {
 
 		doPull := func() error {
 			imgConfig := images.ImgConfig{
-				ImagesPath: p.tmp.Images,
-				ImgList:    imgList,
-				Insecure:   config.CommonOptions.Insecure,
+				ImagesPath:    p.tmp.Images,
+				ImgList:       imgList,
+				Insecure:      config.CommonOptions.Insecure,
+				Architectures: []string{p.cfg.Pkg.Metadata.Architecture, p.cfg.Pkg.Build.Architecture},
 			}
 
 			return imgConfig.PullAll()

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -387,11 +387,12 @@ func (p *Packager) pushImagesToRegistry(componentImages []string, noImgChecksum 
 	}
 
 	imgConfig := images.ImgConfig{
-		ImagesPath: p.tmp.Images,
-		ImgList:    componentImages,
-		NoChecksum: noImgChecksum,
-		RegInfo:    p.cfg.State.RegistryInfo,
-		Insecure:   config.CommonOptions.Insecure,
+		ImagesPath:    p.tmp.Images,
+		ImgList:       componentImages,
+		NoChecksum:    noImgChecksum,
+		RegInfo:       p.cfg.State.RegistryInfo,
+		Insecure:      config.CommonOptions.Insecure,
+		Architectures: []string{p.cfg.Pkg.Metadata.Architecture, p.cfg.Pkg.Build.Architecture},
 	}
 
 	return utils.Retry(func() error {


### PR DESCRIPTION
## Description

This ensures that ImgConfigs always carry their architecture down to Crane.

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
