### PR TITLE
Increase the timeout for the helm wait test

### DIFF
--- a/src/test/e2e/28_wait_test.go
+++ b/src/test/e2e/28_wait_test.go
@@ -49,7 +49,7 @@ func TestWait(t *testing.T) {
 		stdOut = res.stdOut
 		stdErr = res.stdErr
 		err = res.err
-	case <-time.After(10 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Error("Timeout waiting for zarf deploy (it tried to wait)")
 		t.Log("Removing hanging namespace...")
 		kubectlOut, err := exec.Command("kubectl", "delete", "namespace", "no-wait", "--force=true", "--wait=false", "--grace-period=0").Output()


### PR DESCRIPTION
## Description

Small fix to increase the timeout on our helm wait test

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
