### PR TITLE
Rename helmrelease manifest file for BB extension

### DIFF
--- a/src/extensions/bigbang/bigbang.go
+++ b/src/extensions/bigbang/bigbang.go
@@ -433,7 +433,7 @@ func addBigBangManifests(YOLO bool, manifestDir string, cfg *extensions.BigBang)
 		})
 	}
 
-	if err := addManifest("bb-ext-helmrepository.yaml", manifestHelmRelease(hrValues)); err != nil {
+	if err := addManifest("bb-ext-helmrelease.yaml", manifestHelmRelease(hrValues)); err != nil {
 		return manifest, err
 	}
 


### PR DESCRIPTION
## Description

Flux has both `HelmRelease` and `HelmRepository` custom resources. Renaming this manifest for consistency with the kind of thing being created here. Since Big Bang now has an option to deploy with `HelmRepository` source this could be confusing to end users when deploying and reviewing the manifests in the zarf package.

## Related Issue

No issue, just something I noticed while deploying.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
