### PR TITLE
fixes an issue where renovate by default ignores examples directory

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,15 @@
   "ignoreDeps": [
     "sigs.k8s.io/kustomize/kyaml"
   ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/__tests__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ],
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
## Description

By [default](https://github.com/renovatebot/renovate/blob/e34f138a08dfcbb60ebc9f0c2a20cc8f09f95fde/lib/config/presets/internal/default.ts#L298) renovate ignores the `examples` path.  After [implementing checks against Big Bang versions in Repo1](https://github.com/defenseunicorns/zarf/pull/1585), I've noticed that renovate was not able to detect any issues.  I did some local debugging and discovered the issue.  This MR adds all the defaults, minus the examples directory.  

Testing locally:

```shell
LOG_LEVEL=debug renovate --token <token> --platform=local --dry-run
```

## Related Issue

#1585

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
