### PR TITLE
Capitalize WordPress in docs correctly

### DIFF
--- a/docs-website/static/docs/tutorials/package_create_wordpress.html
+++ b/docs-website/static/docs/tutorials/package_create_wordpress.html
@@ -58,11 +58,11 @@ b.BWHI {background-color: #aaaaaa}
 <b style="color:#55ffff;">kind</b>:<b style="color:#ff55ff;"> ZarfPackageConfig</b>
 <b style="color:#ff55ff;"></b><b style="color:#55ffff;">metadata</b>:<b style="color:#55ffff;"></b>
 <b style="color:#55ffff;">  name</b>:<b style="color:#ff55ff;"> wordpress</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> A Zarf Package that deploys the Wordpress blogging and content management platform</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> A Zarf Package that deploys the WordPress blogging and content management platform</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">version</b>:<b style="color:#ff55ff;"> 16.0.4</b>
 <b style="color:#ff55ff;"></b><b style="color:#55ffff;">components</b>:
 -<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> wordpress</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> Deploys the Bitnami-packaged Wordpress chart into the cluster</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> Deploys the Bitnami-packaged WordPress chart into the cluster</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">required</b>:<b style="color:#ffffff;"> true</b>
 <b style="color:#ffffff;">  </b><b style="color:#55ffff;">charts</b>:
   -<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> wordpress</b>
@@ -82,27 +82,27 @@ b.BWHI {background-color: #aaaaaa}
 <b style="color:#ff55ff;">  </b>-<b style="color:#ff55ff;"> docker.io/bitnami/wordpress:6.2.0-debian-11-r18</b>
 <b style="color:#ff55ff;"></b><b style="color:#55ffff;">variables</b>:
 -<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> WORDPRESS_USERNAME</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The username that is used to login to the Wordpress admin account</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The username that is used to login to the WordPress admin account</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">default</b>:<b style="color:#ff55ff;"> zarf</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">prompt</b>:<b style="color:#ffffff;"> true</b>
 <b style="color:#ffffff;"></b>-<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> WORDPRESS_PASSWORD</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The password that is used to login to the Wordpress admin account</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The password that is used to login to the WordPress admin account</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">prompt</b>:<b style="color:#ffffff;"> true</b>
 <b style="color:#ffffff;">  </b><b style="color:#55ffff;">sensitive</b>:<b style="color:#ffffff;"> true</b>
 <b style="color:#ffffff;"></b>-<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> WORDPRESS_EMAIL</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The email that is used for the Wordpress admin account</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The email that is used for the WordPress admin account</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">default</b>:<b style="color:#ff55ff;"> hello@defenseunicorns.com</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">prompt</b>:<b style="color:#ffffff;"> true</b>
 <b style="color:#ffffff;"></b>-<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> WORDPRESS_FIRST_NAME</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The first name that is used for the Wordpress admin account</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The first name that is used for the WordPress admin account</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">default</b>:<b style="color:#ff55ff;"> Zarf</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">prompt</b>:<b style="color:#ffffff;"> true</b>
 <b style="color:#ffffff;"></b>-<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> WORDPRESS_LAST_NAME</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The last name that is used for the Wordpress admin account</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The last name that is used for the WordPress admin account</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">default</b>:<b style="color:#ff55ff;"> The Axolotl</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">prompt</b>:<b style="color:#ffffff;"> true</b>
 <b style="color:#ffffff;"></b>-<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> WORDPRESS_BLOG_NAME</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The blog name that is used for the Wordpress admin account</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The blog name that is used for the WordPress admin account</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">default</b>:<b style="color:#ff55ff;"> The Zarf Blog</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">prompt</b>:<b style="color:#ffffff;"> true</b>
 

--- a/docs-website/static/docs/tutorials/package_deploy_wordpress.html
+++ b/docs-website/static/docs/tutorials/package_deploy_wordpress.html
@@ -59,7 +59,7 @@ b.BWHI {background-color: #aaaaaa}
 <b style="color:#55ffff;">kind</b>:<b style="color:#ff55ff;"> ZarfPackageConfig</b>
 <b style="color:#ff55ff;"></b><b style="color:#55ffff;">metadata</b>:<b style="color:#55ffff;"></b>
 <b style="color:#55ffff;">  name</b>:<b style="color:#ff55ff;"> wordpress</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> A Zarf Package that deploys the Wordpress blogging and content management platform</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> A Zarf Package that deploys the WordPress blogging and content management platform</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">version</b>:<b style="color:#ff55ff;"> 16.0.4</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">architecture</b>:<b style="color:#ff55ff;"> amd64</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">aggregateChecksum</b>:<b style="color:#ff55ff;"> 8375743b716d39346967c70b1bcaf2480a09417c8aa302e4868dd9793663b1ef</b>
@@ -75,7 +75,7 @@ b.BWHI {background-color: #aaaaaa}
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">differential</b>:<b style="color:#ffffff;"> false</b>
 <b style="color:#ffffff;"></b><b style="color:#55ffff;">components</b>:
 -<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> wordpress</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> Deploys the Bitnami-packaged Wordpress chart into the cluster</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> Deploys the Bitnami-packaged WordPress chart into the cluster</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">required</b>:<b style="color:#ffffff;"> true</b>
 <b style="color:#ffffff;">  </b><b style="color:#55ffff;">charts</b>:
   -<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> wordpress</b>
@@ -95,27 +95,27 @@ b.BWHI {background-color: #aaaaaa}
 <b style="color:#ff55ff;">  </b>-<b style="color:#ff55ff;"> docker.io/bitnami/wordpress:6.2.0-debian-11-r18</b>
 <b style="color:#ff55ff;"></b><b style="color:#55ffff;">variables</b>:
 -<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> WORDPRESS_USERNAME</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The username that is used to login to the Wordpress admin account</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The username that is used to login to the WordPress admin account</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">default</b>:<b style="color:#ff55ff;"> zarf</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">prompt</b>:<b style="color:#ffffff;"> true</b>
 <b style="color:#ffffff;"></b>-<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> WORDPRESS_PASSWORD</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The password that is used to login to the Wordpress admin account</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The password that is used to login to the WordPress admin account</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">prompt</b>:<b style="color:#ffffff;"> true</b>
 <b style="color:#ffffff;">  </b><b style="color:#55ffff;">sensitive</b>:<b style="color:#ffffff;"> true</b>
 <b style="color:#ffffff;"></b>-<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> WORDPRESS_EMAIL</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The email that is used for the Wordpress admin account</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The email that is used for the WordPress admin account</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">default</b>:<b style="color:#ff55ff;"> hello@defenseunicorns.com</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">prompt</b>:<b style="color:#ffffff;"> true</b>
 <b style="color:#ffffff;"></b>-<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> WORDPRESS_FIRST_NAME</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The first name that is used for the Wordpress admin account</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The first name that is used for the WordPress admin account</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">default</b>:<b style="color:#ff55ff;"> Zarf</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">prompt</b>:<b style="color:#ffffff;"> true</b>
 <b style="color:#ffffff;"></b>-<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> WORDPRESS_LAST_NAME</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The last name that is used for the Wordpress admin account</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The last name that is used for the WordPress admin account</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">default</b>:<b style="color:#ff55ff;"> The Axolotl</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">prompt</b>:<b style="color:#ffffff;"> true</b>
 <b style="color:#ffffff;"></b>-<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> WORDPRESS_BLOG_NAME</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The blog name that is used for the Wordpress admin account</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The blog name that is used for the WordPress admin account</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">default</b>:<b style="color:#ff55ff;"> The Zarf Blog</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">prompt</b>:<b style="color:#ffffff;"> true</b>
 

--- a/docs-website/static/docs/tutorials/package_deploy_wordpress_bottom.html
+++ b/docs-website/static/docs/tutorials/package_deploy_wordpress_bottom.html
@@ -47,17 +47,17 @@ b.BWHI {background-color: #aaaaaa}
 <body>
 <pre>
 <b class="BOLD FONT HIG"> ? </b><b class="BOLD FONT HIW">Deploy this Zarf package? </b>(y/N) <span style="color:#55ffff;">Yes</span> <br/>
-<b style="color:#55ff55;"> The username that is used to login to the Wordpress admin account</b>
+<b style="color:#55ff55;"> The username that is used to login to the WordPress admin account</b>
 <b class="BOLD FONT HIG"> ? </b><b class="BOLD FONT HIW">Please provide a value for "WORDPRESS_USERNAME"</b><span style="color:#55ffff;">zarf</span> <br/>
-<b style="color:#55ff55;"> The password that is used to login to the Wordpress admin account</b>
+<b style="color:#55ff55;"> The password that is used to login to the WordPress admin account</b>
 <b class="BOLD FONT HIG"> ? </b><b class="BOLD FONT HIW">Please provide a value for "WORDPRESS_PASSWORD"</b><span style="color:#55ffff;">password</span> <br/>
-<b style="color:#55ff55;"> The email that is used for the Wordpress admin account</b>
+<b style="color:#55ff55;"> The email that is used for the WordPress admin account</b>
 <b class="BOLD FONT HIG"> ? </b><b class="BOLD FONT HIW">Please provide a value for "WORDPRESS_EMAIL"</b><span style="color:#55ffff;">hello@defenseunicorns.com</span> <br/>
-<b style="color:#55ff55;"> The first name that is used for the Wordpress admin account</b>
+<b style="color:#55ff55;"> The first name that is used for the WordPress admin account</b>
 <b class="BOLD FONT HIG"> ? </b><b class="BOLD FONT HIW">Please provide a value for "WORDPRESS_FIRST_NAME"</b><span style="color:#55ffff;">Zarf</span> <br/>
-<b style="color:#55ff55;"> The last name that is used for the Wordpress admin account</b>
+<b style="color:#55ff55;"> The last name that is used for the WordPress admin account</b>
 <b class="BOLD FONT HIG"> ? </b><b class="BOLD FONT HIW">Please provide a value for "WORDPRESS_LAST_NAME"</b><span style="color:#55ffff;">The Axolotl</span> <br/>
-<b style="color:#55ff55;"> The blog name that is used for the Wordpress admin account</b>
+<b style="color:#55ff55;"> The blog name that is used for the WordPress admin account</b>
 <b class="BOLD FONT HIG"> ? </b><b class="BOLD FONT HIW">Please provide a value for "WORDPRESS_BLOG_NAME"</b><span style="color:#55ffff;">The Zarf Blog</span> <br/>
 <b style="background-color:#555555"></b><b style="background-color:#555555">                                                                                </b>
 <b style="background-color:#555555"></b><b style="background-color:#555555"></b><b style="color:#ffffff;background-color:#555555"></b><b style="color:#ffffff;background-color:#555555">  📦 WORDPRESS COMPONENT                                                        </b><b style="background-color:#555555"></b><b style="background-color:#555555"></b>
@@ -81,8 +81,8 @@ b.BWHI {background-color: #aaaaaa}
 <b style="color:#55ff55;"></b><b style="color:#55ff55;">  ✔ </b> <b style="color:#55ff55;"></b><b style="color:#55ff55;">Zarf deployment complete</b>
 
 <b style="color:#55ffff;"></b><b style="color:#55ffff;">Connect Command             </b><b style="color:#555555;"></b><b style="color:#555555;"> | </b><b style="color:#55ffff;"></b><b style="color:#55ffff;">Description</b>
-<b style="color:#55ffff;"></b>zarf connect wordpress-blog <b style="color:#555555;"></b><b style="color:#555555;"> | </b>The public facing Wordpress blog site
-zarf connect wordpress-admin<b style="color:#555555;"></b><b style="color:#555555;"> | </b>The login page for the Wordpress admin panel
+<b style="color:#55ffff;"></b>zarf connect wordpress-blog <b style="color:#555555;"></b><b style="color:#555555;"> | </b>The public facing WordPress blog site
+zarf connect wordpress-admin<b style="color:#555555;"></b><b style="color:#555555;"> | </b>The login page for the WordPress admin panel
 </pre>
 </body>
 </html>

--- a/docs/6-zarf-tutorials/0-creating-a-zarf-package.md
+++ b/docs/6-zarf-tutorials/0-creating-a-zarf-package.md
@@ -19,11 +19,11 @@ Before beginning this tutorial you will need the following:
 
 ## Putting Together a Zarf Package
 
-In order to create a Zarf package you first need to have an idea of what application(s) you want to package.  In this example we will be using the [Wordpress chart from Bitnami](https://artifacthub.io/packages/helm/bitnami/wordpress) but the steps and tools used below are very similar for other applications.
+In order to create a Zarf package you first need to have an idea of what application(s) you want to package.  In this example we will be using the [WordPress chart from Bitnami](https://artifacthub.io/packages/helm/bitnami/wordpress) but the steps and tools used below are very similar for other applications.
 
 ### Creating the Package Definition
 
-A `zarf.yaml` file follows the [Zarf Package Schema](../3-create-a-zarf-package/4-zarf-schema.md) and allows us to specify package metadata and a set of components for us to deploy. We start a package definition with the `kind` of package we are making and `metadata` that describes the package.  You can start our Wordpress package by creating a new `zarf.yaml` with the following content:
+A `zarf.yaml` file follows the [Zarf Package Schema](../3-create-a-zarf-package/4-zarf-schema.md) and allows us to specify package metadata and a set of components for us to deploy. We start a package definition with the `kind` of package we are making and `metadata` that describes the package.  You can start our WordPress package by creating a new `zarf.yaml` with the following content:
 
 ```yaml
 kind: ZarfPackageConfig # ZarfPackageConfig is the package kind for most normal zarf packages
@@ -31,7 +31,7 @@ metadata:
   name: wordpress       # specifies the name of our package and should be unique and unchanging through updates
   version: 16.0.4       # (optional) a version we can track as we release updates or publish to a registry
   description: |        # (optional) a human-readable description of the package that you are creating
-    "A Zarf Package that deploys the Wordpress blogging and content management platform"
+    "A Zarf Package that deploys the WordPress blogging and content management platform"
 ```
 
 :::tip
@@ -40,15 +40,15 @@ If you are using an Integrated Development Environment (such as [VS Code](../3-c
 
 :::
 
-### Adding the Wordpress Component
+### Adding the WordPress Component
 
-Components are the unit of Zarf Packages that define an application stack.  These are defined under the `components` key and allow many different resource types to be brought into a package.  You can learn more about components on the [Understanding Zarf Components](../3-create-a-zarf-package/2-zarf-components.md) page. To add our Wordpress component, add the following to the bottom of our `zarf.yaml`:
+Components are the unit of Zarf Packages that define an application stack.  These are defined under the `components` key and allow many different resource types to be brought into a package.  You can learn more about components on the [Understanding Zarf Components](../3-create-a-zarf-package/2-zarf-components.md) page. To add our WordPress component, add the following to the bottom of our `zarf.yaml`:
 
 ```yaml
 components:
   - name: wordpress  # specifies the name of our component and should be unique and unchanging through updates
     description: |   # (optional) a human-readable description of the component you are defining
-      "Deploys the Bitnami-packaged Wordpress chart into the cluster"
+      "Deploys the Bitnami-packaged WordPress chart into the cluster"
     required: true   # (optional) sets the component as 'required' so that it is always deployed
     charts:
       - name: wordpress
@@ -74,7 +74,7 @@ wordpressBlogName: The Zarf Blog
 metrics:
   enabled: true
 
-# Sets the Wordpress service as a ClusterIP service to not conflict with potential
+# Sets the WordPress service as a ClusterIP service to not conflict with potential
 # pre-existing LoadBalancer services.
 service:
   type: ClusterIP
@@ -123,30 +123,30 @@ variables:
     # The unique name of the variable corresponding to the ###ZARF_VAR_### template
   - name: WORDPRESS_USERNAME
     # A human-readable description of the variable shown during prompting
-    description: The username that is used to login to the Wordpress admin account
+    description: The username that is used to login to the WordPress admin account
     # A default value to take if --confirm is used or the user chooses the default prompt
     default: zarf
     # Whether to prompt for this value interactively if it is not --set on the CLI
     prompt: true
   - name: WORDPRESS_PASSWORD
-    description: The password that is used to login to the Wordpress admin account
+    description: The password that is used to login to the WordPress admin account
     prompt: true
     # Whether to treat this value as sensitive to keep it out of Zarf logs
     sensitive: true
   - name: WORDPRESS_EMAIL
-    description: The email that is used for the Wordpress admin account
+    description: The email that is used for the WordPress admin account
     default: hello@defenseunicorns.com
     prompt: true
   - name: WORDPRESS_FIRST_NAME
-    description: The first name that is used for the Wordpress admin account
+    description: The first name that is used for the WordPress admin account
     default: Zarf
     prompt: true
   - name: WORDPRESS_LAST_NAME
-    description: The last name that is used for the Wordpress admin account
+    description: The last name that is used for the WordPress admin account
     default: The Axolotl
     prompt: true
   - name: WORDPRESS_BLOG_NAME
-    description: The blog name that is used for the Wordpress admin account
+    description: The blog name that is used for the WordPress admin account
     default: The Zarf Blog
     prompt: true
 ```
@@ -183,7 +183,7 @@ metadata:
     # Enables "zarf connect wordpress-blog"
     zarf.dev/connect-name: wordpress-blog
   annotations:
-    zarf.dev/connect-description: "The public facing Wordpress blog site"
+    zarf.dev/connect-description: "The public facing WordPress blog site"
 spec:
   selector:
     app.kubernetes.io/instance: wordpress
@@ -202,7 +202,7 @@ metadata:
     # Enables "zarf connect wordpress-admin"
     zarf.dev/connect-name: wordpress-admin
   annotations:
-    zarf.dev/connect-description: "The login page for the Wordpress admin panel"
+    zarf.dev/connect-description: "The login page for the WordPress admin panel"
     # Sets a URL-suffix to automatically navigate to in the browser
     zarf.dev/connect-url: "/wp-admin"
 spec:
@@ -228,7 +228,7 @@ To add this to our `zarf.yaml` we can simply specify it under our `wordpress` co
 
 ### Creating the Package
 
-Once you have followed the above you should now have a `zarf.yaml` file that matches the one found on the [Wordpress example page](../../examples/wordpress/README.md).
+Once you have followed the above you should now have a `zarf.yaml` file that matches the one found on the [WordPress example page](../../examples/wordpress/README.md).
 
 Creating this package is as simple as running the `zarf package create` command with the directory containing our `zarf.yaml`.  Zarf will show us the `zarf.yaml` one last time asking if we would like to build the package, and will ask us for a maximum package size (useful if you need to split a package across multiple [Compact Discs](https://en.wikipedia.org/wiki/Compact_disc)).  Upon confirmation Zarf will pull down all of the resources and bundle them into a package tarball.
 
@@ -258,7 +258,7 @@ You can learn more about what is going on behind the scenes of this process on t
 
 :::
 
-Congratulations! You've built the Wordpress package. Now, you can learn how to [inspect the SBOMs](../5-dashboard-ui/1-sbom-dashboard.md) or head straight to [deploying it](./2-deploying-zarf-packages.md)!
+Congratulations! You've built the WordPress package. Now, you can learn how to [inspect the SBOMs](../5-dashboard-ui/1-sbom-dashboard.md) or head straight to [deploying it](./2-deploying-zarf-packages.md)!
 
 ## Troubleshooting
 

--- a/docs/6-zarf-tutorials/2-deploying-zarf-packages.md
+++ b/docs/6-zarf-tutorials/2-deploying-zarf-packages.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-In this tutorial, we are going to deploy the Wordpress package onto your cluster using the package we created in the earlier [create a package](./0-creating-a-zarf-package.md) tutorial and the cluster we initialized in the [initialize a k8s cluster](./1-initializing-a-k8s-cluster.md) tutorial. We will be leveraging that past work to go the extra step of deploying an application we packaged onto our cluster with the `zarf package deploy` command.
+In this tutorial, we are going to deploy the WordPress package onto your cluster using the package we created in the earlier [create a package](./0-creating-a-zarf-package.md) tutorial and the cluster we initialized in the [initialize a k8s cluster](./1-initializing-a-k8s-cluster.md) tutorial. We will be leveraging that past work to go the extra step of deploying an application we packaged onto our cluster with the `zarf package deploy` command.
 
 ## System Requirements
 
@@ -14,9 +14,9 @@ Prior to this tutorial you'll want to have a built package and a working cluster
 
 - Zarf binary installed on your $PATH: ([Installing Zarf](../1-getting-started/index.md#installing-zarf))
 - [An initialized cluster](./1-initializing-a-k8s-cluster.md)
-- The [Wordpress package created](./0-creating-a-zarf-package.md)
+- The [WordPress package created](./0-creating-a-zarf-package.md)
 
-## Deploying the Wordpress package
+## Deploying the WordPress package
 
 1. Use the `zarf package deploy` command to deploy the package you built in a the previous tutorial (see [prerequisites](#prerequisites)).
 
@@ -46,7 +46,7 @@ To accept a default value for a given variable, simply press the `enter` key.  Y
 
 3. Because we included the connect services in the [previous tutorial](./0-creating-a-zarf-package.md#setting-up-a-zarf-connect-service) we can quickly test our package in a browser with `zarf connect wordpress-blog`.
 
-![Zarf Connect Wordpress](../.images/tutorials/wordpress_connected.png)
+![Zarf Connect WordPress](../.images/tutorials/wordpress_connected.png)
 
 4. We can also explore the resources deployed by our package by running the `zarf tools monitor` command to start [`K9s`](../5-dashboard-ui/2-k9s-dashboard.md). Once you are done, hit `ctrl/control c` to exit.
 
@@ -54,7 +54,7 @@ To accept a default value for a given variable, simply press the `enter` key.  Y
 
 ## Removal
 
-1. Use the `zarf package list` command to get a list of the installed packages.  This will give you the name of the Wordpress package to remove it.
+1. Use the `zarf package list` command to get a list of the installed packages.  This will give you the name of the WordPress package to remove it.
 
 <iframe src="/docs/tutorials/package_deploy_wordpress_list.html" height="120px" width="100%"></iframe>
 

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -1,6 +1,6 @@
-# Wordpress
+# WordPress
 
-This example demonstrates how to use Zarf to deploy a Wordpress blog into a cluster.  It is used as a part of the [Creating a Zarf Package](../../docs/6-zarf-tutorials/0-creating-a-zarf-package.md) and [Deploying a Zarf Package](../../docs/6-zarf-tutorials/2-deploying-zarf-packages.md) tutorials.
+This example demonstrates how to use Zarf to deploy a WordPress blog into a cluster.  It is used as a part of the [Creating a Zarf Package](../../docs/6-zarf-tutorials/0-creating-a-zarf-package.md) and [Deploying a Zarf Package](../../docs/6-zarf-tutorials/2-deploying-zarf-packages.md) tutorials.
 
 :::info
 
@@ -14,43 +14,43 @@ metadata:
   name: wordpress       # specifies the name of our package and should be unique and unchanging through updates
   version: 16.0.4       # (optional) a version we can track as we release updates or publish to a registry
   description: |        # (optional) a human-readable description of the package that you are creating
-    "A Zarf Package that deploys the Wordpress blogging and content management platform"
+    "A Zarf Package that deploys the WordPress blogging and content management platform"
 
 variables:
     # The unique name of the variable corresponding to the ###ZARF_VAR_### template
   - name: WORDPRESS_USERNAME
     # A human-readable description of the variable shown during prompting
-    description: The username that is used to login to the Wordpress admin account
+    description: The username that is used to login to the WordPress admin account
     # A default value to take if --confirm is used or the user chooses the default prompt
     default: zarf
     # Whether to prompt for this value interactively if it is not --set on the CLI
     prompt: true
   - name: WORDPRESS_PASSWORD
-    description: The password that is used to login to the Wordpress admin account
+    description: The password that is used to login to the WordPress admin account
     prompt: true
     # Whether to treat this value as sensitive to keep it out of Zarf logs
     sensitive: true
   - name: WORDPRESS_EMAIL
-    description: The email that is used for the Wordpress admin account
+    description: The email that is used for the WordPress admin account
     default: hello@defenseunicorns.com
     prompt: true
   - name: WORDPRESS_FIRST_NAME
-    description: The first name that is used for the Wordpress admin account
+    description: The first name that is used for the WordPress admin account
     default: Zarf
     prompt: true
   - name: WORDPRESS_LAST_NAME
-    description: The last name that is used for the Wordpress admin account
+    description: The last name that is used for the WordPress admin account
     default: The Axolotl
     prompt: true
   - name: WORDPRESS_BLOG_NAME
-    description: The blog name that is used for the Wordpress admin account
+    description: The blog name that is used for the WordPress admin account
     default: The Zarf Blog
     prompt: true
 
 components:
   - name: wordpress  # specifies the name of our component and should be unique and unchanging through updates
     description: |   # (optional) a human-readable description of the component you are defining
-      "Deploys the Bitnami-packaged Wordpress chart into the cluster"
+      "Deploys the Bitnami-packaged WordPress chart into the cluster"
     required: true   # (optional) sets the component as 'required' so that it is always deployed
     charts:
       - name: wordpress

--- a/examples/wordpress/connect-services.yaml
+++ b/examples/wordpress/connect-services.yaml
@@ -6,7 +6,7 @@ metadata:
     # Enables "zarf connect wordpress-blog"
     zarf.dev/connect-name: wordpress-blog
   annotations:
-    zarf.dev/connect-description: "The public facing Wordpress blog site"
+    zarf.dev/connect-description: "The public facing WordPress blog site"
 spec:
   selector:
     app.kubernetes.io/instance: wordpress
@@ -25,7 +25,7 @@ metadata:
     # Enables "zarf connect wordpress-admin"
     zarf.dev/connect-name: wordpress-admin
   annotations:
-    zarf.dev/connect-description: "The login page for the Wordpress admin panel"
+    zarf.dev/connect-description: "The login page for the WordPress admin panel"
     # Sets a URL-suffix to automatically navigate to in the browser
     zarf.dev/connect-url: "/wp-admin"
 spec:

--- a/examples/wordpress/wordpress-values.yaml
+++ b/examples/wordpress/wordpress-values.yaml
@@ -10,7 +10,7 @@ wordpressBlogName: ###ZARF_VAR_WORDPRESS_BLOG_NAME###
 metrics:
   enabled: true
 
-# Sets the Wordpress service as a ClusterIP service to not conflict with potential
+# Sets the WordPress service as a ClusterIP service to not conflict with potential
 # pre-existing LoadBalancer services.
 service:
   type: ClusterIP

--- a/examples/wordpress/zarf.yaml
+++ b/examples/wordpress/zarf.yaml
@@ -3,43 +3,43 @@ metadata:
   name: wordpress       # specifies the name of our package and should be unique and unchanging through updates
   version: 16.0.4       # (optional) a version we can track as we release updates or publish to a registry
   description: |        # (optional) a human-readable description of the package that you are creating
-    "A Zarf Package that deploys the Wordpress blogging and content management platform"
+    "A Zarf Package that deploys the WordPress blogging and content management platform"
 
 variables:
     # The unique name of the variable corresponding to the ###ZARF_VAR_### template
   - name: WORDPRESS_USERNAME
     # A human-readable description of the variable shown during prompting
-    description: The username that is used to login to the Wordpress admin account
+    description: The username that is used to login to the WordPress admin account
     # A default value to take if --confirm is used or the user chooses the default prompt
     default: zarf
     # Whether to prompt for this value interactively if it is not --set on the CLI
     prompt: true
   - name: WORDPRESS_PASSWORD
-    description: The password that is used to login to the Wordpress admin account
+    description: The password that is used to login to the WordPress admin account
     prompt: true
     # Whether to treat this value as sensitive to keep it out of Zarf logs
     sensitive: true
   - name: WORDPRESS_EMAIL
-    description: The email that is used for the Wordpress admin account
+    description: The email that is used for the WordPress admin account
     default: hello@defenseunicorns.com
     prompt: true
   - name: WORDPRESS_FIRST_NAME
-    description: The first name that is used for the Wordpress admin account
+    description: The first name that is used for the WordPress admin account
     default: Zarf
     prompt: true
   - name: WORDPRESS_LAST_NAME
-    description: The last name that is used for the Wordpress admin account
+    description: The last name that is used for the WordPress admin account
     default: The Axolotl
     prompt: true
   - name: WORDPRESS_BLOG_NAME
-    description: The blog name that is used for the Wordpress admin account
+    description: The blog name that is used for the WordPress admin account
     default: The Zarf Blog
     prompt: true
 
 components:
   - name: wordpress  # specifies the name of our component and should be unique and unchanging through updates
     description: |   # (optional) a human-readable description of the component you are defining
-      "Deploys the Bitnami-packaged Wordpress chart into the cluster"
+      "Deploys the Bitnami-packaged WordPress chart into the cluster"
     required: true   # (optional) sets the component as 'required' so that it is always deployed
     charts:
       - name: wordpress


### PR DESCRIPTION
## Description

To make the docs more appealing to WordPress users spell the software name correctly with a capital P.

See e.g. https://developer.wordpress.org/reference/functions/capital_p_dangit/

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed

---------