### PR TITLE
Fixup Zarf logging for sensitive vals and byte arrays

### DIFF
--- a/docs/12-contribute-to-zarf/2-testing.md
+++ b/docs/12-contribute-to-zarf/2-testing.md
@@ -29,10 +29,10 @@ make test-e2e ARCH="[amd64|arm64]"
 APPLIANCE_MODE=true make test-e2e ARCH="[amd64|arm64]"
 
 # If you already have everything build, you can run this inside this folder. This lets you customize the test run.
-go test ./src/test/... -v
+go test ./src/test/... -v -failfast
 
 # Let's say you only want to run one test. You would run:
-go test ./src/test/... -v -run TestFooBarBaz
+go test ./src/test/... -v -failfast -run TestFooBarBaz
 ```
 
 :::note

--- a/src/internal/cluster/state.go
+++ b/src/internal/cluster/state.go
@@ -192,7 +192,7 @@ func (c *Cluster) sanitizeZarfState(state types.ZarfState) types.ZarfState {
 // SaveZarfState takes a given state and persists it to the Zarf/zarf-state secret.
 func (c *Cluster) SaveZarfState(state types.ZarfState) error {
 	message.Debugf("k8s.SaveZarfState()")
-	message.Debug(message.JSONValue(state))
+	message.Debug(message.JSONValue(c.sanitizeZarfState(state)))
 
 	// Convert the data back to JSON.
 	data, err := json.Marshal(state)

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -359,7 +359,6 @@ func (h *Helm) loadChartData() (*chart.Chart, map[string]any, error) {
 		if err != nil {
 			return loadedChart, nil, fmt.Errorf("unable to parse chart values: %w", err)
 		}
-		message.Debug(chartValues)
 	} else {
 		// Otherwise, use the overrides instead.
 		loadedChart = h.ChartOverride

--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -21,7 +21,7 @@ import (
 // PushToZarfRegistry pushes a provided image into the configured Zarf registry
 // This function will optionally shorten the image name while appending a checksum of the original image name.
 func (i *ImgConfig) PushToZarfRegistry() error {
-	message.Debugf("images.PushToZarfRegistry(%#v)", i)
+	message.Debug("images.PushToZarfRegistry()")
 
 	logs.Warn.SetOutput(&message.DebugWriter{})
 	logs.Progress.SetOutput(&message.DebugWriter{})

--- a/src/pkg/message/message.go
+++ b/src/pkg/message/message.go
@@ -75,16 +75,22 @@ func UseLogFile() {
 	// Prepend the log filename with a timestamp.
 	ts := time.Now().Format("2006-01-02-15-04-05")
 
-	// Try to create a temp log file.
 	var err error
-	if logFile, err = os.CreateTemp("", fmt.Sprintf("zarf-%s-*.log", ts)); err != nil {
-		Error(err, "Error saving a log file")
-	} else {
-		useLogFile = true
+	if logFile != nil {
+		// Use the existing log file if logFile is set
 		logStream := io.MultiWriter(os.Stderr, logFile)
 		pterm.SetDefaultOutput(logStream)
-		message := fmt.Sprintf("Saving log file to %s", logFile.Name())
-		Note(message)
+	} else {
+		// Try to create a temp log file if one hasn't been made already
+		if logFile, err = os.CreateTemp("", fmt.Sprintf("zarf-%s-*.log", ts)); err != nil {
+			Error(err, "Error saving a log file")
+		} else {
+			useLogFile = true
+			logStream := io.MultiWriter(os.Stderr, logFile)
+			pterm.SetDefaultOutput(logStream)
+			message := fmt.Sprintf("Saving log file to %s", logFile.Name())
+			Note(message)
+		}
 	}
 }
 

--- a/src/pkg/message/message.go
+++ b/src/pkg/message/message.go
@@ -47,7 +47,7 @@ var useLogFile bool
 type DebugWriter struct{}
 
 func (d *DebugWriter) Write(raw []byte) (int, error) {
-	Debug(raw)
+	Debug(string(raw))
 	return len(raw), nil
 }
 

--- a/src/pkg/utils/credentials.go
+++ b/src/pkg/utils/credentials.go
@@ -2,8 +2,10 @@ package utils
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/types"
 	"github.com/pterm/pterm"
@@ -14,6 +16,9 @@ func PrintCredentialTable(state types.ZarfState, componentsToDeploy []types.Depl
 	if len(componentsToDeploy) == 0 {
 		componentsToDeploy = []types.DeployedComponent{{Name: "logging"}, {Name: "git-server"}}
 	}
+
+	// Set output to os.Stderr to avoid creds being printed in logs
+	pterm.SetDefaultOutput(os.Stderr)
 
 	pterm.Println()
 	loginTableHeader := pterm.TableData{
@@ -42,6 +47,11 @@ func PrintCredentialTable(state types.ZarfState, componentsToDeploy []types.Depl
 	if len(loginTable) > 0 {
 		loginTable = append(loginTableHeader, loginTable...)
 		_ = pterm.DefaultTable.WithHasHeader().WithData(loginTable).Render()
+	}
+
+	// Restore the log file if it was specified
+	if !config.SkipLogFile {
+		message.UseLogFile()
 	}
 }
 

--- a/src/test/e2e/20_zarf_init_test.go
+++ b/src/test/e2e/20_zarf_init_test.go
@@ -55,10 +55,10 @@ func TestZarfInit(t *testing.T) {
 	// Verify that any state secrets were not included in the log
 	base64State, _, err := e2e.ExecZarfCommand("tools", "kubectl", "get", "secret", "zarf-state", "-n", "zarf", "-o", "jsonpath={.data.state}")
 	require.NoError(t, err)
-	stateJson, err := base64.StdEncoding.DecodeString(base64State)
+	stateJSON, err := base64.StdEncoding.DecodeString(base64State)
 	require.NoError(t, err)
 	state := types.ZarfState{}
-	err = json.Unmarshal(stateJson, &state)
+	err = json.Unmarshal(stateJSON, &state)
 	require.NoError(t, err)
 	require.NotContains(t, logText, state.AgentTLS.CA)
 	require.NotContains(t, logText, state.AgentTLS.Cert)

--- a/src/test/e2e/24_variables_test.go
+++ b/src/test/e2e/24_variables_test.go
@@ -31,8 +31,12 @@ func TestVariables(t *testing.T) {
 	// Deploy nginx
 	stdOut, stdErr, err := e2e.ExecZarfCommand("package", "deploy", path, "--confirm", "--set", "SITE_NAME=Lula Web", "--set", "AWS_REGION=unicorn-land", "-l", "trace")
 	require.NoError(t, err, stdOut, stdErr)
-	// Verify that unicorn-land was not included in the log
+	// Verify that the sensitive variable 'unicorn-land' was not printed to the screen
 	require.NotContains(t, stdErr, "unicorn-land")
+
+	logText := e2e.GetLogFileContents(t, stdErr)
+	// Verify that the sensitive variable 'unicorn-land' was not included in the log
+	require.NotContains(t, logText, "unicorn-land")
 
 	// Verify the terraform file was templated correctly
 	outputTF, err := os.ReadFile(tfPath)


### PR DESCRIPTION
## Description

This fixes up our logging to sanitize on save as well as load state, not log imgconfigs and not log byte arrays.

## Related Issue

Fixes #1655

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
