### PR TITLE
Properly remove files in parallel tests for component actions

### DIFF
--- a/examples/component-actions/zarf.yaml
+++ b/examples/component-actions/zarf.yaml
@@ -127,7 +127,7 @@ components:
       # this file will be copied to the target location and the cat, dog, and snake sounds will be replaced with their values
       # requires the on-deploy-with-dynamic-variable and on-deploy-with-multiple-variables components
       - source: test.txt
-        target: templated.txt
+        target: test-templated.txt
 
   - name: on-deploy-with-timeout
     description: This component will fail after 1 second
@@ -169,7 +169,7 @@ components:
           - cmd: touch $ZARF_VAR_TEST_FILENAME
             env:
               # this will set the env var ZARF_VAR_TEST_FILENAME - useful for passing information into scripts
-              - ZARF_VAR_TEST_FILENAME=filename-from-env.txt
+              - ZARF_VAR_TEST_FILENAME=test-filename-from-env.txt
 
   - name: on-create-with-network-wait-action
     description: This component will wait for 15 seconds for a network resource to be available

--- a/src/test/e2e/02_component_actions_test.go
+++ b/src/test/e2e/02_component_actions_test.go
@@ -24,11 +24,8 @@ func TestComponentActions(t *testing.T) {
 		"test-deploy-before.txt",
 		"test-deploy-after.txt",
 	}
-	deployWithEnvVarArtifact := "filename-from-env.txt"
 
 	allArtifacts := append(deployArtifacts, createArtifacts...)
-	allArtifacts = append(allArtifacts, deployWithEnvVarArtifact)
-	allArtifacts = append(allArtifacts, "templated.txt")
 	e2e.CleanFiles(allArtifacts...)
 	defer e2e.CleanFiles(allArtifacts...)
 
@@ -107,33 +104,43 @@ func TestComponentActions(t *testing.T) {
 
 	t.Run("action on-deploy-with-env-var", func(t *testing.T) {
 		t.Parallel()
+		deployWithEnvVarArtifact := "test-filename-from-env.txt"
+
 		// Test using environment variables
 		stdOut, stdErr, err = e2e.Zarf("package", "deploy", path, "--components=on-deploy-with-env-var", "--confirm")
 		require.NoError(t, err, stdOut, stdErr)
 		require.FileExists(t, deployWithEnvVarArtifact)
+
+		// Remove the templated file at the end of the test
+		e2e.CleanFiles(deployWithEnvVarArtifact)
 	})
 
 	t.Run("action on-deploy-with-template", func(t *testing.T) {
 		t.Parallel()
+		deployTempaltedArtifact := "test-templated.txt"
+
 		// Test using a templated file but without dynamic variables
 		stdOut, stdErr, err = e2e.Zarf("package", "deploy", path, "--components=on-deploy-with-template-use-of-variable", "--confirm")
 		require.NoError(t, err, stdOut, stdErr)
-		outTemplated, err := os.ReadFile("templated.txt")
+		outTemplated, err := os.ReadFile(deployTempaltedArtifact)
 		require.NoError(t, err)
 		require.Contains(t, string(outTemplated), "The dog says ruff")
 		require.Contains(t, string(outTemplated), "The cat says ###ZARF_VAR_CAT_SOUND###")
 		require.Contains(t, string(outTemplated), "The snake says ###ZARF_VAR_SNAKE_SOUND###")
 
 		// Remove the templated file so we can test with dynamic variables
-		e2e.CleanFiles("templated.txt")
+		e2e.CleanFiles(deployTempaltedArtifact)
 
 		// Test using a templated file with dynamic variables
 		stdOut, stdErr, err = e2e.Zarf("package", "deploy", path, "--components=on-deploy-with-template-use-of-variable,on-deploy-with-dynamic-variable,on-deploy-with-multiple-variables", "--confirm")
 		require.NoError(t, err, stdOut, stdErr)
-		outTemplated, err = os.ReadFile("templated.txt")
+		outTemplated, err = os.ReadFile(deployTempaltedArtifact)
 		require.NoError(t, err)
 		require.Contains(t, string(outTemplated), "The dog says ruff")
 		require.Contains(t, string(outTemplated), "The cat says meow")
 		require.Contains(t, string(outTemplated), "The snake says hiss")
+
+		// Remove the templated file at the end of the test
+		e2e.CleanFiles(deployTempaltedArtifact)
 	})
 }

--- a/src/test/e2e/02_component_actions_test.go
+++ b/src/test/e2e/02_component_actions_test.go
@@ -111,7 +111,7 @@ func TestComponentActions(t *testing.T) {
 		require.NoError(t, err, stdOut, stdErr)
 		require.FileExists(t, deployWithEnvVarArtifact)
 
-		// Remove the templated file at the end of the test
+		// Remove the env var file at the end of the test
 		e2e.CleanFiles(deployWithEnvVarArtifact)
 	})
 

--- a/src/test/e2e/02_component_actions_test.go
+++ b/src/test/e2e/02_component_actions_test.go
@@ -117,30 +117,30 @@ func TestComponentActions(t *testing.T) {
 
 	t.Run("action on-deploy-with-template", func(t *testing.T) {
 		t.Parallel()
-		deployTempaltedArtifact := "test-templated.txt"
+		deployTemplatedArtifact := "test-templated.txt"
 
 		// Test using a templated file but without dynamic variables
 		stdOut, stdErr, err = e2e.Zarf("package", "deploy", path, "--components=on-deploy-with-template-use-of-variable", "--confirm")
 		require.NoError(t, err, stdOut, stdErr)
-		outTemplated, err := os.ReadFile(deployTempaltedArtifact)
+		outTemplated, err := os.ReadFile(deployTemplatedArtifact)
 		require.NoError(t, err)
 		require.Contains(t, string(outTemplated), "The dog says ruff")
 		require.Contains(t, string(outTemplated), "The cat says ###ZARF_VAR_CAT_SOUND###")
 		require.Contains(t, string(outTemplated), "The snake says ###ZARF_VAR_SNAKE_SOUND###")
 
 		// Remove the templated file so we can test with dynamic variables
-		e2e.CleanFiles(deployTempaltedArtifact)
+		e2e.CleanFiles(deployTemplatedArtifact)
 
 		// Test using a templated file with dynamic variables
 		stdOut, stdErr, err = e2e.Zarf("package", "deploy", path, "--components=on-deploy-with-template-use-of-variable,on-deploy-with-dynamic-variable,on-deploy-with-multiple-variables", "--confirm")
 		require.NoError(t, err, stdOut, stdErr)
-		outTemplated, err = os.ReadFile(deployTempaltedArtifact)
+		outTemplated, err = os.ReadFile(deployTemplatedArtifact)
 		require.NoError(t, err)
 		require.Contains(t, string(outTemplated), "The dog says ruff")
 		require.Contains(t, string(outTemplated), "The cat says meow")
 		require.Contains(t, string(outTemplated), "The snake says hiss")
 
 		// Remove the templated file at the end of the test
-		e2e.CleanFiles(deployTempaltedArtifact)
+		e2e.CleanFiles(deployTemplatedArtifact)
 	})
 }


### PR DESCRIPTION
## Description

This fixes the cleanup of files in the parallel tests of component actions.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
