### PR TITLE
Fixes an issue where specifying repo for Big Bang extension fails

### DIFF
--- a/src/extensions/bigbang/flux.go
+++ b/src/extensions/bigbang/flux.go
@@ -42,7 +42,12 @@ func (h HelmReleaseDependency) Dependencies() []string {
 // getFlux Creates a component to deploy Flux.
 func getFlux(baseDir string, cfg *extensions.BigBang) (manifest types.ZarfManifest, images []string, err error) {
 	localPath := path.Join(baseDir, "bb-ext-flux.yaml")
-	remotePath := fmt.Sprintf("%s//base/flux?ref=%s", bbRepo, cfg.Version)
+
+	if cfg.Repo == "" {
+		cfg.Repo = bbRepo
+	}
+
+	remotePath := fmt.Sprintf("%s//base/flux?ref=%s", cfg.Repo, cfg.Version)
 
 	// Perform Kustomzation now to get the flux.yaml file.
 	if err := kustomize.BuildKustomization(remotePath, localPath, true); err != nil {


### PR DESCRIPTION
## Description

This fixes an issue where when specifying a `repo` in the Big Bang extension (during `zarf package create`, causes a packaging related error.

```shell
ERROR:  Failed to create package: unable to process extensions: unable to process bigbang extension: unable to build kustomization: git cmd = '/usr/local/bin/git fetch --depth=1 origin 2.0.0-beta2': exit status 128
```

Here is a yaml snippet example for `zarf.yaml` that reproduces this error.

```yaml
kind: ZarfPackageConfig
metadata:
  name: big-bang-example
  description: "Deploy Big Bang Core"
  version: 2.0.0-beta2
  url: https://p1.dso.mil/products/big-bang
  # Big Bang / Iron Bank are only amd64
  architecture: amd64

variables:
  - name: DOMAIN
    default: "bigbang.dev"
    prompt: false

components:
  - name: bigbang
    required: true
    extensions:
      bigbang:
        repo: https://github.com/radiusmethod/bigbang.git
        version: 2.0.0-beta2
        valuesFiles:
          # Istio configs
...
```

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
