### PR TITLE
[TASK] Tests for named ports, wait-for, and metrics

### DIFF
--- a/examples/manifests/httpd-deployment.yaml
+++ b/examples/manifests/httpd-deployment.yaml
@@ -17,3 +17,4 @@ spec:
         image: httpd:alpine3.18
         ports:
         - containerPort: 80
+          name: httpd

--- a/examples/manifests/httpd-service.yaml
+++ b/examples/manifests/httpd-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: httpd
+  labels:
+    # Enables "zarf connect httpd"
+    zarf.dev/connect-name: httpd
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: httpd
+  selector:
+    app: httpd
+status:
+  loadBalancer: {}
+  

--- a/examples/manifests/zarf.yaml
+++ b/examples/manifests/zarf.yaml
@@ -12,6 +12,7 @@ components:
         files:
           # local manifests are specified relative to the `zarf.yaml` that uses them:
           - httpd-deployment.yaml
+          - httpd-service.yaml
     actions:
       onDeploy:
       # the following checks were computed by viewing the success state of the package deployment
@@ -22,7 +23,7 @@ components:
                 kind: deployment
                 name: httpd-deployment
                 namespace: httpd
-                condition: available
+                condition: '{.status.readyReplicas}=2'
     # image discovery is supported in all manifests and charts using:
     # zarf prepare find-images
     images:

--- a/src/internal/agent/http/server.go
+++ b/src/internal/agent/http/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/defenseunicorns/zarf/src/internal/agent/hooks"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // NewAdmissionServer creates an http.Server for the mutating webhook admission handler.
@@ -26,6 +27,7 @@ func NewAdmissionServer(port string) *http.Server {
 	mux.Handle("/healthz", healthz())
 	mux.Handle("/mutate/pod", ah.Serve(podsMutation))
 	mux.Handle("/mutate/flux-gitrepository", ah.Serve(gitRepositoryMutation))
+	mux.Handle("/metrics", promhttp.Handler())
 
 	return &http.Server{
 		Addr:    fmt.Sprintf(":%s", port),
@@ -40,6 +42,7 @@ func NewProxyServer(port string) *http.Server {
 	mux := http.NewServeMux()
 	mux.Handle("/healthz", healthz())
 	mux.Handle("/", ProxyHandler())
+	mux.Handle("/metrics", promhttp.Handler())
 
 	return &http.Server{
 		Addr:    fmt.Sprintf(":%s", port),

--- a/src/test/e2e/21_connect_test.go
+++ b/src/test/e2e/21_connect_test.go
@@ -5,6 +5,8 @@
 package test
 
 import (
+	"crypto/tls"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -57,4 +59,41 @@ func TestConnect(t *testing.T) {
 
 	stdOut, stdErr, err = e2e.Zarf("package", "remove", "init", "--components=logging", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
+}
+
+func TestMetrics(t *testing.T) {
+	t.Log("E2E: Emits metrics")
+	e2e.SetupWithCluster(t)
+
+	tunnel, err := cluster.NewTunnel("zarf", "svc", "agent-hook", 8888, 8443)
+
+	require.NoError(t, err)
+	err = tunnel.Connect("", false)
+	require.NoError(t, err)
+	defer tunnel.Close()
+
+	// Get untrusted https endpoint
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	client := &http.Client{Transport: tr}
+	https_endpoint := strings.ReplaceAll(tunnel.HTTPEndpoint(), "http", "https")
+	resp, err := client.Get(https_endpoint + "/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	// Read the response body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	desiredString := "go_gc_duration_seconds_count"
+	require.Equal(t, true, strings.Contains(string(body), desiredString))
+	require.NoError(t, err, resp)
+	require.Equal(t, 200, resp.StatusCode)
+
 }

--- a/src/test/e2e/26_simple_packages_test.go
+++ b/src/test/e2e/26_simple_packages_test.go
@@ -48,6 +48,19 @@ func TestManifests(t *testing.T) {
 	stdOut, stdErr, err := e2e.Zarf("package", "deploy", path, "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 
+	// Test Named Port
+	tunnel, err := cluster.NewTunnel("httpd", "svc", "httpd", 8080, 80)
+
+	require.NoError(t, err)
+	err = tunnel.Connect("", false)
+	require.NoError(t, err)
+	defer tunnel.Close()
+
+	// Ensure connection
+	resp, err := http.Get(tunnel.HTTPEndpoint())
+	require.NoError(t, err, resp)
+	require.Equal(t, 200, resp.StatusCode)
+
 	// Remove the package
 	stdOut, stdErr, err = e2e.Zarf("package", "remove", "manifests", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)


### PR DESCRIPTION
## Description

...

## Related Issue

Expose Prometheus metrics through /metrics HTTP endpoint.
Add example of how to scrape metrics.

This PR also tests:

- [Named Ports PR](https://github.com/cmwylie19/zarf/blob/d5a9cf2a9a16d56a0fd6dca72ac6e695f5ae8835/examples/manifests/httpd-service.yaml#L13)
- [Wait-For PR (jsonPath)](https://github.com/cmwylie19/zarf/blob/d5a9cf2a9a16d56a0fd6dca72ac6e695f5ae8835/examples/manifests/zarf.yaml#L26)

Fixes #1849
<!-- or -->
Relates to #1693 #1873 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
