### PR TITLE
Add GitHub URLs in zarf.yamls to the renovate regex matcher

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -57,7 +57,7 @@
       ],
       "matchStringsStrategy": "recursive",
       "matchStrings": [
-        "https:\\/\\/github.com\\/(?<depName>[\\w\\/\\-\\.]+?)\\/releases\\/download\\/(?<currentValue>[\\w\\/\\-\\.]+?)\\/"
+        "https:\\/\\/github.com\\/(?<depName>[\\w\\/\\-\\.\\+\\%]+?)\\/releases\\/download\\/(?<currentValue>[\\w\\/\\-\\.\\+\\%]+?)\\/"
       ],
       "datasourceTemplate": "github-releases"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,16 @@
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*?version: (?<currentValue>.*)\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "fileMatch": [
+        "(^|/)zarf.yaml$"
+      ],
+      "matchStringsStrategy": "recursive",
+      "matchStrings": [
+        "https:\\/\\/github.com\\/(?<depName>[\\w\\/\\-\\.]+?)\\/releases\\/download\\/(?<currentValue>[\\w\\/\\-\\.]+?)\\/"
+      ],
+      "datasourceTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
## Description

This adds GitHub URLs to the regex matcher for renovate to update things like k3s.

## Related Issue

Relates to #1754 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
