### PR TITLE
1677 getting an error when trying to pull from an oci registry unauthenticated

### DIFF
--- a/src/pkg/utils/oras.go
+++ b/src/pkg/utils/oras.go
@@ -64,6 +64,10 @@ func (o *OrasRemote) withAuthClient(ref registry.Reference) (*auth.Client, error
 		return &auth.Client{}, fmt.Errorf("unable to get credentials for %s: %w", key, err)
 	}
 
+	if authConf.ServerAddress != "" {
+		o.Context = withScopes(ref)
+	}
+
 	cred := auth.Credential{
 		Username:     authConf.Username,
 		Password:     authConf.Password,
@@ -91,7 +95,7 @@ func (o *OrasRemote) withAuthClient(ref registry.Reference) (*auth.Client, error
 // NewOrasRemote returns an oras remote repository client and context for the given reference.
 func NewOrasRemote(ref registry.Reference) (*OrasRemote, error) {
 	o := &OrasRemote{}
-	o.Context = withScopes(ref)
+	o.Context = context.TODO()
 	// patch docker.io to registry-1.docker.io
 	// this allows end users to use docker.io as an alias for registry-1.docker.io
 	if ref.Registry == "docker.io" {

--- a/src/pkg/utils/oras.go
+++ b/src/pkg/utils/oras.go
@@ -35,7 +35,7 @@ func withScopes(ref registry.Reference) context.Context {
 	scopes := []string{
 		fmt.Sprintf("repository:%s:pull,push", ref.Repository),
 	}
-	return auth.WithScopes(context.Background(), scopes...)
+	return auth.WithScopes(context.TODO(), scopes...)
 }
 
 // withAuthClient returns an auth client for the given reference.


### PR DESCRIPTION
## Description

tldr; Current ORAS client will query for scoped access to repo, regardless if credentials exist, resulting in a credential handshake attempt for public, non-authenticated resources, resulting in a failure.

> This behavior __must__ be tested in nightly, linking to the nightly issue

## Related Issue

Fixes #1677 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
