### PR TITLE
Hotfix: only verify authentication to registry if creds exist

### DIFF
--- a/src/pkg/oci/common.go
+++ b/src/pkg/oci/common.go
@@ -54,9 +54,11 @@ func NewOrasRemote(url string) (*OrasRemote, error) {
 		return nil, err
 	}
 
-	err = o.CheckAuth()
-	if err != nil {
-		return nil, fmt.Errorf("unable to authenticate to %s: %s", ref.Registry, err.Error())
+	if auth.GetScopes(o.Context) != nil {
+		err = o.CheckAuth()
+		if err != nil {
+			return nil, fmt.Errorf("unable to authenticate to %s: %s", ref.Registry, err.Error())
+		}
 	}
 
 	copyOpts := oras.DefaultCopyOptions

--- a/src/pkg/oci/common.go
+++ b/src/pkg/oci/common.go
@@ -30,12 +30,11 @@ const (
 
 // OrasRemote is a wrapper around the Oras remote repository that includes a progress bar for interactive feedback.
 type OrasRemote struct {
-	repo           *remote.Repository
-	ctx            context.Context
-	Transport      *utils.Transport
-	CopyOpts       oras.CopyOptions
-	client         *auth.Client
-	hasCredentials bool
+	repo      *remote.Repository
+	ctx       context.Context
+	Transport *utils.Transport
+	CopyOpts  oras.CopyOptions
+	client    *auth.Client
 }
 
 // NewOrasRemote returns an oras remote repository client and context for the given url.
@@ -64,7 +63,6 @@ func NewOrasRemote(url string) (*OrasRemote, error) {
 
 // WithRepository sets the repository for the remote as well as the auth client.
 func (o *OrasRemote) WithRepository(ref registry.Reference) error {
-	o.hasCredentials = false
 	// patch docker.io to registry-1.docker.io
 	// this allows end users to use docker.io as an alias for registry-1.docker.io
 	if ref.Registry == "docker.io" {
@@ -111,10 +109,6 @@ func (o *OrasRemote) withAuthClient(ref registry.Reference) (*auth.Client, error
 	authConf, err := configs[0].GetCredentialsStore(key).Get(key)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get credentials for %s: %w", key, err)
-	}
-
-	if authConf.ServerAddress != "" {
-		o.hasCredentials = true
 	}
 
 	cred := auth.Credential{

--- a/src/pkg/oci/common.go
+++ b/src/pkg/oci/common.go
@@ -147,6 +147,14 @@ func (o *OrasRemote) CheckAuth(scopes ...string) error {
 	if scopes == nil && o.hasCredentials {
 		return fmt.Errorf("%s requires authentication but no request scopes were provided", o.repo.Reference)
 	}
+	if scopes == nil {
+		// no scopes provided, skipping auth check
+		return nil
+	}
+	if !o.hasCredentials {
+		// no credentials provided, skipping auth check
+		return nil
+	}
 	// check if we've already checked the scopes
 	currentScopes := auth.GetScopes(o.ctx)
 	equal := reflect.DeepEqual(currentScopes, scopes)

--- a/src/pkg/oci/common.go
+++ b/src/pkg/oci/common.go
@@ -167,7 +167,7 @@ func (o *OrasRemote) CheckAuth(scopes ...string) error {
 	reg.Client = o.client
 	err = reg.Ping(o.Context)
 	if err == nil {
-		return fmt.Errorf("unable to authenticate to %s: %s", reg.Reference, err.Error())
+		return fmt.Errorf("unable to authenticate to %s: %s", o.Reference.Registry, err.Error())
 	}
 	return nil
 }

--- a/src/pkg/oci/common.go
+++ b/src/pkg/oci/common.go
@@ -6,7 +6,6 @@ package oci
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -113,7 +112,8 @@ func (o *OrasRemote) withAuthClient(ref registry.Reference) (*auth.Client, error
 		return nil, err
 	}
 	if !cfg.ContainsAuth() {
-		return nil, errors.New("no docker config file found, run 'zarf tools registry login --help'")
+		message.Debug("no docker config file found, run 'zarf tools registry login --help'")
+		return nil, nil
 	}
 
 	configs := []*configfile.ConfigFile{cfg}

--- a/src/pkg/oci/common.go
+++ b/src/pkg/oci/common.go
@@ -125,7 +125,7 @@ func (o *OrasRemote) withAuthClient(ref registry.Reference) (*auth.Client, error
 
 	client := &auth.Client{
 		Credential: auth.StaticCredential(ref.Registry, cred),
-		Cache:      auth.NewCache(),
+		Cache:      auth.DefaultCache,
 		Client: &http.Client{
 			Transport: o.Transport,
 		},

--- a/src/pkg/oci/common.go
+++ b/src/pkg/oci/common.go
@@ -144,6 +144,12 @@ func (o *OrasRemote) withAuthClient(ref registry.Reference) (*auth.Client, error
 
 // CheckAuth checks if the user is authenticated to the remote registry.
 func (o *OrasRemote) CheckAuth(scopes ...string) error {
+	if scopes == nil && o.hasCredentials {
+		return fmt.Errorf("%s requires authentication but no request scopes were provided", o.Reference)
+	}
+	if scopes != nil {
+		scopes = []string{auth.ScopeRepository(o.Reference.Repository, scopes...)}
+	}
 	// check if we've already checked the scopes
 	currentScopes := auth.GetScopes(o.Context)
 	equal := reflect.DeepEqual(currentScopes, scopes)
@@ -156,7 +162,7 @@ func (o *OrasRemote) CheckAuth(scopes ...string) error {
 	if o.hasCredentials {
 		o.Context = auth.WithScopes(o.Context, scopes...)
 	}
-	reg, err := remote.NewRegistry(o.Repository.Reference.Registry)
+	reg, err := remote.NewRegistry(o.Reference.Registry)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/oci/common.go
+++ b/src/pkg/oci/common.go
@@ -147,9 +147,6 @@ func (o *OrasRemote) CheckAuth(scopes ...string) error {
 	if scopes == nil && o.hasCredentials {
 		return fmt.Errorf("%s requires authentication but no request scopes were provided", o.Reference)
 	}
-	if scopes != nil {
-		scopes = []string{auth.ScopeRepository(o.Reference.Repository, scopes...)}
-	}
 	// check if we've already checked the scopes
 	currentScopes := auth.GetScopes(o.Context)
 	equal := reflect.DeepEqual(currentScopes, scopes)

--- a/src/pkg/oci/common.go
+++ b/src/pkg/oci/common.go
@@ -140,23 +140,3 @@ func (o *OrasRemote) withAuthClient(ref registry.Reference) (*auth.Client, error
 
 	return client, nil
 }
-
-// CheckAuth checks if the user is authenticated to the remote registry.
-func (o *OrasRemote) CheckRepoAuth() error {
-	// if we have credentials, add the scopes to the context
-	if o.hasCredentials {
-		scope := auth.ScopeRepository(o.repo.Reference.Repository, auth.ActionPull)
-		o.ctx = auth.AppendScopes(o.ctx, scope)
-	}
-	reg, err := remote.NewRegistry(o.repo.Reference.Registry)
-	if err != nil {
-		return err
-	}
-	reg.PlainHTTP = zarfconfig.CommonOptions.Insecure
-	reg.Client = o.client
-	err = reg.Ping(o.ctx)
-	if err != nil {
-		return fmt.Errorf("unable to authenticate to %s: %s", o.repo.Reference.Registry, err.Error())
-	}
-	return nil
-}

--- a/src/pkg/oci/common.go
+++ b/src/pkg/oci/common.go
@@ -150,8 +150,8 @@ func (o *OrasRemote) CheckAuth(scopes ...string) error {
 	// check if we've already checked the scopes
 	currentScopes := auth.GetScopes(o.Context)
 	equal := reflect.DeepEqual(currentScopes, scopes)
-	// if we've already checked the scopes and we dont have credentials, return
-	if equal && !o.hasCredentials {
+	// if we've already checked the scopes return
+	if equal {
 		return nil
 	}
 
@@ -166,7 +166,7 @@ func (o *OrasRemote) CheckAuth(scopes ...string) error {
 	reg.PlainHTTP = zarfconfig.CommonOptions.Insecure
 	reg.Client = o.client
 	err = reg.Ping(o.Context)
-	if err == nil {
+	if err != nil {
 		return fmt.Errorf("unable to authenticate to %s: %s", o.Reference.Registry, err.Error())
 	}
 	return nil

--- a/src/pkg/oci/pull.go
+++ b/src/pkg/oci/pull.go
@@ -29,7 +29,7 @@ var (
 )
 
 func (o *OrasRemote) checkPull() error {
-	scopes := auth.ScopeRepository(o.Reference.Repository, auth.ActionPull)
+	scopes := auth.ScopeRepository(o.repo.Reference.Repository, auth.ActionPull)
 	return o.CheckAuth(scopes)
 }
 
@@ -132,7 +132,7 @@ func (o *OrasRemote) PullPackage(destinationDir string, concurrency int, layersT
 		return nil, err
 	}
 	isPartialPull := len(layersToPull) > 0
-	ref := o.Reference
+	ref := o.repo.Reference
 
 	pterm.Println()
 	message.Debugf("Pulling %s", ref.String())
@@ -190,7 +190,7 @@ func (o *OrasRemote) PullPackage(destinationDir string, concurrency int, layersT
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go utils.RenderProgressBarForLocalDirWrite(destinationDir, estimatedBytes, &wg, doneSaving, "Pulling Zarf package data")
-	_, err = oras.Copy(o.Context, o.Repository, ref.String(), dst, ref.String(), copyOpts)
+	_, err = oras.Copy(o.ctx, o.repo, ref.String(), dst, ref.String(), copyOpts)
 	if err != nil {
 		return partialPaths, err
 	}

--- a/src/pkg/oci/pull.go
+++ b/src/pkg/oci/pull.go
@@ -35,9 +35,6 @@ func (o *OrasRemote) checkPull() error {
 
 // LayersFromPaths returns the descriptors for the given paths from the root manifest.
 func (o *OrasRemote) LayersFromPaths(requestedPaths []string) (layers []ocispec.Descriptor, err error) {
-	if err := o.checkPull(); err != nil {
-		return nil, err
-	}
 	manifest, err := o.FetchRoot()
 	if err != nil {
 		return nil, err
@@ -58,9 +55,6 @@ func (o *OrasRemote) LayersFromPaths(requestedPaths []string) (layers []ocispec.
 //
 // It also respects the `required` flag on components, and will retrieve all necessary layers for required components.
 func (o *OrasRemote) LayersFromRequestedComponents(requestedComponents []string) (layers []ocispec.Descriptor, err error) {
-	if err := o.checkPull(); err != nil {
-		return nil, err
-	}
 	root, err := o.FetchRoot()
 	if err != nil {
 		return nil, err

--- a/src/pkg/oci/pull.go
+++ b/src/pkg/oci/pull.go
@@ -20,18 +20,12 @@ import (
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/file"
-	"oras.land/oras-go/v2/registry/remote/auth"
 )
 
 var (
 	// AlwaysPull is a list of paths that will always be pulled from the remote repository.
 	AlwaysPull = []string{config.ZarfYAML, config.ZarfChecksumsTxt, config.ZarfYAMLSignature}
 )
-
-func (o *OrasRemote) checkPull() error {
-	scopes := auth.ScopeRepository(o.repo.Reference.Repository, auth.ActionPull)
-	return o.CheckAuth(scopes)
-}
 
 // LayersFromPaths returns the descriptors for the given paths from the root manifest.
 func (o *OrasRemote) LayersFromPaths(requestedPaths []string) (layers []ocispec.Descriptor, err error) {
@@ -128,9 +122,6 @@ func (o *OrasRemote) LayersFromRequestedComponents(requestedComponents []string)
 //   - checksums.txt
 //   - zarf.yaml.sig
 func (o *OrasRemote) PullPackage(destinationDir string, concurrency int, layersToPull ...ocispec.Descriptor) (partialPaths []string, err error) {
-	if err := o.checkPull(); err != nil {
-		return nil, err
-	}
 	isPartialPull := len(layersToPull) > 0
 	ref := o.repo.Reference
 
@@ -215,9 +206,6 @@ func (o *OrasRemote) PullPackage(destinationDir string, concurrency int, layersT
 
 // PullLayer pulls a layer from the remote repository and saves it to `destinationDir/annotationTitle`.
 func (o *OrasRemote) PullLayer(desc ocispec.Descriptor, destinationDir string) error {
-	if err := o.checkPull(); err != nil {
-		return err
-	}
 	if desc.MediaType != ZarfLayerMediaTypeBlob {
 		return fmt.Errorf("invalid media type for file layer: %s", desc.MediaType)
 	}
@@ -230,9 +218,6 @@ func (o *OrasRemote) PullLayer(desc ocispec.Descriptor, destinationDir string) e
 
 // PullPackageMetadata pulls the package metadata from the remote repository and saves it to `destinationDir`.
 func (o *OrasRemote) PullPackageMetadata(destinationDir string) (err error) {
-	if err := o.checkPull(); err != nil {
-		return err
-	}
 	root, err := o.FetchRoot()
 	if err != nil {
 		return err

--- a/src/pkg/oci/pull.go
+++ b/src/pkg/oci/pull.go
@@ -29,7 +29,7 @@ var (
 )
 
 func (o *OrasRemote) checkPull() error {
-	scopes := auth.ScopeRepository(o.Reference.Registry, auth.ActionPull)
+	scopes := auth.ScopeRepository(o.Reference.Repository, auth.ActionPull)
 	return o.CheckAuth(scopes)
 }
 

--- a/src/pkg/oci/push.go
+++ b/src/pkg/oci/push.go
@@ -20,7 +20,6 @@ import (
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/file"
-	"oras.land/oras-go/v2/registry/remote/auth"
 )
 
 // ConfigPartial is a partial OCI config that is used to create the manifest config.
@@ -37,16 +36,8 @@ type ConfigPartial struct {
 	Annotations  map[string]string `json:"annotations,omitempty"`
 }
 
-func (o *OrasRemote) checkPush() error {
-	scopes := auth.ScopeRepository(o.repo.Reference.Repository, auth.ActionPull, auth.ActionPush)
-	return o.CheckAuth(scopes)
-}
-
 // PushLayer pushes the given layer (bytes) to the remote repository.
 func (o *OrasRemote) PushLayer(b []byte, mediaType string) (*ocispec.Descriptor, error) {
-	if err := o.checkPush(); err != nil {
-		return nil, err
-	}
 	desc := content.NewDescriptorFromBytes(mediaType, b)
 	return &desc, o.repo.Push(o.ctx, desc, bytes.NewReader(b))
 }
@@ -111,9 +102,6 @@ func (o *OrasRemote) generatePackManifest(src *file.Store, descs []ocispec.Descr
 
 // PublishPackage publishes the package to the remote repository.
 func (o *OrasRemote) PublishPackage(pkg *types.ZarfPackage, sourceDir string, concurrency int) error {
-	if err := o.checkPush(); err != nil {
-		return err
-	}
 	ctx := o.ctx
 	// source file store
 	src, err := file.New(sourceDir)

--- a/src/pkg/oci/push.go
+++ b/src/pkg/oci/push.go
@@ -38,7 +38,7 @@ type ConfigPartial struct {
 }
 
 func (o *OrasRemote) checkPush() error {
-	scopes := auth.ScopeRepository(o.Reference.Registry, auth.ActionPull, auth.ActionPush)
+	scopes := auth.ScopeRepository(o.Reference.Repository, auth.ActionPull, auth.ActionPush)
 	return o.CheckAuth(scopes)
 }
 

--- a/src/pkg/oci/utils.go
+++ b/src/pkg/oci/utils.go
@@ -54,6 +54,9 @@ func ReferenceFromMetadata(registryLocation string, metadata *types.ZarfMetadata
 
 // FetchRoot fetches the root manifest from the remote repository.
 func (o *OrasRemote) FetchRoot() (*ZarfOCIManifest, error) {
+	if err := o.checkPull(); err != nil {
+		return nil, err
+	}
 	// get the manifest descriptor
 	descriptor, err := o.Resolve(o.Context, o.Reference.Reference)
 	if err != nil {
@@ -88,6 +91,9 @@ func (o *OrasRemote) FetchManifest(desc ocispec.Descriptor) (manifest *ZarfOCIMa
 
 // FetchLayer fetches the layer with the given descriptor from the remote repository.
 func (o *OrasRemote) FetchLayer(desc ocispec.Descriptor) (bytes []byte, err error) {
+	if err := o.checkPull(); err != nil {
+		return nil, err
+	}
 	return content.FetchAll(o.Context, o, desc)
 }
 

--- a/src/pkg/oci/utils.go
+++ b/src/pkg/oci/utils.go
@@ -54,9 +54,6 @@ func ReferenceFromMetadata(registryLocation string, metadata *types.ZarfMetadata
 
 // FetchRoot fetches the root manifest from the remote repository.
 func (o *OrasRemote) FetchRoot() (*ZarfOCIManifest, error) {
-	if err := o.checkPull(); err != nil {
-		return nil, err
-	}
 	// get the manifest descriptor
 	descriptor, err := o.repo.Resolve(o.ctx, o.repo.Reference.Reference)
 	if err != nil {
@@ -91,9 +88,6 @@ func (o *OrasRemote) FetchManifest(desc ocispec.Descriptor) (manifest *ZarfOCIMa
 
 // FetchLayer fetches the layer with the given descriptor from the remote repository.
 func (o *OrasRemote) FetchLayer(desc ocispec.Descriptor) (bytes []byte, err error) {
-	if err := o.checkPull(); err != nil {
-		return nil, err
-	}
 	return content.FetchAll(o.ctx, o.repo, desc)
 }
 

--- a/src/pkg/oci/utils.go
+++ b/src/pkg/oci/utils.go
@@ -58,7 +58,7 @@ func (o *OrasRemote) FetchRoot() (*ZarfOCIManifest, error) {
 		return nil, err
 	}
 	// get the manifest descriptor
-	descriptor, err := o.Resolve(o.Context, o.Reference.Reference)
+	descriptor, err := o.repo.Resolve(o.ctx, o.repo.Reference.Reference)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (o *OrasRemote) FetchLayer(desc ocispec.Descriptor) (bytes []byte, err erro
 	if err := o.checkPull(); err != nil {
 		return nil, err
 	}
-	return content.FetchAll(o.Context, o, desc)
+	return content.FetchAll(o.ctx, o.repo, desc)
 }
 
 // FetchZarfYAML fetches the zarf.yaml file from the remote repository.

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -66,7 +66,7 @@ func (p *Packager) Publish() error {
 		}
 	}
 
-	message.HeaderInfof("📦 PACKAGE PUBLISH %s:%s", p.cfg.Pkg.Metadata.Name, p.remote.Reference.Reference)
+	message.HeaderInfof("📦 PACKAGE PUBLISH %s:%s", p.cfg.Pkg.Metadata.Name, ref)
 
 	// Publish the package/skeleton to the registry
 	return p.remote.PublishPackage(&p.cfg.Pkg, p.tmp.Base, config.CommonOptions.OCIConcurrency)

--- a/src/test/common.go
+++ b/src/test/common.go
@@ -15,8 +15,6 @@ import (
 
 	"github.com/defenseunicorns/zarf/src/pkg/utils/exec"
 	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
-	dconfig "github.com/docker/cli/cli/config"
-	"github.com/docker/cli/cli/config/configfile"
 	"github.com/stretchr/testify/require"
 )
 
@@ -101,22 +99,11 @@ func (e2e *ZarfE2ETest) GetLogFileContents(t *testing.T, stdErr string) string {
 }
 
 // SetupDockerRegistry uses the host machine's docker daemon to spin up a local registry for testing purposes.
-func (e2e *ZarfE2ETest) SetupDockerRegistry(t *testing.T, port int) *configfile.ConfigFile {
+func (e2e *ZarfE2ETest) SetupDockerRegistry(t *testing.T, port int) {
 	// spin up a local registry
 	registryImage := "registry:2.8.2"
 	err := exec.CmdWithPrint("docker", "run", "-d", "--restart=always", "-p", fmt.Sprintf("%d:5000", port), "--name", "registry", registryImage)
 	require.NoError(t, err)
-
-	// docker config folder
-	cfg, err := dconfig.Load(dconfig.Dir())
-	require.NoError(t, err)
-	if !cfg.ContainsAuth() {
-		// make a docker config file w/ some blank creds
-		_, _, err := e2e.Zarf("tools", "registry", "login", "--username", "zarf", "-p", "zarf", "localhost:6000")
-		require.NoError(t, err)
-	}
-
-	return cfg
 }
 
 // GetZarfVersion returns the current build/zarf version

--- a/src/test/e2e/50_oci_package_test.go
+++ b/src/test/e2e/50_oci_package_test.go
@@ -122,6 +122,11 @@ func (suite *RegistryClientTestSuite) Test_3_Inspect() {
 	// Test inspect w/ bad ref.
 	_, stdErr, err = e2e.Zarf("package", "inspect", "oci://"+badRef.String(), "--insecure")
 	suite.Error(err, stdErr)
+
+	// Test inspect on a public package.
+	// NOTE: This also makes sure that Zarf does not attempt auth when inspecting a public package.
+	_, stdErr, err = e2e.Zarf("package", "inspect", "oci://ghcr.io/defenseunicorns/packages/dubbd-k3d:0.3.0-amd64")
+	suite.NoError(err, stdErr)
 }
 
 func (suite *RegistryClientTestSuite) Test_4_Pull_And_Deploy() {

--- a/src/test/e2e/52_oci_compose_differential_test.go
+++ b/src/test/e2e/52_oci_compose_differential_test.go
@@ -41,7 +41,7 @@ func (suite *OCIDifferentialSuite) SetupSuite() {
 	differentialPackageName = fmt.Sprintf("zarf-package-podinfo-with-oci-flux-%s-v0.24.0-differential-v0.25.0.tar.zst", e2e.Arch)
 	normalPackageName = fmt.Sprintf("zarf-package-podinfo-with-oci-flux-%s-v0.24.0.tar.zst", e2e.Arch)
 
-	_ = e2e.SetupDockerRegistry(suite.T(), 555)
+	e2e.SetupDockerRegistry(suite.T(), 555)
 	suite.Reference.Registry = "localhost:555"
 }
 


### PR DESCRIPTION
## Description

Fixes what I broke.

This does re-architect some portions of OrasRemote and locks it down more. Everything in `*remote.Registry` is no longer exposed to outside usage and users of this remote client are restricted to the public receiver methods written in `pkg/oci`.

The context is now private as it really should not be edited outside of private receivers within OrasRemote.

During the writing of this PR I found out that ORAs already handles scopes at the request level and there is zero need to handle scopes yourself. I have not checked if I never had to do this, or if ORAs updated.

## Related Issue

Fixes #1881 
Fixes #1795 
Fixes #1821 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
