### PR TITLE
Big Bang 2.0 support

### DIFF
--- a/examples/big-bang/config/disable-all.yaml
+++ b/examples/big-bang/config/disable-all.yaml
@@ -2,7 +2,7 @@
 istio:
   enabled: false
 
-istiooperator:
+istioOperator:
   enabled: false
 
 jaeger:
@@ -20,16 +20,16 @@ gatekeeper:
 kyverno:
   enabled: false
 
-kyvernopolicies:
+kyvernoPolicies:
   enabled: false
 
-kyvernoreporter:
+kyvernoReporter:
   enabled: false
 
-logging:
+elasticsearchKibana:
   enabled: false
 
-eckoperator:
+eckOperator:
   enabled: false
 
 fluentbit:

--- a/examples/big-bang/config/kyverno.yaml
+++ b/examples/big-bang/config/kyverno.yaml
@@ -5,7 +5,7 @@ clusterAuditor:
   enabled: false
 kyverno:
   enabled: true
-kyvernopolicies:
+kyvernoPolicies:
   enabled: true
   values:
     policies:

--- a/examples/big-bang/config/loki.yaml
+++ b/examples/big-bang/config/loki.yaml
@@ -1,13 +1,13 @@
 # Use Loki instead of EFK
-logging:
+elasticsearchKibana:
   enabled: false
 
-eckoperator:
+eckOperator:
   enabled: false
 
 fluentbit:
   enabled: false
-  
+
 loki:
   enabled: true
 

--- a/examples/big-bang/zarf.yaml
+++ b/examples/big-bang/zarf.yaml
@@ -3,7 +3,7 @@ metadata:
   name: big-bang-example
   description: "Deploy Big Bang Core"
   # renovate: datasource=gitlab-releases depName=big-bang/bigbang versioning=semver registryUrl=https://repo1.dso.mil/
-  version: 1.57.1
+  version: 2.0.0
   url: https://p1.dso.mil/products/big-bang
   # Big Bang / Iron Bank are only amd64
   architecture: amd64
@@ -19,7 +19,7 @@ components:
     extensions:
       bigbang:
         # renovate: datasource=gitlab-releases depName=big-bang/bigbang versioning=semver registryUrl=https://repo1.dso.mil/
-        version: 1.57.1
+        version: 2.0.0
         valuesFiles:
           # Istio configs
           - config/ingress.yaml

--- a/src/extensions/bigbang/manifests.go
+++ b/src/extensions/bigbang/manifests.go
@@ -42,7 +42,7 @@ git:
   # -- HTTP git credentials, both username and password must be provided
     username: "###ZARF_GIT_PUSH###"
     password: "###ZARF_GIT_AUTH_PUSH###"
-kyvernopolicies:
+kyvernoPolicies:
   values:
     exclude:
       any:

--- a/src/extensions/bigbang/test/package/disable-all.yaml
+++ b/src/extensions/bigbang/test/package/disable-all.yaml
@@ -2,7 +2,7 @@
 istio:
   enabled: false
 
-istiooperator:
+istioOperator:
   enabled: false
 
 jaeger:
@@ -20,16 +20,16 @@ gatekeeper:
 kyverno:
   enabled: false
 
-kyvernopolicies:
+kyvernoPolicies:
   enabled: false
 
-kyvernoreporter:
+kyvernoReporter:
   enabled: false
 
-logging:
+elasticsearchKibana:
   enabled: false
 
-eckoperator:
+eckOperator:
   enabled: false
 
 fluentbit:


### PR DESCRIPTION
## Description

This adds support for Big Bang 2.0.0 (which was released today, Thursday April 20, 2023), and is backward compatible.  

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
