### PR TITLE
chore: Standardize usage of <TabItem> tag to aid conversion.

### DIFF
--- a/docs/0-zarf-overview.md
+++ b/docs/0-zarf-overview.md
@@ -161,7 +161,7 @@ In the more complex use case, your package consists of updates for many apps/sys
 3. `$` Enter the commands into your terminal.
 
 <Tabs>
-<TabItem value="Linux" label="Linux">
+<TabItem value="Linux">
 
 :::info
 
@@ -199,7 +199,7 @@ Zarf has no prerequisites on Linux. However, for this example, we will use Docke
 :::
 
 </TabItem>
-<TabItem value="macOS" label="macOS">
+<TabItem value="macOS">
 
 :::info
 
@@ -231,7 +231,7 @@ zarf package deploy sget://defenseunicorns/zarf-hello-world:$(uname -m)
 ```
 
 </TabItem>
-<TabItem value="Windows" label="Windows">
+<TabItem value="Windows">
 
 ## Windows Commands
 

--- a/docs/2-the-zarf-cli/index.md
+++ b/docs/2-the-zarf-cli/index.md
@@ -18,7 +18,7 @@ You can get the Zarf CLI on your machine in a few different ways. You can use th
 
 <!-- NOTE: The empty line after the '<TabItem ...>' lines are important for the rendering... -->
 <Tabs>
-<TabItem value="macOS" label="macOS" default>
+<TabItem value="macOS">
 
 ```bash
 brew tap defenseunicorns/tap
@@ -27,7 +27,7 @@ brew install zarf
 
 </TabItem>
 
-<TabItem value="Linux" label="Linux">
+<TabItem value="Linux">
 
 ```bash
 brew tap defenseunicorns/tap
@@ -71,7 +71,7 @@ Available Commands:
 </details>
 
 <Tabs>
-<TabItem value="homebrew" label="Installed via Homebrew" default>
+<TabItem value="Installed with Homebrew">
 
 ```bash
 zarf --help
@@ -79,9 +79,9 @@ zarf --help
 
 </TabItem>
 
-<TabItem value="custom-install" label="Downloaded from Github">
+<TabItem value="Downloaded from Github">
 
-- If you're not sure where the file was downloaded to, a good default place to look is `~/Downloads`.
+- If you're not sure where the file was downloaded, a good default place to look is `~/Downloads`.
 - While we only say `zarf` for this example command, the name of the binary is the name of the file you downloaded, which will likely have a different name.
 
 ```bash
@@ -91,7 +91,7 @@ chmod +x ~/Downloads/zarf   # Make the binary executable
 
 </TabItem>
 
-<TabItem value="manually-built" label="Manually Built">
+<TabItem value="Manually Built">
 
 - While we only say `zarf` for this example command, depending on your system, you might have to use a different name for the binary like `zarf-mac-intel` or `zarf-mac-apple`.
 


### PR DESCRIPTION
## Description
The `<TabItem>` component had inconsistent usage, making conversion logic more complex than needed. I've standardized the usage to make the conversion more straightforward.

...

## Related Issue


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
