### PR TITLE
Kube version override

### DIFF
--- a/examples/cert-manager/zarf.yaml
+++ b/examples/cert-manager/zarf.yaml
@@ -1,0 +1,13 @@
+kind: ZarfPackageConfig
+metadata:
+  name: cert-manager
+  description: Cloud native certificate management
+components:
+- name: cert-manager-component
+  description: Cloud native certificate management
+  required: true
+  charts:
+  - name: cert-manager
+    version: v1.11.1
+    namespace: cert-manager
+    url: https://charts.jetstack.io/

--- a/src/cmd/prepare.go
+++ b/src/cmd/prepare.go
@@ -109,7 +109,7 @@ var prepareFindImages = &cobra.Command{
 		defer pkgClient.ClearTempPaths()
 
 		// Find all the images the package might need
-		if err := pkgClient.FindImages(baseDir, repoHelmChartPath); err != nil {
+		if err := pkgClient.FindImages(baseDir, repoHelmChartPath, kubeVersionOverride); err != nil {
 			message.Fatalf(err, "Unable to find images for the package definition %s", baseDir)
 		}
 	},
@@ -149,8 +149,8 @@ func init() {
 	prepareFindImages.Flags().StringVarP(&repoHelmChartPath, "repo-chart-path", "p", "", lang.CmdPrepareFlagRepoChartPath)
 	// use the package create config for this and reset it here to avoid overwriting the config.CreateOptions.SetVariables
 	prepareFindImages.Flags().StringToStringVar(&pkgConfig.CreateOpts.SetVariables, "set", v.GetStringMapString(V_PKG_CREATE_SET), lang.CmdPrepareFlagSet)
-	// allow for the override of KubeVersion
-	prepareFindImages.Flags().StringVar(&kubeVersionOverride, "kube-version", "", "--kube-version v1.21")
+	// allow for the override of the default helm KubeVersion
+	prepareFindImages.Flags().StringVar(&kubeVersionOverride, "kube-version", "", lang.CmdPrepareFlagKubeVersion)
 
 	prepareTransformGitLinks.Flags().StringVar(&pkgConfig.InitOpts.GitServer.PushUsername, "git-account", config.ZarfGitPushUser, lang.CmdPrepareFlagGitAccount)
 }

--- a/src/cmd/prepare.go
+++ b/src/cmd/prepare.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var repoHelmChartPath string
+var repoHelmChartPath, kubeVersionOverride string
 var prepareCmd = &cobra.Command{
 	Use:     "prepare",
 	Aliases: []string{"prep"},
@@ -149,6 +149,8 @@ func init() {
 	prepareFindImages.Flags().StringVarP(&repoHelmChartPath, "repo-chart-path", "p", "", lang.CmdPrepareFlagRepoChartPath)
 	// use the package create config for this and reset it here to avoid overwriting the config.CreateOptions.SetVariables
 	prepareFindImages.Flags().StringToStringVar(&pkgConfig.CreateOpts.SetVariables, "set", v.GetStringMapString(V_PKG_CREATE_SET), lang.CmdPrepareFlagSet)
+	// allow for the override of KubeVersion
+	prepareFindImages.Flags().StringVar(&kubeVersionOverride, "kube-version", "", "--kube-version v1.21")
 
 	prepareTransformGitLinks.Flags().StringVar(&pkgConfig.InitOpts.GitServer.PushUsername, "git-account", config.ZarfGitPushUser, lang.CmdPrepareFlagGitAccount)
 }

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -262,6 +262,7 @@ zarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-ur
 	CmdPrepareFlagSet           = "Specify package variables to set on the command line (KEY=value). Note, if using a config file, this will be set by [package.create.set]."
 	CmdPrepareFlagRepoChartPath = `If git repos hold helm charts, often found with gitops tools, specify the chart path, e.g. "/" or "/chart"`
 	CmdPrepareFlagGitAccount    = "User or organization name for the git account that the repos are created under."
+	CmdPrepareFlagKubeVersion   = "Override the default helm template KubeVersion when performing a package chart template"
 
 	// zarf tools
 	CmdToolsShort = "Collection of additional tools to make airgap easier"

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -161,6 +161,7 @@ func (h *Helm) TemplateChart() (string, error) {
 	client.Verify = false
 	client.InsecureSkipTLSverify = config.CommonOptions.Insecure
 
+	client.KubeVersion = h.KubeVersion
 	client.ReleaseName = h.Chart.ReleaseName
 
 	// If no release name is specified, use the chart name.

--- a/src/internal/packager/helm/common.go
+++ b/src/internal/packager/helm/common.go
@@ -11,6 +11,7 @@ import (
 	"github.com/defenseunicorns/zarf/src/types"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chartutil"
 )
 
 // Helm is a config object for working with helm charts.
@@ -24,6 +25,7 @@ type Helm struct {
 	Component         types.ZarfComponent
 	Cluster           *cluster.Cluster
 	Cfg               *types.PackagerConfig
+	KubeVersion       *chartutil.KubeVersion
 
 	actionConfig *action.Configuration
 }


### PR DESCRIPTION
## Description
Adding a flag to the `zarf prepare find-images` command such that helm charts that implement a minimum `kubeVersion` field in the `Chart.yaml` can specify an override target Kubernetes version. That will allow `zarf prepare find-images` to specify a `--kube-version` that emulates the same activity that helm uses for `helm template`.

## Related Issue

Fixes #1607 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
