### PR TITLE
return images as an array of strings for all components

### DIFF
--- a/src/cmd/prepare.go
+++ b/src/cmd/prepare.go
@@ -110,7 +110,7 @@ var prepareFindImages = &cobra.Command{
 		defer pkgClient.ClearTempPaths()
 
 		// Find all the images the package might need
-		if err := pkgClient.FindImages(baseDir, repoHelmChartPath, kubeVersionOverride); err != nil {
+		if _, err := pkgClient.FindImages(baseDir, repoHelmChartPath, kubeVersionOverride); err != nil {
 			message.Fatalf(err, lang.CmdPrepareFindImagesErr, baseDir)
 		}
 	},

--- a/src/pkg/packager/prepare.go
+++ b/src/pkg/packager/prepare.go
@@ -28,10 +28,10 @@ import (
 )
 
 // FindImages iterates over a Zarf.yaml and attempts to parse any images.
-func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOverride string) ([]string, error) {
+func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOverride string) (map[string][]string, error) {
 
 	var originalDir string
-	var images []string
+	imagesMap := make(map[string][]string)
 
 	// Change the working directory if this run has an alternate base dir
 	if baseDir != "" {
@@ -231,7 +231,7 @@ func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOver
 			componentDefinition += fmt.Sprintf("\n  - name: %s\n    images:\n", component.Name)
 			for _, image := range sortedImages {
 				// Use print because we want this dumped to stdout
-				images = append(images, image)
+				imagesMap[component.Name] = append(imagesMap[component.Name], image)
 				componentDefinition += fmt.Sprintf("      - %s\n", image)
 			}
 		}
@@ -266,7 +266,7 @@ func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOver
 		_ = os.Chdir(originalDir)
 	}
 
-	return images, nil
+	return imagesMap, nil
 }
 
 func (p *Packager) processUnstructuredImages(resource *unstructured.Unstructured, matchedImages, maybeImages k8s.ImageMap) (k8s.ImageMap, k8s.ImageMap, error) {

--- a/src/pkg/packager/prepare.go
+++ b/src/pkg/packager/prepare.go
@@ -28,9 +28,10 @@ import (
 )
 
 // FindImages iterates over a Zarf.yaml and attempts to parse any images.
-func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOverride string) error {
+func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOverride string) ([]string, error) {
 
 	var originalDir string
+	var images []string
 
 	// Change the working directory if this run has an alternate base dir
 	if baseDir != "" {
@@ -40,11 +41,11 @@ func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOver
 	}
 
 	if err := p.readYaml(config.ZarfYAML); err != nil {
-		return fmt.Errorf("unable to read the zarf.yaml file: %s", err.Error())
+		return nil, fmt.Errorf("unable to read the zarf.yaml file: %s", err.Error())
 	}
 
 	if err := p.composeComponents(); err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, warning := range p.warnings {
@@ -53,7 +54,7 @@ func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOver
 
 	// After components are composed, template the active package
 	if err := p.fillActiveTemplate(); err != nil {
-		return fmt.Errorf("unable to fill values in template: %s", err.Error())
+		return nil, fmt.Errorf("unable to fill values in template: %s", err.Error())
 	}
 
 	for _, component := range p.cfg.Pkg.Components {
@@ -105,7 +106,7 @@ func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOver
 
 		componentPath, err := p.createOrGetComponentPaths(component)
 		if err != nil {
-			return fmt.Errorf("unable to create component paths: %s", err.Error())
+			return nil, fmt.Errorf("unable to create component paths: %s", err.Error())
 		}
 
 		chartOverrides := make(map[string]string)
@@ -125,18 +126,18 @@ func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOver
 
 				err := helmCfg.PackageChart(componentPath.Charts)
 				if err != nil {
-					return fmt.Errorf("unable to package the chart %s: %s", chart.URL, err.Error())
+					return nil, fmt.Errorf("unable to package the chart %s: %s", chart.URL, err.Error())
 				}
 
 				for idx, path := range chart.ValuesFiles {
 					dst := helm.StandardName(componentPath.Values, chart) + "-" + strconv.Itoa(idx)
 					if utils.IsURL(path) {
 						if err := utils.DownloadToFile(path, dst, component.CosignKeyPath); err != nil {
-							return fmt.Errorf(lang.ErrDownloading, path, err.Error())
+							return nil, fmt.Errorf(lang.ErrDownloading, path, err.Error())
 						}
 					} else {
 						if err := utils.CreatePathAndCopy(path, dst); err != nil {
-							return fmt.Errorf("unable to copy values file %s: %w", path, err)
+							return nil, fmt.Errorf("unable to copy values file %s: %w", path, err)
 						}
 					}
 				}
@@ -179,7 +180,7 @@ func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOver
 
 		if len(component.Manifests) > 0 {
 			if err := utils.CreateDirectory(componentPath.Manifests, 0700); err != nil {
-				return fmt.Errorf("unable to create the manifest path %s: %s", componentPath.Manifests, err.Error())
+				return nil, fmt.Errorf("unable to create the manifest path %s: %s", componentPath.Manifests, err.Error())
 			}
 
 			for _, manifest := range component.Manifests {
@@ -188,7 +189,7 @@ func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOver
 					kname := fmt.Sprintf("kustomization-%s-%d.yaml", manifest.Name, idx)
 					destination := filepath.Join(componentPath.Manifests, kname)
 					if err := kustomize.Build(k, destination, manifest.KustomizeAllowAnyDirectory); err != nil {
-						return fmt.Errorf("unable to build the kustomization for %s: %s", k, err.Error())
+						return nil, fmt.Errorf("unable to build the kustomization for %s: %s", k, err.Error())
 					}
 					manifest.Files = append(manifest.Files, destination)
 				}
@@ -198,7 +199,7 @@ func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOver
 						mname := fmt.Sprintf("manifest-%s-%d.yaml", manifest.Name, idx)
 						destination := filepath.Join(componentPath.Manifests, mname)
 						if err := utils.DownloadToFile(f, destination, component.CosignKeyPath); err != nil {
-							return fmt.Errorf(lang.ErrDownloading, f, err.Error())
+							return nil, fmt.Errorf(lang.ErrDownloading, f, err.Error())
 						}
 						f = destination
 					}
@@ -230,6 +231,7 @@ func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOver
 			componentDefinition += fmt.Sprintf("\n  - name: %s\n    images:\n", component.Name)
 			for _, image := range sortedImages {
 				// Use print because we want this dumped to stdout
+				images = append(images, image)
 				componentDefinition += fmt.Sprintf("      - %s\n", image)
 			}
 		}
@@ -264,7 +266,7 @@ func (p *Packager) FindImages(baseDir, repoHelmChartPath string, kubeVersionOver
 		_ = os.Chdir(originalDir)
 	}
 
-	return nil
+	return images, nil
 }
 
 func (p *Packager) processUnstructuredImages(resource *unstructured.Unstructured, matchedImages, maybeImages k8s.ImageMap) (k8s.ImageMap, k8s.ImageMap, error) {


### PR DESCRIPTION
## Description

Users using library code can benefit from receiving a [list of images ](https://github.com/defenseunicorns/zarf/blob/8d67f5fb2935ee9355786dfc0fd3b83efb6a8142/src/pkg/packager/prepare.go#L31). This was a feature request from the community. This provides users with the ability to pre-cache/pre-download images. 

## Related Issue

Fixes #1918 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
