### PR TITLE
hotfix: create all namespaces, even when in yolo mode

### DIFF
--- a/src/internal/packager/helm/post-render.go
+++ b/src/internal/packager/helm/post-render.go
@@ -198,9 +198,9 @@ func (r *renderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error) {
 			}
 		}
 
-		// If the package is marked as YOLO and the state is empty, skip the secret creation
+		// If the package is marked as YOLO and the state is empty, skip the secret creation for this namespace
 		if r.options.Cfg.Pkg.Metadata.YOLO && r.options.Cfg.State.Distro == "YOLO" {
-			break
+			continue
 		}
 
 		// Create the secret


### PR DESCRIPTION
When deploying a yolo package, we still want the post-render logic to create all the namespaces for us. The `break` statement we had before was stopping before creating all of the namespaces.