### PR TITLE
More powerful version cmd

### DIFF
--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -6,26 +6,78 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"runtime"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/config/lang"
 	"github.com/spf13/cobra"
+
+	"runtime/debug"
+
+	goyaml "github.com/goccy/go-yaml"
 )
+
+var showDependencies bool
+var showBuild bool
 
 var versionCmd = &cobra.Command{
 	Use:     "version",
 	Aliases: []string{"v"},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		config.SkipLogFile = true
-		cliSetup()
 	},
 	Short: lang.CmdVersionShort,
 	Long:  lang.CmdVersionLong,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(config.CLIVersion)
+		yamlOutput := make(map[string]interface{})
+		if showDependencies || showBuild {
+			buildInfo, ok := debug.ReadBuildInfo()
+			if !ok {
+				fmt.Println()
+				fmt.Println("Failed to get build info")
+				return
+			}
+			if showDependencies {
+				depMap := map[string]string{}
+				for _, dep := range buildInfo.Deps {
+					if dep.Replace != nil {
+						depMap[dep.Path] = fmt.Sprintf("%s -> %s %s", dep.Path, dep.Replace.Path, dep.Version)
+					} else {
+						depMap[dep.Path] = fmt.Sprintf("%s %s", dep.Path, dep.Version)
+					}
+				}
+				yamlOutput["dependencies"] = depMap
+			}
+			if showBuild {
+				buildMap := make(map[string]interface{})
+				buildMap["platform"] = runtime.GOOS + "/" + runtime.GOARCH
+				buildMap["goVersion"] = runtime.Version()
+				ver := semver.MustParse(config.CLIVersion)
+				buildMap["major"] = ver.Major()
+				buildMap["minor"] = ver.Minor()
+				buildMap["patch"] = ver.Patch()
+				buildMap["prerelease"] = ver.Prerelease()
+
+				yamlOutput["build"] = buildMap
+			}
+
+			text, _ := goyaml.Marshal(yamlOutput)
+			fmt.Println(string(text))
+		} else {
+			fmt.Println(config.CLIVersion)
+		}
 	},
 }
 
+func isVersionCmd() bool {
+	args := os.Args
+	return len(args) > 1 && (args[1] == "version" || args[1] == "v")
+}
+
 func init() {
+	versionCmd.Flags().BoolVar(&showDependencies, "dependencies", false, "Show binary's dependencies")
+	versionCmd.Flags().BoolVar(&showBuild, "build", false, "Show binary's build settings")
 	rootCmd.AddCommand(versionCmd)
 }

--- a/src/cmd/viper.go
+++ b/src/cmd/viper.go
@@ -93,6 +93,11 @@ func initViper() {
 		return
 	}
 
+	// Skip for the version command
+	if isVersionCmd() {
+		return
+	}
+
 	// Specify an alternate config file
 	cfgFile := os.Getenv("ZARF_CONFIG")
 


### PR DESCRIPTION
## Description

Tests to come.

Adds `--build` and `--dependencies` to the `zarf version` cmd. The output format is YAML, and is fully ready to be piped to `yq` similar to other tools.

ex:

```bash
$ zarf version --build
build:
  goVersion: go1.20.3
  major: 0
  minor: 28
  patch: 3
  platform: linux/amd64
  prerelease: 1-g02150cfd
```

```bash
$ zarf version --dependencies
dependencies:
  atomicgo.dev/cursor: atomicgo.dev/cursor v0.1.1
  atomicgo.dev/keyboard: atomicgo.dev/keyboard v0.2.9
  atomicgo.dev/schedule: atomicgo.dev/schedule v0.0.2
  cloud.google.com/go/compute/metadata: cloud.google.com/go/compute/metadata v0.2.3
  cloud.google.com/go/iam: cloud.google.com/go/iam v0.13.0
  cloud.google.com/go/kms: cloud.google.com/go/kms v1.10.1
  cuelang.org/go: cuelang.org/go v0.5.0
...
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
