### PR TITLE
Officially require 1.54.0 or greater of Big Bang now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,9 @@ test-upgrade: ## Run the Zarf CLI E2E tests for an external registry and cluster
 	cd src/test/upgrade-test && go test -failfast -v -timeout 30m
 
 .PHONY: test-unit
-test-unit: ensure-ui-build-dir ## Run unit tests within the src/pkg directory
+test-unit: ensure-ui-build-dir ## Run unit tests within the src/pkg and the bigbang extension directory
 	cd src/pkg && go test ./... -failfast -v -timeout 30m
+	cd src/extensions/bigbang && go test ./. -failfast -v timeout 30m
 
 .PHONY: test-built-ui
 test-built-ui: ## Run the Zarf UI E2E tests (requires `make build-ui` first)

--- a/docs/13-walkthroughs/5-big-bang.md
+++ b/docs/13-walkthroughs/5-big-bang.md
@@ -110,7 +110,7 @@ The `valuesFiles` are applied from top to bottom and will apply the last value t
 
 :::note
 
-This extension works best with Big Bang version `1.54.0` or later.  Version `1.53.0` requires manual patches to images to function correctly.
+This extension requires Big Bang version `1.54.0` or later.
 
 :::
 

--- a/examples/git-data/README.md
+++ b/examples/git-data/README.md
@@ -28,7 +28,7 @@ A SHA-based clone only mirrors the SHA hash defined in the Zarf definition. The 
 
 ## Git Reference-Based Git Repository Clone
 
-If you need even more control, Zarf also supports providing full `git` [refspecs](https://git-scm.com/book/en/v2/Git-Internals-The-Refspec), as seen in `https://repo1.dso.mil/big-bang/bigbang.git@refs/heads/release-1.53.x`.  This allows you to pull specific tags or branches by using this standard.  The branch name used by zarf on deploy will depend on the kind of ref specified, branches will use the upstream branch name, whereas other refs (namely tags) will use the `zarf-ref-*` branch name.
+If you need even more control, Zarf also supports providing full `git` [refspecs](https://git-scm.com/book/en/v2/Git-Internals-The-Refspec), as seen in `https://repo1.dso.mil/big-bang/bigbang.git@refs/heads/release-1.54.x`.  This allows you to pull specific tags or branches by using this standard.  The branch name used by zarf on deploy will depend on the kind of ref specified, branches will use the upstream branch name, whereas other refs (namely tags) will use the `zarf-ref-*` branch name.
 
 ## Git Repository Full Clone
 

--- a/examples/git-data/zarf.yaml
+++ b/examples/git-data/zarf.yaml
@@ -31,7 +31,7 @@ components:
     required: true
     repos:
       # Do a branch-provided Git Repo mirror
-      - "https://github.com/DoD-Platform-One/big-bang.git@refs/heads/release-1.53.x"
+      - "https://github.com/DoD-Platform-One/big-bang.git@refs/heads/release-1.54.x"
 
   - name: specific-hash
     required: true

--- a/src/extensions/bigbang/bigbang.go
+++ b/src/extensions/bigbang/bigbang.go
@@ -240,7 +240,7 @@ func isValidVersion(version string) bool {
 	minor, _ := strconv.Atoi(parts[1])
 
 	// This extension requires BB 1.54.0 or greater.
-	return major >= 1 && minor >= 54
+	return major == 1 && minor >= 54 || major > 2
 }
 
 // findBBResources takes a list of yaml objects (as a string) and

--- a/src/extensions/bigbang/bigbang.go
+++ b/src/extensions/bigbang/bigbang.go
@@ -142,7 +142,7 @@ func Run(tmpPaths types.ComponentPaths, c types.ZarfComponent) (types.ZarfCompon
 		}
 
 		// In Big Bang the metrics-server is a special case that only deploy if needed.
-		// The check it, we need to look for the APIService to exist instead of the HelmRelease, which
+		// The check it, we need to look for the existence of APIService instead of the HelmRelease, which
 		// may not ever be created. See links below for more details.
 		// https://repo1.dso.mil/big-bang/bigbang/-/blob/1.54.0/chart/templates/metrics-server/helmrelease.yaml
 		if hr.Metadata.Name == "metrics-server" {

--- a/src/extensions/bigbang/bigbang.go
+++ b/src/extensions/bigbang/bigbang.go
@@ -45,7 +45,7 @@ func Run(tmpPaths types.ComponentPaths, c types.ZarfComponent) (types.ZarfCompon
 
 	// Make sure the version is valid.
 	if !isValidVersion(cfg.Version) {
-		return c, fmt.Errorf("invalid Big Bang version: %s, must be at least 1.53.0", cfg.Version)
+		return c, fmt.Errorf("invalid Big Bang version: %s, must be at least 1.54.0", cfg.Version)
 	}
 
 	// Print the banner for Big Bang.
@@ -142,9 +142,9 @@ func Run(tmpPaths types.ComponentPaths, c types.ZarfComponent) (types.ZarfCompon
 		}
 
 		// In Big Bang the metrics-server is a special case that only deploy if needed.
-		// The check it, we need to look for the APIService to be exist instead of the HelmRelease, which
+		// The check it, we need to look for the APIService to exist instead of the HelmRelease, which
 		// may not ever be created. See links below for more details.
-		// https://repo1.dso.mil/big-bang/bigbang/-/blob/1.53.0/chart/templates/metrics-server/helmrelease.yaml
+		// https://repo1.dso.mil/big-bang/bigbang/-/blob/1.54.0/chart/templates/metrics-server/helmrelease.yaml
 		if hr.Metadata.Name == "metrics-server" {
 			action.Description = "K8s metric server to exist or be deployed by Big Bang"
 			action.Wait.Cluster = &types.ZarfComponentActionWaitCluster{
@@ -226,7 +226,7 @@ func Run(tmpPaths types.ComponentPaths, c types.ZarfComponent) (types.ZarfCompon
 	return c, nil
 }
 
-// isValidVersion check if the version is 1.53.0 or greater.
+// isValidVersion check if the version is 1.54.0 or greater.
 func isValidVersion(version string) bool {
 	// Split the version string into its major, minor, and patch components
 	parts := strings.Split(version, ".")

--- a/src/extensions/bigbang/bigbang.go
+++ b/src/extensions/bigbang/bigbang.go
@@ -239,9 +239,8 @@ func isValidVersion(version string) bool {
 	major, _ := strconv.Atoi(parts[0])
 	minor, _ := strconv.Atoi(parts[1])
 
-	// This extension requires BB 1.53.0 or greater.
-	// @todo: This should be updated to 1.54.0 when 1.55.0 is released.
-	return major >= 1 && minor >= 53
+	// This extension requires BB 1.54.0 or greater.
+	return major >= 1 && minor >= 54
 }
 
 // findBBResources takes a list of yaml objects (as a string) and

--- a/src/extensions/bigbang/bigbang_test.go
+++ b/src/extensions/bigbang/bigbang_test.go
@@ -1,0 +1,31 @@
+package bigbang
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRequiredBigBangVersions(t *testing.T) {
+	// Support 1.54.0 and beyond
+	err, vv := isValidVersion("1.54.0")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, vv, true)
+
+	// Do not support earlier than 1.54.0
+	err, vv = isValidVersion("1.53.0")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, vv, false)
+
+	// Support for Big Bang release candidates
+	err, vv = isValidVersion("1.57.0-rc.0")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, vv, true)
+
+	// Fail on non-semantic versions
+	err, vv = isValidVersion("1.57")
+	Expected := "No Major.Minor.Patch elements found"
+	if err.Error() != Expected {
+		t.Errorf("Error actual = %v, and Expected = %v.", err, Expected)
+	}
+	assert.Equal(t, vv, false)
+}

--- a/src/extensions/bigbang/bigbang_test.go
+++ b/src/extensions/bigbang/bigbang_test.go
@@ -21,9 +21,14 @@ func TestRequiredBigBangVersions(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, vv, true)
 
+	// Support for Big Bang 2.0.0
+	err, vv = isValidVersion("2.0.0")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, vv, true)
+
 	// Fail on non-semantic versions
-	err, vv = isValidVersion("1.57")
-	Expected := "No Major.Minor.Patch elements found"
+	err, vv = isValidVersion("1.57b")
+	Expected := "Invalid Semantic Version"
 	if err.Error() != Expected {
 		t.Errorf("Error actual = %v, and Expected = %v.", err, Expected)
 	}

--- a/src/test/e2e/07_create_git_test.go
+++ b/src/test/e2e/07_create_git_test.go
@@ -57,15 +57,15 @@ func TestCreateGit(t *testing.T) {
 	require.Equal(t, "v0.16.0\n", stdOut)
 
 	// Verify a repo with a branch.
-	gitDirFlag = fmt.Sprintf("--git-dir=%s/components/specific-branch/repos/big-bang-2752174810/.git", extractDir)
+	gitDirFlag = fmt.Sprintf("--git-dir=%s/components/specific-branch/repos/big-bang-2705706079/.git", extractDir)
 	stdOut, stdErr, err = exec.Cmd("git", gitDirFlag, "log", "HEAD^..HEAD", "--oneline", "--decorate")
 	require.NoError(t, err, stdOut, stdErr)
-	require.Contains(t, stdOut, "(HEAD -> release-1.53.x, tag: 1.53.0-rc.1, tag: 1.53.0, online-upstream/release-1.53.x)")
+	require.Contains(t, stdOut, "(HEAD -> release-1.54.x, tag: 1.54.0-rc.0, tag: 1.54.0, online-upstream/release-1.54.x)")
 
 	// Verify a repo with a branch only has one branch.
 	stdOut, stdErr, err = exec.Cmd("git", gitDirFlag, "branch")
 	require.NoError(t, err, stdOut, stdErr)
-	require.Equal(t, "* release-1.53.x\n", stdOut)
+	require.Equal(t, "* release-1.54.x\n", stdOut)
 
 	// Verify a repo with a commit hash.
 	gitDirFlag = fmt.Sprintf("--git-dir=%s/components/specific-hash/repos/zarf-1356873667/.git", extractDir)


### PR DESCRIPTION
## Description

This makes the requirement for the `bigbang` component officially 1.54.0 or greater.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
