### PR TITLE
Change repo1 to GitHub to reduce CI flakes due to repo1 availability

### DIFF
--- a/examples/git-data/zarf.yaml
+++ b/examples/git-data/zarf.yaml
@@ -31,7 +31,7 @@ components:
     required: true
     repos:
       # Do a branch-provided Git Repo mirror
-      - "https://repo1.dso.mil/big-bang/bigbang.git@refs/heads/release-1.53.x"
+      - "https://github.com/DoD-Platform-One/big-bang.git@refs/heads/release-1.53.x"
 
   - name: specific-hash
     required: true

--- a/src/test/e2e/07_create_git_test.go
+++ b/src/test/e2e/07_create_git_test.go
@@ -57,7 +57,7 @@ func TestCreateGit(t *testing.T) {
 	require.Equal(t, "v0.16.0\n", stdOut)
 
 	// Verify a repo with a branch.
-	gitDirFlag = fmt.Sprintf("--git-dir=%s/components/specific-branch/repos/bigbang-3067531188/.git", extractDir)
+	gitDirFlag = fmt.Sprintf("--git-dir=%s/components/specific-branch/repos/big-bang-2752174810/.git", extractDir)
 	stdOut, stdErr, err = exec.Cmd("git", gitDirFlag, "log", "HEAD^..HEAD", "--oneline", "--decorate")
 	require.NoError(t, err, stdOut, stdErr)
 	require.Contains(t, stdOut, "(HEAD -> release-1.53.x, tag: 1.53.0-rc.1, tag: 1.53.0, online-upstream/release-1.53.x)")


### PR DESCRIPTION
## Description

This changes repo1 to github for the big bang repo in the git data test.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
