### PR TITLE
Docs: correct install command

### DIFF
--- a/docs/0-zarf-overview.md
+++ b/docs/0-zarf-overview.md
@@ -171,7 +171,7 @@ For more install options please visit our [Getting Started page](3-getting-start
 
 ```bash
 # To install Zarf
-brew tap defenseunicorns/tap brew install zarf
+brew tap defenseunicorns/tap && brew install zarf
 
 # Next, you will need a Kubernetes cluster. This example uses KIND.
 brew install kind && kind delete cluster && kind create cluster
@@ -209,7 +209,7 @@ For more install options please visit our [Getting Started page](3-getting-start
 
 ```bash
 # To install Zarf
-brew tap defenseunicorns/tap brew install zarf
+brew tap defenseunicorns/tap && brew install zarf
 
 # Next, you will need a Kubernetes cluster. This example uses KIND.
 brew install kind && kind delete cluster && kind create cluster


### PR DESCRIPTION
Small documentation fix.  Without this, the error from `brew tap` is:
```
Error: Invalid usage: This command does not take more than 2 tap arguments.
```
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
