### PR TITLE
docs edits to "Understanding Zarf Components" page

### DIFF
--- a/docs/4-user-guide/2-zarf-packages/2-zarf-components.md
+++ b/docs/4-user-guide/2-zarf-packages/2-zarf-components.md
@@ -4,23 +4,23 @@ sidebar_position: 2
 
 # Understanding Zarf Components
 
-The actual capabilities that Zarf Packages provided are defined within named components. These components define what dependencies they have and a declarative definition of how they should be deployed. Each package can have as many components as the package creator wants but a package isn't anything without at least one component.
+The capabilities that Zarf Packages provide are defined within named components. These components define their required dependencies and provide a declarative definition for how they should be deployed. Although a package creator may include multiple components in their package, it is essential to have at least one component for a package to exist.
 
-Components can define a wide range of resources that it needs when the package it is a part of gets deployed. The schema for the components is linked below but a high-level look at the things components can define includes:
+Components can define a wide range of resources necessary for package deployment. The schema for the components is accessible via the [Zarf Component Schema](../3-zarf-schema.md#components) page. Some examples of the types of resources that a component can define are:
 
-* Files to move onto the host
-* Helm charts to install into the running k8s cluster
-* Raw Kubernetes manifests to deploy (by getting converted into zarf-generated helm charts and installed)
-* Container images to push into the registry the init-package created in the k8s cluster
-* Git repositories to push into the git server the init-package created in the k8s cluster
-* Data to push into a resource (i.e. a pod) in the k8s cluster
-* Scripts to run before/after the component is deployed
+* Files to move onto the host.
+* Helm charts to install into the running K8s cluster.
+* Raw Kubernetes manifests to deploy (by getting converted into zarf-generated helm charts and installed).
+* Container images to push into the registry the init-package created in the K8s cluster.
+* Git repositories to push into the git server the init-package created in the K8s cluster.
+* Data to push into a resource (i.e. a pod) in the K8s cluster.
+* Scripts to run before/after the component is deployed.
 
-### Deploying a component
+### Deploying a Component
 
-When deploying a Zarf package, the **components within a package are deployed in the order they are defined in the `zarf.yaml` that the package was created from.** The `zarf.yaml` configuration for each component also defines whether the component is 'required' or not. 'Required' components are always deployed without any additional user interaction whenever the package is deployed while optional components are printed out in an interactive prompt to the user asking if they wish to the deploy the component.
+When you deploy a Zarf Package, the **components inside it are deployed in the order specified in the `zarf.yaml` file used to create the package.** Each component in the `zarf.yaml` configuration file is marked as either required or optional. Required components are deployed automatically without any user input when the package is deployed. Optional components are printed out in an interactive prompt, allowing you to choose whether or not to deploy them.
 
- If you already know which components you want to deploy, you can do so without getting prompted by passing the components as a comma-separated list to the `--components` flag during the deploy command. (ex. `zarf package deploy ./path/to/package.tar.zst --components=optional-component-1,optional-component-2`)
+If you know which components you want to deploy, you can avoid getting prompted by specifying them as a comma-separated list to the  `--components` flag when executing the deploy command. For instance, you can enter `zarf package deploy ./path/to/package.tar.zst --components=optional-component-1,optional-component-2` to deploy those specific components.
 
 ## Composing Package Components
 
@@ -33,7 +33,7 @@ components:
      path: 'path/to/flux/package/directory/'
 ```
 
-Unless you specify the component name in the import field, Zarf will try to import a component from the specified path that has the same name as the new component that is currently being defined. In the example above, since the new component is named 'flux' Zarf will import the 'flux' component from the specified path. If the new component is going to have a different name, you can specify the name of the package that needs to be imported in the import field.
+If you don't specify the component name in the import field, Zarf will attempt to import a component with the same name as the one currently being defined from the specified path. In the example above, since the new component is called 'flux', Zarf will import the 'flux' component from the specified path. However, if you plan to give the new component a different name, you can specify the name of the package that needs to be imported in the import field.
 
 ```yaml
 components:
@@ -43,10 +43,13 @@ components:
      name: flux-v1.0.0
 ```
 
-> Note: When importing a component, Zarf will copy all of the values from the original component except for the `required` key. In addition, while Zarf will copy the values, you have the ability to override the value for the `description` key.
+:::note
+When importing a component, Zarf will copy all of the values from the original component except for the `required` key. In addition, while Zarf will copy the values, you have the ability to override the value for the `description` key.
 
- Checkout the [composable-packages](https://github.com/defenseunicorns/zarf/blob/master/examples/composable-packages/zarf.yaml) example to see this in action.
+See the [composable-packages](https://github.com/defenseunicorns/zarf/blob/master/examples/composable-packages/zarf.yaml) example to see this in action.
+:::
 
-## What Makes Up A Component
 
-Zarf components can contain different key/value pairs which you can learn more about here under the `components` section: [ZarfComponent Schema Docs](../3-zarf-schema.md#components)
+## What Makes up a Component
+
+Zarf components can contain different key/value pairs, which you can learn more about under the `components` section on the [Zarf Component Schema](../3-zarf-schema.md#components) page.


### PR DESCRIPTION
## Description
Documentation does not reflect the editorial guidelines outlined in the Project Style Guide. Editing the "Understanding Zarf Components" page to align with the updated Style Guide to improve readability for users.

- Improve the language to reflect a more professional tone
- Capitalize K8s
- Punctuate list
- Fix headings to align with style guide
- Edit link at the bottom of the page
- Include Zarf Schema link towards the top of page

## Related Issue

Fixes #1560 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
