### PR TITLE
Swap Dockerfile base image to Chainguard static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM gcr.io/distroless/static:nonroot
+FROM cgr.dev/chainguard/static:latest
 ARG TARGETARCH
 
 USER nonroot:nonroot
- 
+
 COPY --chown=nonroot:nonroot "build/zarf-linux-$TARGETARCH" /zarf
 
 CMD ["/zarf", "internal", "agent", "-l=trace", "--no-log-file"]


### PR DESCRIPTION
## Description

This switches the Zarf agent base image to Chainguard static.

## Related Issue

Fixes #1539

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
