### PR TITLE
No longer explicitly check for deprecated text in the upgrade test

### DIFF
--- a/src/test/upgrade-test/previously_built_test.go
+++ b/src/test/upgrade-test/previously_built_test.go
@@ -35,8 +35,7 @@ func TestPreviouslyBuiltZarfPackage(t *testing.T) {
 	stdOut, stdErr, err := exec.Cmd(zarfBinPath, zarfDeployArgs...)
 	require.NoError(t, err, stdOut, stdErr)
 
-	// [DEPRECATIONS] We expect the older package to contain the deprecations
-	require.Contains(t, stdErr, "Component 'test-upgrade-package' is using setVariable")
+	// [DEPRECATIONS] We expect any deprecated things to work from the old package
 	require.Contains(t, stdErr, "Successfully deployed podinfo 6.3.4")
 	require.Contains(t, stdErr, "-----BEGIN PUBLIC KEY-----")
 
@@ -59,8 +58,7 @@ func TestPreviouslyBuiltZarfPackage(t *testing.T) {
 	stdOut, stdErr, err = exec.Cmd(zarfBinPath, zarfDeployArgs...)
 	require.NoError(t, err, stdOut, stdErr)
 
-	// [DEPRECATIONS] We expect the newer package to have been migrated
-	require.NotContains(t, stdErr, "Component 'test-upgrade-package' is using setVariable")
+	// [DEPRECATIONS] We expect any deprecated things to work from the new package
 	require.Contains(t, stdErr, "Successfully deployed podinfo 6.3.5")
 	require.Contains(t, stdErr, "-----BEGIN PUBLIC KEY-----")
 


### PR DESCRIPTION
## Description

We should not check for deprecated text in the upgrade test.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
