### PR TITLE
Use UID and GID for USER in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM cgr.dev/chainguard/static:latest
 ARG TARGETARCH
 
+# 65532 is the UID of the `nonroot` user in chainguard/static.  See: https://edu.chainguard.dev/chainguard/chainguard-images/reference/static/overview/#users
 USER 65532:65532
 
-COPY --chown=nonroot:nonroot "build/zarf-linux-$TARGETARCH" /zarf
+COPY --chown=65532:65532 "build/zarf-linux-$TARGETARCH" /zarf
 
 CMD ["/zarf", "internal", "agent", "-l=trace", "--no-log-file"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM cgr.dev/chainguard/static:latest
 ARG TARGETARCH
 
-USER nonroot:nonroot
+USER 65532:65532
 
 COPY --chown=nonroot:nonroot "build/zarf-linux-$TARGETARCH" /zarf
 


### PR DESCRIPTION
## Description

On clusters that strictly enforce no root containers via an Admission Controller, they can't determine that a named user isn't 0 in the container. This changes the container to identify the USER by UID and GID so the admission controller can allow this through.

Chainguard documents the UID and GID of nonroot https://edu.chainguard.dev/chainguard/chainguard-images/reference/static/overview/#users

## Related Issue

Fixes #1921

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
