### PR TITLE
Add a max metadata size to not error on some package pulls

### DIFF
--- a/src/pkg/packager/network.go
+++ b/src/pkg/packager/network.go
@@ -181,6 +181,7 @@ func (p *Packager) handleOciPackage() error {
 		return nil
 	}
 	copyOpts.PostCopy = copyOpts.OnCopySkipped
+	copyOpts.MaxMetadataBytes = 12 * 1024 * 1024
 
 	_, err = oras.Copy(src.Context, src.Repository, ref.Reference, dst, ref.Reference, copyOpts)
 	if err != nil {


### PR DESCRIPTION
## Description

This hotfixes a potential issue where metadata exceeds the default maxmetadata size in oras.

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
