### PR TITLE
Fix: Failing Big Bang 2.0 Deployments

### DIFF
--- a/src/extensions/bigbang/manifests.go
+++ b/src/extensions/bigbang/manifests.go
@@ -67,7 +67,7 @@ func manifestZarfCredentials(version string) corev1.Secret {
 	values := bbV1ZarfCredentialsValues
 
 	semverVersion, err := semver.NewVersion(version)
-	if err != nil && semverVersion.Major() == 2 {
+	if err == nil && semverVersion.Major() == 2 {
 		values = bbV2ZarfCredentialsValues
 	}
 


### PR DESCRIPTION
## Description

It appears that there is a mistake in the error handling of the semver.NewVersion function. It should be checking for no error instead of error. Found with @ragingpastry

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
