### PR TITLE
Fix a bug with registry push/pull on detected but invalid clusters

### DIFF
--- a/src/cmd/tools/crane.go
+++ b/src/cmd/tools/crane.go
@@ -56,7 +56,7 @@ func init() {
 			if platform != "all" {
 				v1Platform, err = v1.ParsePlatform(platform)
 				if err != nil {
-					message.Fatalf(err, lang.CmdToolsRegistryInvalidPlatformErr, err.Error())
+					message.Fatalf(err, lang.CmdToolsRegistryInvalidPlatformErr, platform, err.Error())
 				}
 			}
 
@@ -137,7 +137,7 @@ func zarfCraneInternalWrapper(commandToWrap func(*[]crane.Option) *cobra.Command
 
 	wrappedCommand.RunE = func(cmd *cobra.Command, args []string) error {
 		if len(args) < imageNameArgumentIndex+1 {
-			message.Fatal(nil, lang.CmdToolsCraneNotEnoughArgumentsSpecified)
+			message.Fatal(nil, lang.CmdToolsCraneNotEnoughArgumentsErr)
 		}
 
 		// Try to connect to a Zarf initialized cluster otherwise then pass it down to crane.
@@ -146,10 +146,11 @@ func zarfCraneInternalWrapper(commandToWrap func(*[]crane.Option) *cobra.Command
 			return originalListFn(cmd, args)
 		}
 
-		// Load the state
+		// Load the state (if able)
 		zarfState, err := zarfCluster.LoadZarfState()
 		if err != nil {
-			return err
+			message.Warnf(lang.CmdToolsCraneConnectedButBadStateErr, err.Error())
+			return originalListFn(cmd, args)
 		}
 
 		// Check to see if it matches the existing internal address.

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -375,7 +375,8 @@ const (
 	CmdToolsClearCacheSuccess       = "Successfully cleared the cache from %s"
 	CmdToolsClearCacheFlagCachePath = "Specify the location of the Zarf artifact cache (images and git repositories)"
 
-	CmdToolsCraneNotEnoughArgumentsSpecified = "You do not have enough arguments specified."
+	CmdToolsCraneNotEnoughArgumentsErr   = "You do not have enough arguments specified for this command"
+	CmdToolsCraneConnectedButBadStateErr = "Detected a K8s cluster but was unable to get Zarf state - continuing without state information: %s"
 
 	CmdToolsDownloadInitShort               = "Downloads the init package for the current Zarf version into the specified directory"
 	CmdToolsDownloadInitFlagOutputDirectory = "Specify a directory to place the init package in."
@@ -421,7 +422,7 @@ const (
 		zarf tools wait-for http google.com success                           #  wait for any 2xx response from http://google.com
 `
 	CmdToolsWaitForFlagTimeout        = "Specify the timeout duration for the wait command."
-	CmdToolsWaitForErrTimeoutString   = "Invalid timeout duration. Please use a valid duration string (e.g. 1s, 2m, 3h)."
+	CmdToolsWaitForErrTimeoutString   = "Invalid timeout duration '%s'. Please use a valid duration string (e.g. 1s, 2m, 3h)."
 	CmdToolsWaitForErrTimeout         = "Wait timed out."
 	CmdToolsWaitForErrConditionString = "Invalid HTTP status code. Please use a valid HTTP status code (e.g. 200, 404, 500)."
 	CmdToolsWaitForErrZarfPath        = "Could not locate the current Zarf binary path."
@@ -513,7 +514,7 @@ const (
 var (
 	ErrInitNotFound      = errors.New("this command requires a zarf-init package, but one was not found on the local system. Re-run the last command again without '--confirm' to download the package")
 	ErrUnableToCheckArch = errors.New("unable to get the configured cluster's architecture")
-	ErrInterrupt         = errors.New("Failed due to interrupt")
+	ErrInterrupt         = errors.New("execution cancelled due to an interrupt")
 )
 
 // Collection of reusable warn messages.

--- a/src/extensions/bigbang/test/package/flux-overrides-helm-controller.yaml
+++ b/src/extensions/bigbang/test/package/flux-overrides-helm-controller.yaml
@@ -10,8 +10,8 @@ spec:
       - name: manager
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: 200m
+            memory: 256Mi
           requests:
-            cpu: 500m
-            memory: 1Gi
+            cpu: 100m
+            memory: 64Mi

--- a/src/extensions/bigbang/test/package/flux-overrides-kustomize-controller.yaml
+++ b/src/extensions/bigbang/test/package/flux-overrides-kustomize-controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: source-controller
+  name: kustomize-controller
   namespace: flux-system
 spec:
   template:
@@ -10,8 +10,8 @@ spec:
       - name: manager
         resources:
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 256Mi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 64Mi

--- a/src/extensions/bigbang/test/package/flux-overrides-notification-controller.yaml
+++ b/src/extensions/bigbang/test/package/flux-overrides-notification-controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: source-controller
+  name: notification-controller
   namespace: flux-system
 spec:
   template:
@@ -10,8 +10,8 @@ spec:
       - name: manager
         resources:
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 256Mi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 64Mi

--- a/src/extensions/bigbang/test/package/zarf.yaml
+++ b/src/extensions/bigbang/test/package/zarf.yaml
@@ -21,6 +21,8 @@ components:
         fluxPatchFiles:
           - flux-overrides-helm-controller.yaml
           - flux-overrides-source-controller.yaml
+          - flux-overrides-kustomize-controller.yaml
+          - flux-overrides-notification-controller.yaml
         valuesFiles:
           - disable-all-bb###ZARF_PKG_TMPL_BB_MAJOR###.yaml
           - enable-twistlock.yaml

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Set the default helm client timeout to 15 minutes
-const defaultClientTimeout = 15 * time.Minute
+const defaultClientTimeout = 5 * time.Minute
 
 // InstallOrUpgradeChart performs a helm install of the given chart.
 func (h *Helm) InstallOrUpgradeChart() (types.ConnectStrings, string, error) {

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Set the default helm client timeout to 15 minutes
-const defaultClientTimeout = 3 * time.Minute
+const defaultClientTimeout = 15 * time.Minute
 
 // InstallOrUpgradeChart performs a helm install of the given chart.
 func (h *Helm) InstallOrUpgradeChart() (types.ConnectStrings, string, error) {

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Set the default helm client timeout to 15 minutes
-const defaultClientTimeout = 5 * time.Minute
+const defaultClientTimeout = 3 * time.Minute
 
 // InstallOrUpgradeChart performs a helm install of the given chart.
 func (h *Helm) InstallOrUpgradeChart() (types.ConnectStrings, string, error) {


### PR DESCRIPTION
## Description

This fixes an issue with zarf tools registry where an invalid cluster (one that was not connectable or did not have state) could cause a failure.

## Related Issue

Fixes #1929 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
