### PR TITLE
Hotfix inline publish

### DIFF
--- a/src/pkg/message/message.go
+++ b/src/pkg/message/message.go
@@ -117,7 +117,7 @@ func GetLogLevel() LogLevel {
 
 // ZarfCommand prints a zarf terminal command.
 func ZarfCommand(format string, a ...any) {
-	Command("zarf"+format, a...)
+	Command("zarf "+format, a...)
 }
 
 // Command prints a zarf terminal command.

--- a/src/pkg/oci/utils.go
+++ b/src/pkg/oci/utils.go
@@ -27,6 +27,8 @@ import (
 //
 // appending the provided suffix to the version
 func ReferenceFromMetadata(registryLocation string, metadata *types.ZarfMetadata, suffix string) (*registry.Reference, error) {
+	registryLocation = strings.TrimPrefix(registryLocation, utils.OCIURLPrefix)
+
 	ver := metadata.Version
 	if len(ver) == 0 {
 		return nil, errors.New("version is required for publishing")

--- a/src/pkg/oci/utils.go
+++ b/src/pkg/oci/utils.go
@@ -40,6 +40,8 @@ func ReferenceFromMetadata(registryLocation string, metadata *types.ZarfMetadata
 
 	raw := fmt.Sprintf(format, registryLocation, metadata.Name, ver, suffix)
 
+	message.Debugf("raw OCI reference from metadata: %s", raw)
+
 	ref, err := registry.ParseReference(raw)
 	if err != nil {
 		return nil, err

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -42,7 +42,7 @@ func (p *Packager) Create(baseDir string) error {
 	}
 
 	if utils.IsOCIURL(p.cfg.CreateOpts.Output) {
-		ref, err := oci.ReferenceFromMetadata(p.cfg.CreateOpts.Output, &p.cfg.Pkg.Metadata, p.cfg.Pkg.Build.Architecture)
+		ref, err := oci.ReferenceFromMetadata(p.cfg.CreateOpts.Output, &p.cfg.Pkg.Metadata, p.arch)
 		if err != nil {
 			return err
 		}

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -40,7 +40,7 @@ func (p *Packager) Publish() error {
 		if err != nil {
 			return fmt.Errorf("unable to read the zarf.yaml in %s: %w", p.tmp.Base, err)
 		}
-		referenceSuffix = p.cfg.Pkg.Build.Architecture
+		referenceSuffix = p.arch
 	}
 
 	// Get a reference to the registry for this package

--- a/src/test/e2e/50_oci_package_test.go
+++ b/src/test/e2e/50_oci_package_test.go
@@ -61,7 +61,7 @@ func (suite *RegistryClientTestSuite) Test_0_Publish() {
 
 	// Inline publish package.
 	dir := filepath.Join("examples", "helm-charts")
-	stdOut, stdErr, err = e2e.Zarf("package", "create", dir, "-o", "oci://"+ref, "--insecure", "--oci-concurrency=5")
+	stdOut, stdErr, err = e2e.Zarf("package", "create", dir, "-o", "oci://"+ref, "--insecure", "--oci-concurrency=5", "--confirm")
 	suite.NoError(err, stdOut, stdErr)
 }
 

--- a/src/test/e2e/50_oci_package_test.go
+++ b/src/test/e2e/50_oci_package_test.go
@@ -58,6 +58,11 @@ func (suite *RegistryClientTestSuite) Test_0_Publish() {
 	example = filepath.Join(suite.PackagesDir, fmt.Sprintf("zarf-package-dos-games-%s.tar.zst", e2e.Arch))
 	_, stdErr, err = e2e.Zarf("package", "publish", example, "oci://"+ref, "--insecure")
 	suite.Error(err, stdErr)
+
+	// Inline publish package.
+	dir := filepath.Join("examples", "helm-charts")
+	stdOut, stdErr, err = e2e.Zarf("package", "create", dir, "-o", "oci://"+ref, "--insecure", "--oci-concurrency=5")
+	suite.NoError(err, stdOut, stdErr)
 }
 
 func (suite *RegistryClientTestSuite) Test_1_Pull() {


### PR DESCRIPTION
## Description

Fixes `ReferenceFromMetadata` not properly receiving the `arch` suffix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

