### PR TITLE
Use action defaults MaxTotalSeconds during Big Bang deploy

### DIFF
--- a/src/extensions/bigbang/bigbang.go
+++ b/src/extensions/bigbang/bigbang.go
@@ -139,14 +139,20 @@ func Run(YOLO bool, tmpPaths types.ComponentPaths, c types.ZarfComponent) (types
 		return c, fmt.Errorf("unable to sort Big Bang HelmReleases: %w", err)
 	}
 
-	tenMinsInSecs := 10 * 60
+	// ten minutes in seconds
+	maxTotalSeconds := 10 * 60
+
+	defaultMaxTotalSeconds := c.Actions.OnDeploy.Defaults.MaxTotalSeconds
+	if defaultMaxTotalSeconds != 0 {
+		maxTotalSeconds = defaultMaxTotalSeconds
+	}
 
 	// Add wait actions for each of the helm releases in generally the order they should be deployed.
 	for _, hrNamespacedName := range namespacedHelmReleaseNames {
 		hr := hrDependencies[hrNamespacedName]
 		action := types.ZarfComponentAction{
 			Description:     fmt.Sprintf("Big Bang Helm Release `%s` to be ready", hr.Metadata.Name),
-			MaxTotalSeconds: &tenMinsInSecs,
+			MaxTotalSeconds: &maxTotalSeconds,
 			Wait: &types.ZarfComponentActionWait{
 				Cluster: &types.ZarfComponentActionWaitCluster{
 					Kind:       "HelmRelease",

--- a/src/extensions/bigbang/bigbang.go
+++ b/src/extensions/bigbang/bigbang.go
@@ -143,7 +143,7 @@ func Run(YOLO bool, tmpPaths types.ComponentPaths, c types.ZarfComponent) (types
 	maxTotalSeconds := 10 * 60
 
 	defaultMaxTotalSeconds := c.Actions.OnDeploy.Defaults.MaxTotalSeconds
-	if defaultMaxTotalSeconds != 0 {
+	if defaultMaxTotalSeconds > maxTotalSeconds {
 		maxTotalSeconds = defaultMaxTotalSeconds
 	}
 


### PR DESCRIPTION
## Description

This PR makes it so that the Big Bang extension respects and uses the `onDeploy.defaults.maxTotalSeconds` field during its `onSuccess` actions to wait for HelmReleases to be ready.

The default time is still ten minutes (600s), but if a default is specified _and is greater than 600_, it will use that instead.

```yaml
components:
  - name: bigbang
    extensions:
      bigbang:
        version: 2.0.0
        valuesFiles:
          - config/disable-all.yaml
    actions:
      onDeploy:
        defaults:
          maxTotalSeconds: 1200 # 20 minutes in seconds
 ```

## Related Issue

Fixes #1780 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
