### PR TITLE
Fix README setup-zarf link and brew install commands on overview (combination of #1542 and #1543)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To try Zarf out for yourself, visit the ["Try It Now"](https://zarf.dev/install)
 
 From the docs you can learn more about [installation](https://docs.zarf.dev/docs/operator-manual/set-up-and-install), [using the CLI](https://docs.zarf.dev/docs/user-guide/the-zarf-cli/), [making packages](https://docs.zarf.dev/docs/user-guide/zarf-packages/), and the [Zarf package schema](https://docs.zarf.dev/docs/user-guide/zarf-schema).
 
-Using Zarf in Github workflows? Check out the [setup-zarf](https://github.com/defenseunicorns/setup-zarf)](https://github.com/defenseunicorns/setup-zarf) action. Install any version of Zarf and its `init` package with zero added dependencies.
+Using Zarf in Github workflows? Check out the [setup-zarf](https://github.com/defenseunicorns/setup-zarf) action. Install any version of Zarf and its `init` package with zero added dependencies.
 
 ## Developing
 

--- a/docs/0-zarf-overview.md
+++ b/docs/0-zarf-overview.md
@@ -81,7 +81,7 @@ Zarf can pull from various places like Docker Hub, Iron Bank, GitHub, and local 
 
 ### (1) Create a Package
 
-This part of the process requires access to the internet. The `zarf` binary is presented with a `zarf.yaml`, it then begins downloading, packing, and compressing the software that you requested. It then outputs a single, ready-to-move distributable called "a package". 
+This part of the process requires access to the internet. The `zarf` binary is presented with a `zarf.yaml`, it then begins downloading, packing, and compressing the software that you requested. It then outputs a single, ready-to-move distributable called "a package".
 
 For additional information, see the [Building a package](./13-walkthroughs/0-using-zarf-package-create.md) section.
 
@@ -162,7 +162,7 @@ This quick start requires you to already have:
 
 - [Homebrew](https://brew.sh/) package manager installed on your machine.
 - [Docker](https://www.docker.com/) installed and running on your machine.
-  
+
 For more install options please visit our [Getting Started page](3-getting-started.md).
 
 </Admonition>
@@ -171,7 +171,7 @@ For more install options please visit our [Getting Started page](3-getting-start
 
 ```bash
 # To install Zarf
-brew tap defenseunicorns/tap brew install zarf
+brew tap defenseunicorns/tap && brew install zarf
 
 # Next, you will need a Kubernetes cluster. This example uses KIND.
 brew install kind && kind delete cluster && kind create cluster
@@ -200,7 +200,7 @@ This quick start requires you to already have:
 
 - [Homebrew](https://brew.sh/) package manager installed on your machine.
 - [Docker](https://www.docker.com/) installed and running on your machine.
-  
+
 For more install options please visit our [Getting Started page](3-getting-started.md).
 
 </Admonition>
@@ -209,7 +209,7 @@ For more install options please visit our [Getting Started page](3-getting-start
 
 ```bash
 # To install Zarf
-brew tap defenseunicorns/tap brew install zarf
+brew tap defenseunicorns/tap && brew install zarf
 
 # Next, you will need a Kubernetes cluster. This example uses KIND.
 brew install kind && kind delete cluster && kind create cluster


### PR DESCRIPTION
## Description

Fix README setup-zarf link and brew install commands on overview (combination of #1542 and #1543)

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
