### PR TITLE
docs edits to "The Zarf init Package" page

### DIFF
--- a/docs/4-user-guide/2-zarf-packages/3-the-zarf-init-package.md
+++ b/docs/4-user-guide/2-zarf-packages/3-the-zarf-init-package.md
@@ -4,13 +4,14 @@ sidebar_position: 3
 
 # The Zarf 'init' Package
 
-The init package is the `zarf.yaml` file that lives at the [root of the Zarf repository](https://github.com/defenseunicorns/zarf/blob/main/zarf.yaml). It is defined via composed components that all offer value for future packages to utilize. When the init package is deployed, it will create a `zarf` namespace within your k8s cluster and deploy various pods, services, and secrets to that namespace, depending on which optional components you choose to deploy.
+The init package is the `zarf.yaml` file that lives at the [root of the Zarf repository](https://github.com/defenseunicorns/zarf/blob/main/zarf.yaml).
+It is defined by composed components which provide a foundation for future packages to utilize. Upon deployment, the init package generates a `zarf` namespace within your K8s cluster and deploys pods, services, and secrets to that namespace based on the optional components selected for deployment.
 
 ## Mandatory Components
 
-Zarf's work necessitates that some components in the [init package](https://github.com/defenseunicorns/zarf/blob/main/zarf.yaml) are "always on" (a.k.a. required & cannot be disabled). These components are always deployed whenever you perform a `zarf init` command. Those include:
+Zarf's capabilities require certain components of the init package to be constantly active, meaning that they cannot be disabled and are always on. These components are automatically deployed whenever a `zarf init` command is executed. These components include:
 
-|                         | Description                                                                                                          |
+| Components              | Description                                                                                                          |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | zarf-injector           | Adds a Rust and Go binary to the working directory to use during the registry bootstrapping.
 | container-registry-seed | Adds a container registry so Zarf can bootstrap itself into the cluster.                                             |
@@ -18,22 +19,26 @@ Zarf's work necessitates that some components in the [init package](https://gith
 
 ## Additional Components
 
-In addition to those that are always installed, Zarf's optional components provide additional functionality and can be enabled as & when you need them.
+In addition to required components, Zarf also offers optional components that provide additional functionality and can be enabled as needed. 
 
-These optional components for the init package are listed below along with the "magic strings" you pass to `zarf init --components` to pull them in:
+Below are the optional components available for the init package, along with their respective "magic strings" that can be passed to `zarf init --components` to pull them in:
 
-| components   | Description                                                                                                                                                       |
+| Components   | Description                                                                                                                                                       |
 | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| k3s          | REQUIRES ROOT. Installs a lightweight Kubernetes Cluster on the local host&mdash;[k3s](https://k3s.io/)&mdash;and configures it to start up on boot.                             |
-| logging      | Adds a log monitoring stack&mdash;[promtail / loki / graphana (a.k.a. PLG)](https://github.com/grafana/loki)&mdash;into the cluster.                              |
+| k3s          | REQUIRES ROOT. Installs a lightweight Kubernetes Cluster on the local host&mdash;[K3s](https://k3s.io/)&mdash;and configures it to start up on boot.                             |
+| logging      | Adds a log monitoring stack&mdash;[promtail/loki/graphana (aka PLG)](https://github.com/grafana/loki)&mdash;into the cluster.                              |
 | git-server   | Adds a [GitOps](https://www.cloudbees.com/gitops/what-is-gitops)-compatible source control service&mdash;[Gitea](https://gitea.io/en-us/)&mdash;into the cluster. |
 
-There are two ways to deploy optional components, you can either pass a comma separated list of components to the `--components` flag such as `zarf init --components k3s,git-server --confirm` or you can exclude the flags and say yes/no as each optional component gets prompted to you.
+There are two ways to deploy optional components. Firstly, you can provide a comma-separated list of components to the `--components` flag, such as `zarf init --components k3s,git-server --confirm`. Alternatively, you can choose to exclude the flags and respond with a yes or no for each optional component when prompted
 
-> Note: The 'k3s' component requires root access when deploying as it will modify your host machine to install the cluster.
+:::note
+
+Deploying the 'k3s' component will require root access, as it modifies your host machine to install the cluster.
+ 
+:::
 
 ## What Makes the Init Package Special
 
-Deploying onto air-gapped environments is a [hard problem](../../1-understand-the-basics.md#what-is-the-air-gap), especially when the k8s environment you're deploying to doesn't have a container registry running for you to put your images into. This leads to a classic 'chicken or the egg' problem since the container registry image needs to make its way into the cluster but there is no container registry running on the cluster to push to yet because the image isn't in the cluster yet. To remain distro agnostic, we had to come up with a unique solution to seed the container registry into the cluster.
+Deploying onto air-gapped environments is a [hard problem](../../1-understand-the-basics.md#what-is-the-air-gap), particularly when the K8s environment doesn't have a container registry for you to store images. This results in a dilemma where the container registry image must be introduced to the cluster, but there is no container registry to push it to as the image is not yet in the cluster. To ensure that our approach is distro-agnostic, we developed a distinct solution to seed the container registry into the cluster.
 
-The `zarf-injector` [component](https://github.com/defenseunicorns/zarf/blob/main/packages/zarf-injector/zarf.yaml) within the init-package solves this problem by injecting a single rust binary (statically compiled) and a series of configmap chunks of a `registry:2` image into an ephemeral pod based on an existing image in the cluster.
+To address this problem, we use the `zarf-injector` [component](https://github.com/defenseunicorns/zarf/blob/main/packages/zarf-injector/zarf.yaml) within the init-package. This resolves the issue by injecting a single rust binary (statically compiled) and a series of configmap chunks of a `registry:2` image into a ephemeral pod that is based on an existing image in the cluster.


### PR DESCRIPTION
## Description
Documentation does not reflect the editorial guidelines outlined in the Project Style Guide. Editing the "The Zarf init Package" page to align with the updated Style Guide to improve readability for users.

- Improve the language to reflect a more professional tone
- Capitalize K8s/K3s (Did not capitalize in the components table as that is the accurate component title) 
- Remove '&'
- Remove metaphorical language
- Add 'note' admonition

## Related Issue

Fixes #1572 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
