### PR TITLE
Fix unpacking sboms issue from older Zarf packages

### DIFF
--- a/src/pkg/packager/inspect.go
+++ b/src/pkg/packager/inspect.go
@@ -73,10 +73,12 @@ func (p *Packager) Inspect(includeSBOM bool, outputSBOM string, inspectPublicKey
 
 	if includeSBOM || outputSBOM != "" {
 		// Extract the SBOM files from the sboms.tar file
-		if err := archiver.Unarchive(p.tmp.SbomTar, p.tmp.Sboms); err != nil {
-			return fmt.Errorf("unable to extract the SBOM files: %w", err)
+		_, tarErr := os.Stat(p.tmp.SbomTar)
+		if tarErr == nil {
+			if err := archiver.Unarchive(p.tmp.SbomTar, p.tmp.Sboms); err != nil {
+				return fmt.Errorf("unable to extract the SBOM files: %w", err)
+			}
 		}
-
 	}
 
 	// Open a browser to view the SBOM if specified


### PR DESCRIPTION
## Description

This fixes an issue where SBOMs from older packages are not unpacked correctly.

## Related Issue

Fixes #1610

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
