### PR TITLE
Add the ability for zarf to template folders of files

### DIFF
--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -388,7 +388,12 @@ func (p *Packager) addComponent(component types.ZarfComponent) (*types.Component
 				_ = os.Chmod(dst, 0600)
 			}
 
-			componentSBOM.Files = append(componentSBOM.Files, dst)
+			if info.IsDir() {
+				files, _ := utils.RecursiveFileList(dst, nil, false, true)
+				componentSBOM.Files = append(componentSBOM.Files, files...)
+			} else {
+				componentSBOM.Files = append(componentSBOM.Files, dst)
+			}
 		}
 	}
 
@@ -410,8 +415,7 @@ func (p *Packager) addComponent(component types.ZarfComponent) (*types.Component
 			}
 
 			// Unwrap the dataInjection dir into individual files.
-			pattern := regexp.MustCompile(`(?mi).+$`)
-			files, _ := utils.RecursiveFileList(dst, pattern, false, true)
+			files, _ := utils.RecursiveFileList(dst, nil, false, true)
 			componentSBOM.Files = append(componentSBOM.Files, files...)
 		}
 	}

--- a/src/pkg/utils/io.go
+++ b/src/pkg/utils/io.go
@@ -171,6 +171,10 @@ func ReplaceTextTemplate(path string, mappings map[string]*TextTemplate, depreca
 // the skipPermission flag can be provided to ignore unauthorized files/dirs when true
 // the skipHidden flag can be provided to ignore dot prefixed files/dirs when true
 func RecursiveFileList(dir string, pattern *regexp.Regexp, skipPermission bool, skipHidden bool) (files []string, err error) {
+	if pattern == nil {
+		pattern = regexp.MustCompile(`(?mi).+$`)
+	}
+
 	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		// ignore files/dirs that it does not have permission to read
 		if err != nil && os.IsPermission(err) && skipPermission {


### PR DESCRIPTION
## Description

This allows Zarf to template files in a folder in addition to individual files.

## Related Issue

Fixes #1617 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
