### PR TITLE
Ensure variables are uppercase 

### DIFF
--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -81,8 +81,11 @@ var packageDeployCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		pkgConfig.DeployOpts.PackagePath = choosePackage(args)
 
-		// Ensure uppercase keys from viper
+		// Ensure uppercase keys from viper and CLI --set
 		viperConfigSetVariables := utils.TransformMapKeys(v.GetStringMapString(V_PKG_DEPLOY_SET), strings.ToUpper)
+		pkgConfig.DeployOpts.SetVariables = utils.TransformMapKeys(pkgConfig.DeployOpts.SetVariables, strings.ToUpper)
+
+		// Merge the viper config file variables and provided CLI flag variables (CLI takes precedence))
 		pkgConfig.DeployOpts.SetVariables = utils.MergeMap(viperConfigSetVariables, pkgConfig.DeployOpts.SetVariables)
 
 		// Configure the packager


### PR DESCRIPTION
If there are variables in a config.json/toml and variables provided via the `--set` flag we need to ensure both the variable keys are uppercase before processing and templating them. At the moment we were only uppercasing the config file variable keys which resulted in inconsistent behavior  because of the indeterministic ordering of maps as we were looking for the variable's value.


Fixes #1726 