### PR TITLE
Allow for internal crane pulls and pushes without a tunnel + explicit auth

### DIFF
--- a/docs/2-the-zarf-cli/100-cli-commands/zarf_tools_registry_pull.md
+++ b/docs/2-the-zarf-cli/100-cli-commands/zarf_tools_registry_pull.md
@@ -7,6 +7,18 @@ Pull remote images by reference and store their contents locally
 zarf tools registry pull IMAGE TARBALL [flags]
 ```
 
+## Examples
+
+```
+
+	# pull an image from an internal repo in Zarf to a local tarball
+	$ zarf tools registry pull 127.0.0.1:31999/stefanprodan/podinfo:6.4.0 image.tar
+
+	# pull an image from a repo hosted at reg.example.com to a local tarball
+	$ zarf tools registry pull reg.example.com/stefanprodan/podinfo:6.4.0 image.tar
+
+```
+
 ## Options
 
 ```

--- a/docs/2-the-zarf-cli/100-cli-commands/zarf_tools_registry_push.md
+++ b/docs/2-the-zarf-cli/100-cli-commands/zarf_tools_registry_push.md
@@ -11,6 +11,18 @@ If the PATH is a directory, it will be read as an OCI image layout. Otherwise, P
 zarf tools registry push PATH IMAGE [flags]
 ```
 
+## Examples
+
+```
+
+	# push an image into an internal repo in Zarf
+	$ zarf tools registry push image.tar 127.0.0.1:31999/stefanprodan/podinfo:6.4.0
+
+	# push an image into an repo hosted at reg.example.com
+	$ zarf tools registry push image.tar reg.example.com/stefanprodan/podinfo:6.4.0
+
+```
+
 ## Options
 
 ```

--- a/src/cmd/tools/crane.go
+++ b/src/cmd/tools/crane.go
@@ -63,14 +63,14 @@ func init() {
 	craneLogin.Example = ""
 
 	registryCmd.AddCommand(craneLogin)
-	registryCmd.AddCommand(craneCmd.NewCmdPull(&craneOptions))
-	registryCmd.AddCommand(craneCmd.NewCmdPush(&craneOptions))
 
 	craneCopy := craneCmd.NewCmdCopy(&craneOptions)
 
 	registryCmd.AddCommand(craneCopy)
 	registryCmd.AddCommand(zarfCraneCatalog(&craneOptions))
-	registryCmd.AddCommand(zarfCraneList(&craneOptions))
+	registryCmd.AddCommand(zarfCraneInternalWrapper(craneCmd.NewCmdList, &craneOptions, lang.CmdToolsRegistryListExample, 0))
+	registryCmd.AddCommand(zarfCraneInternalWrapper(craneCmd.NewCmdPush, &craneOptions, lang.CmdToolsRegistryPushExample, 1))
+	registryCmd.AddCommand(zarfCraneInternalWrapper(craneCmd.NewCmdPull, &craneOptions, lang.CmdToolsRegistryPullExample, 0))
 
 	registryCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, lang.CmdToolsRegistryFlagVerbose)
 	registryCmd.PersistentFlags().BoolVar(&insecure, "insecure", false, lang.CmdToolsRegistryFlagInsecure)
@@ -122,17 +122,17 @@ func zarfCraneCatalog(cranePlatformOptions *[]crane.Option) *cobra.Command {
 }
 
 // Wrap the original crane list with a zarf specific version
-func zarfCraneList(cranePlatformOptions *[]crane.Option) *cobra.Command {
-	craneList := craneCmd.NewCmdList(cranePlatformOptions)
+func zarfCraneInternalWrapper(commandToWrap func(*[]crane.Option) *cobra.Command, cranePlatformOptions *[]crane.Option, exampleText string, imageNameArgumentIndex int) *cobra.Command {
+	wrappedCommand := commandToWrap(cranePlatformOptions)
 
-	craneList.Example = lang.CmdToolsRegistryListExample
-	craneList.Args = nil
+	wrappedCommand.Example = exampleText
+	wrappedCommand.Args = nil
 
-	originalListFn := craneList.RunE
+	originalListFn := wrappedCommand.RunE
 
-	craneList.RunE = func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			message.Fatal(nil, lang.CmdToolsCraneListNoRepoSpecified)
+	wrappedCommand.RunE = func(cmd *cobra.Command, args []string) error {
+		if len(args) < imageNameArgumentIndex+1 {
+			message.Fatal(nil, lang.CmdToolsCraneNotEnoughArgumentsSpecified)
 		}
 
 		// Try to connect to a Zarf initialized cluster otherwise then pass it down to crane.
@@ -148,7 +148,7 @@ func zarfCraneList(cranePlatformOptions *[]crane.Option) *cobra.Command {
 		}
 
 		// Check to see if it matches the existing internal address.
-		if !strings.HasPrefix(args[0], zarfState.RegistryInfo.Address) {
+		if !strings.HasPrefix(args[imageNameArgumentIndex], zarfState.RegistryInfo.Address) {
 			return originalListFn(cmd, args)
 		}
 
@@ -165,7 +165,7 @@ func zarfCraneList(cranePlatformOptions *[]crane.Option) *cobra.Command {
 
 			givenAddress := fmt.Sprintf("%s/", zarfState.RegistryInfo.Address)
 			tunnelAddress := fmt.Sprintf("%s/", tunnelReg.Endpoint())
-			args[0] = strings.Replace(args[0], givenAddress, tunnelAddress, 1)
+			args[imageNameArgumentIndex] = strings.Replace(args[imageNameArgumentIndex], givenAddress, tunnelAddress, 1)
 		}
 
 		// Add the correct authentication to the crane command options
@@ -175,5 +175,5 @@ func zarfCraneList(cranePlatformOptions *[]crane.Option) *cobra.Command {
 		return originalListFn(cmd, args)
 	}
 
-	return craneList
+	return wrappedCommand
 }

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -340,6 +340,22 @@ const (
 	$ zarf tools registry ls reg.example.com/stefanprodan/podinfo
 `
 
+	CmdToolsRegistryPushExample = `
+	# push an image into an internal repo in Zarf
+	$ zarf tools registry push image.tar 127.0.0.1:31999/stefanprodan/podinfo:6.4.0
+
+	# push an image into an repo hosted at reg.example.com
+	$ zarf tools registry push image.tar reg.example.com/stefanprodan/podinfo:6.4.0
+`
+
+	CmdToolsRegistryPullExample = `
+	# pull an image from an internal repo in Zarf to a local tarball
+	$ zarf tools registry pull 127.0.0.1:31999/stefanprodan/podinfo:6.4.0 image.tar
+
+	# pull an image from a repo hosted at reg.example.com to a local tarball
+	$ zarf tools registry pull reg.example.com/stefanprodan/podinfo:6.4.0 image.tar
+`
+
 	CmdToolsRegistryInvalidPlatformErr = "Invalid platform '%s': %s"
 	CmdToolsRegistryFlagVerbose        = "Enable debug logs"
 	CmdToolsRegistryFlagInsecure       = "Allow image references to be fetched without TLS"
@@ -359,7 +375,7 @@ const (
 	CmdToolsClearCacheSuccess       = "Successfully cleared the cache from %s"
 	CmdToolsClearCacheFlagCachePath = "Specify the location of the Zarf artifact cache (images and git repositories)"
 
-	CmdToolsCraneListNoRepoSpecified = "You must specify a repository name to return a list of tags for."
+	CmdToolsCraneNotEnoughArgumentsSpecified = "You do not have enough arguments specified."
 
 	CmdToolsDownloadInitShort               = "Downloads the init package for the current Zarf version into the specified directory"
 	CmdToolsDownloadInitFlagOutputDirectory = "Specify a directory to place the init package in."


### PR DESCRIPTION
Allow for internal crane pulls and pushes without a tunnel + explicit credentials

## Description

This gives the same ability as #1835 to `zarf tools crane push` and `zarf tools crane pull`.  Essentially, you shouldn't have to create a tunnel and auth to the registry to pull or push images to it.

## Related Issue

#1835

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
