### PR TITLE
Update --confirm flag description for init and package deploy cmd

### DIFF
--- a/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_init.md
+++ b/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_init.md
@@ -48,7 +48,7 @@ zarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-ur
       --artifact-push-username string   Username to access to the artifact registry Zarf is configured to use. User must be able to upload package artifacts.
       --artifact-url string             External artifact registry url to use for this Zarf cluster
       --components string               Specify which optional components to install.  E.g. --components=git-server,logging
-      --confirm                         Confirm the install without prompting
+      --confirm                         Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes.
       --git-pull-password string        Password for the pull-only user to access the git server
       --git-pull-username string        Username for pull-only access to the git server
       --git-push-password string        Password for the push-user to access the git server

--- a/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_package_deploy.md
+++ b/docs/4-user-guide/1-the-zarf-cli/100-cli-commands/zarf_package_deploy.md
@@ -15,7 +15,7 @@ zarf package deploy [PACKAGE] [flags]
 
 ```
       --components string     Comma-separated list of components to install.  Adding this flag will skip the init prompts for which components to install
-      --confirm               Confirm package deployment without prompting
+      --confirm               Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes.
   -h, --help                  help for deploy
   -k, --key string            Path to public key file for validating signed packages
       --oci-concurrency int   Number of concurrent layer operations to perform when interacting with a remote package. (default 3)

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -132,7 +132,7 @@ zarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-ur
 
 	CmdInitFlagSet = "Specify deployment variables to set on the command line (KEY=value)"
 
-	CmdInitFlagConfirm      = "Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, and select optional components. May introduce breaking changes."
+	CmdInitFlagConfirm      = "Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes."
 	CmdInitFlagComponents   = "Specify which optional components to install.  E.g. --components=git-server,logging"
 	CmdInitFlagStorageClass = "Specify the storage class to use for the registry.  E.g. --storage-class=standard"
 
@@ -215,7 +215,7 @@ zarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-ur
 	CmdPackageCreateFlagSigningKey         = "Path to private key file for signing packages"
 	CmdPackageCreateFlagSigningKeyPassword = "Password to the private key file used for signing packages"
 
-	CmdPackageDeployFlagConfirm    = "Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, and select optional components. May introduce breaking changes."
+	CmdPackageDeployFlagConfirm    = "Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes."
 	CmdPackageDeployFlagSet        = "Specify deployment variables to set on the command line (KEY=value)"
 	CmdPackageDeployFlagComponents = "Comma-separated list of components to install.  Adding this flag will skip the init prompts for which components to install"
 	CmdPackageDeployFlagShasum     = "Shasum of the package to deploy. Required if deploying a remote package and \"--insecure\" is not provided"

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -132,7 +132,7 @@ zarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-ur
 
 	CmdInitFlagSet = "Specify deployment variables to set on the command line (KEY=value)"
 
-	CmdInitFlagConfirm      = "Confirm the install without prompting"
+	CmdInitFlagConfirm      = "Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, and select optional components. May introduce breaking changes."
 	CmdInitFlagComponents   = "Specify which optional components to install.  E.g. --components=git-server,logging"
 	CmdInitFlagStorageClass = "Specify the storage class to use for the registry.  E.g. --storage-class=standard"
 
@@ -215,7 +215,7 @@ zarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-ur
 	CmdPackageCreateFlagSigningKey         = "Path to private key file for signing packages"
 	CmdPackageCreateFlagSigningKeyPassword = "Password to the private key file used for signing packages"
 
-	CmdPackageDeployFlagConfirm    = "Confirm package deployment without prompting"
+	CmdPackageDeployFlagConfirm    = "Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, and select optional components. May introduce breaking changes."
 	CmdPackageDeployFlagSet        = "Specify deployment variables to set on the command line (KEY=value)"
 	CmdPackageDeployFlagComponents = "Comma-separated list of components to install.  Adding this flag will skip the init prompts for which components to install"
 	CmdPackageDeployFlagShasum     = "Shasum of the package to deploy. Required if deploying a remote package and \"--insecure\" is not provided"


### PR DESCRIPTION
## Description

Current Command descriptions are not specific to the consequences that command may have including 

 Skips prompts to review SBOM
configure variables
select optional components 
review potential breaking changes.

Adds warning and more specific language to flag 

Updated to 
--Confirm  - Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes.
...

## Related Issue

Relates to #1600 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
