### PR TITLE
Add ExitOnInterrupt utils function; catch interrupts when using wait

### DIFF
--- a/src/cmd/tools/wait.go
+++ b/src/cmd/tools/wait.go
@@ -29,6 +29,7 @@ var waitForCmd = &cobra.Command{
 	Example: lang.CmdToolsWaitForExample,
 	Args:    cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
+		exec.ExitOnInterrupt(1, lang.ErrInterrupt)
 		// Parse the timeout string
 		timeout, err := time.ParseDuration(waitTimeout)
 		if err != nil {

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -27,6 +27,7 @@ const (
 	ErrCreatingDir         = "failed to create directory %s: %s"
 	ErrRemoveFile          = "failed to remove file %s: %s"
 	ErrUnarchive           = "failed to unarchive %s: %s"
+	ErrInterrupt           = "Failed due to interrupt"
 )
 
 // Zarf CLI commands.


### PR DESCRIPTION
Add ExitOnInterrupt utils function; catch interrupts when using wait

## Description

Add ability to catch interrupts when using wait command.

## Related Issue

Fixes #1864

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
