### PR TITLE
[TASK] TransformGitURL helm helper

### DIFF
--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -12,6 +12,7 @@ import (
 	"github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/internal/packager/git"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
+	"github.com/defenseunicorns/zarf/src/pkg/transform"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/registry"
@@ -164,4 +165,19 @@ func (h *Helm) DownloadChartFromGitToTemp(spinner *message.Spinner) (string, err
 	}
 
 	return gitCfg.GitPath, nil
+}
+
+// Helper function src/pkg/packager/prepare.goL118 src/pkg/packager/create.goL328
+func (h *Helm) TransformGitURL(charts string) (string, error) {
+	// calling GitTransformURLSplitRef() to see if refPlain is empty
+	_, refPlain, _ := transform.GitTransformURLSplitRef(h.Chart.URL)
+
+	// if it is append chart version as if its a tag
+	if refPlain == "" {
+		h.Chart.URL = fmt.Sprintf("%s@%s", h.Chart.URL, h.Chart.Version)
+	}
+
+	// reduce code duplication
+	return h.PackageChartFromGit(charts)
+
 }

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -326,7 +326,9 @@ func (p *Packager) addComponent(index int, component types.ZarfComponent, isSkel
 
 	// If any helm charts are defined, process them.
 	for chartIdx, chart := range component.Charts {
-		re := regexp.MustCompile(`\.git$`)
+		// https://regex101.com/r/jYLoUy/1
+		re := regexp.MustCompile(`\.git@`)
+		// check if the chart is a git url with a ref
 		isGitURL := re.MatchString(chart.URL)
 		helmCfg := helm.Helm{
 			Chart: chart,
@@ -344,7 +346,8 @@ func (p *Packager) addComponent(index int, component types.ZarfComponent, isSkel
 
 			p.cfg.Pkg.Components[index].Charts[chartIdx].LocalPath = rel
 		} else if isGitURL {
-			_, err = helmCfg.PackageChartFromGit(componentPath.Charts)
+			_, err = helmCfg.TransformGitURL(componentPath.Charts)
+			// _, err = helmCfg.PackageChartFromGit(componentPath.Charts)
 			if err != nil {
 				return fmt.Errorf("error creating chart archive, unable to pull the chart from git: %s", err.Error())
 			}

--- a/src/pkg/packager/prepare.go
+++ b/src/pkg/packager/prepare.go
@@ -113,9 +113,11 @@ func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOver
 		if len(component.Charts) > 0 {
 			_ = utils.CreateDirectory(componentPath.Charts, 0700)
 			_ = utils.CreateDirectory(componentPath.Values, 0700)
-			re := regexp.MustCompile(`\.git$`)
+			// https://regex101.com/r/jYLoUy/1
+			re := regexp.MustCompile(`\.git@`)
 
 			for _, chart := range component.Charts {
+				// check if the chart is a git url with a ref
 				isGitURL := re.MatchString(chart.URL)
 				helmCfg := helm.Helm{
 					Chart: chart,
@@ -124,7 +126,8 @@ func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOver
 
 				helmCfg.Cfg.State = types.ZarfState{}
 				if isGitURL {
-					path, err := helmCfg.PackageChartFromGit(componentPath.Charts)
+					path, err := helmCfg.TransformGitURL(componentPath.Charts)
+					// path, err := helmCfg.PackageChartFromGit(componentPath.Charts)
 					if err != nil {
 						return fmt.Errorf("unable to download chart from git repo (%s): %w", chart.URL, err)
 					}


### PR DESCRIPTION
## Description

What we could do (to keep backwards compat in tact and address https://github.com/defenseunicorns/zarf/issues/1766) is see if there is an @ ref on the git URL and if there is, leave it on there, and if not append the @tag as we do today. Dedup some code in src/pkg/packager/prepare.go, and src/pkg/packager/create.go.
## Related Issue

Fixes #
<!-- or -->
Relates to #1766

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
