### PR TITLE
Fix root command help printing

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -48,18 +48,17 @@ var rootCmd = &cobra.Command{
 	Long:  lang.RootCmdLong,
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		zarfLogo := message.GetLogo()
+		_, _ = fmt.Fprintln(os.Stderr, zarfLogo)
+		cmd.Help()
+
 		if len(args) > 0 {
-			pterm.Println()
 			if strings.Contains(args[0], config.ZarfPackagePrefix) || strings.Contains(args[0], "zarf-init") {
-				pterm.FgYellow.Printfln(lang.RootCmdDeprecatedDeploy, args[0])
+				pterm.FgYellow.Printfln("\n"+lang.RootCmdDeprecatedDeploy, args[0])
 			}
 			if args[0] == config.ZarfYAML {
-				pterm.FgYellow.Printfln(lang.RootCmdDeprecatedCreate)
+				pterm.FgYellow.Printfln("\n" + lang.RootCmdDeprecatedCreate)
 			}
-		} else {
-			zarfLogo := message.GetLogo()
-			_, _ = fmt.Fprintln(os.Stderr, zarfLogo)
-			cmd.Help()
 		}
 	},
 }


### PR DESCRIPTION
## Description

This hotfixes the root command to properly display help information when a bad command is entered

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
