### PR TITLE
Clear the cache before running go releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
           sudo env "PATH=$PATH" CI=true APPLIANCE_MODE=true make test-e2e ARCH=amd64
           sudo rm -rf zarf-sbom
           sudo rm -rf build/zarf-package-*
+          sudo zarf tools clear-cache
           sudo chown $USER /tmp/zarf-*.log
 
       - name: Save logs


### PR DESCRIPTION
## Description

This clears the zarf image cache before running a release to reduce disk pressure.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
