### PR TITLE
Reduce test disk usage and normalize git tests

### DIFF
--- a/src/test/e2e/08_create_differential_test.go
+++ b/src/test/e2e/08_create_differential_test.go
@@ -20,6 +20,7 @@ import (
 func TestCreateDifferential(t *testing.T) {
 	t.Log("E2E: Test Differential Package Behavior")
 	tmpdir := t.TempDir()
+	cachePath := filepath.Join(tmpdir, ".cache-location")
 
 	packagePath := "src/test/packages/08-differential-package"
 	packageName := "zarf-package-differential-package-amd64-v0.25.0.tar.zst"
@@ -27,17 +28,17 @@ func TestCreateDifferential(t *testing.T) {
 	differentialFlag := fmt.Sprintf("--differential=%s", packageName)
 
 	// Build the package a first time
-	stdOut, stdErr, err := e2e.Zarf("package", "create", packagePath, "--set=PACKAGE_VERSION=v0.25.0", "--confirm")
+	stdOut, stdErr, err := e2e.Zarf("package", "create", packagePath, "--zarf-cache", cachePath, "--set=PACKAGE_VERSION=v0.25.0", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 	defer e2e.CleanFiles(packageName)
 
 	// Build the differential package without changing the version
-	_, stdErr, err = e2e.Zarf("package", "create", packagePath, "--set=PACKAGE_VERSION=v0.25.0", differentialFlag, "--confirm")
+	_, stdErr, err = e2e.Zarf("package", "create", packagePath, "--zarf-cache", cachePath, "--set=PACKAGE_VERSION=v0.25.0", differentialFlag, "--confirm")
 	require.Error(t, err, "zarf package create should have errored when a differential package was being created without updating the package version number")
 	require.Contains(t, stdErr, "unable to create a differential package with the same version")
 
 	// Build the differential package
-	stdOut, stdErr, err = e2e.Zarf("package", "create", packagePath, "--set=PACKAGE_VERSION=v0.26.0", differentialFlag, "--confirm")
+	stdOut, stdErr, err = e2e.Zarf("package", "create", packagePath, "--zarf-cache", cachePath, "--set=PACKAGE_VERSION=v0.26.0", differentialFlag, "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 	defer e2e.CleanFiles(differentialPackageName)
 

--- a/src/test/e2e/22_git_and_flux_test.go
+++ b/src/test/e2e/22_git_and_flux_test.go
@@ -24,7 +24,7 @@ func TestGitAndFlux(t *testing.T) {
 	cachePath := filepath.Join(tmpdir, ".cache-location")
 
 	buildPath := filepath.Join("src", "test", "packages", "22-git-and-flux")
-	stdOut, stdErr, err := e2e.Zarf("package", "create", buildPath, "--zarf-cache", cachePath, "-o=build", "--confirm", "--skip-sbom")
+	stdOut, stdErr, err := e2e.Zarf("package", "create", buildPath, "--zarf-cache", cachePath, "-o=build", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 
 	path := fmt.Sprintf("build/zarf-package-git-data-test-%s-1.0.0.tar.zst", e2e.Arch)
@@ -33,9 +33,6 @@ func TestGitAndFlux(t *testing.T) {
 	// Deploy the gitops example
 	stdOut, stdErr, err = e2e.Zarf("package", "deploy", path, "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
-
-	// This package contains SBOMable things but was created with --skip-sbom
-	require.Contains(t, string(stdErr), "This package does NOT contain an SBOM.")
 
 	tunnel, err := cluster.NewZarfTunnel()
 	require.NoError(t, err)

--- a/src/test/e2e/25_helm_test.go
+++ b/src/test/e2e/25_helm_test.go
@@ -90,12 +90,15 @@ func testHelmUninstallRollback(t *testing.T) {
 	evilPath := fmt.Sprintf("zarf-package-dos-games-%s.tar.zst", e2e.Arch)
 
 	// Create the evil package (with the bad configmap).
-	stdOut, stdErr, err := e2e.Zarf("package", "create", "src/test/packages/25-evil-dos-games/", "--confirm")
+	stdOut, stdErr, err := e2e.Zarf("package", "create", "src/test/packages/25-evil-dos-games/", "--skip-sbom", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 
 	// Deploy the evil package.
 	stdOut, stdErr, err = e2e.Zarf("package", "deploy", evilPath, "--confirm")
 	require.Error(t, err, stdOut, stdErr)
+
+	// This package contains SBOMable things but was created with --skip-sbom
+	require.Contains(t, string(stdErr), "This package does NOT contain an SBOM.")
 
 	// Ensure that this does not leave behind a dos-games chart
 	helmOut, err := exec.Command("helm", "list", "-n", "dos-games").Output()

--- a/src/test/packages/08-differential-package/zarf.yaml
+++ b/src/test/packages/08-differential-package/zarf.yaml
@@ -23,3 +23,5 @@ components:
       - https://github.com/stefanprodan/podinfo.git
       - https://github.com/kelseyhightower/nocode.git
       - https://github.com/defenseunicorns/zarf.git@refs/heads/main
+
+# FLAG 289MB!

--- a/src/test/packages/08-differential-package/zarf.yaml
+++ b/src/test/packages/08-differential-package/zarf.yaml
@@ -23,5 +23,3 @@ components:
       - https://github.com/stefanprodan/podinfo.git
       - https://github.com/kelseyhightower/nocode.git
       - https://github.com/defenseunicorns/zarf.git@refs/heads/main
-
-# FLAG 289MB!

--- a/src/test/packages/22-git-and-flux/zarf.yaml
+++ b/src/test/packages/22-git-and-flux/zarf.yaml
@@ -28,7 +28,7 @@ components:
       onDeploy:
         before:
           # Check to verify the package secret has been saved for the already deployed component
-          - cmd: test $(./zarf tools kubectl get secret -n zarf zarf-package-git-data-check-secrets -o jsonpath='{.data.*}' | base64 --decode | jq -r .deployedComponents | jq '. | length') -eq 1
+          - cmd: test $(./zarf tools kubectl get secret -n zarf zarf-package-git-data-test -o jsonpath='{.data.*}' | base64 --decode | jq -r .deployedComponents | jq '. | length') -eq 1
             description: Check that the package secret has been updated with the deployed component
             maxRetries: 3
 
@@ -43,7 +43,7 @@ components:
       onDeploy:
         before:
           # Check to verify the package secret has been saved for the already deployed component
-          - cmd: test $(./zarf tools kubectl get secret -n zarf zarf-package-git-data-check-secrets -o jsonpath='{.data.*}' | base64 --decode | jq -r .deployedComponents | jq '. | length') -eq 2
+          - cmd: test $(./zarf tools kubectl get secret -n zarf zarf-package-git-data-test -o jsonpath='{.data.*}' | base64 --decode | jq -r .deployedComponents | jq '. | length') -eq 2
             description: Check that the package secret has been updated with the deployed component
             maxRetries: 3
 
@@ -58,10 +58,10 @@ components:
       onDeploy:
         before:
           # Check to verify the package secret has been saved for the already deployed component
-          - cmd: test $(./zarf tools kubectl get secret -n zarf zarf-package-git-data-check-secrets -o jsonpath='{.data.*}' | base64 --decode | jq -r .deployedComponents | jq '. | length') -eq 3
+          - cmd: test $(./zarf tools kubectl get secret -n zarf zarf-package-git-data-test -o jsonpath='{.data.*}' | base64 --decode | jq -r .deployedComponents | jq '. | length') -eq 3
             description: Check that the package secret has been updated with the deployed component
             maxRetries: 3
         onSuccess:
-          - cmd: test $(./zarf tools kubectl get secret -n zarf zarf-package-git-data-check-secrets -o jsonpath='{.data.*}' | base64 --decode | jq -r .deployedComponents | jq '. | length') -eq 4
+          - cmd: test $(./zarf tools kubectl get secret -n zarf zarf-package-git-data-test -o jsonpath='{.data.*}' | base64 --decode | jq -r .deployedComponents | jq '. | length') -eq 4
             description: Check that the package secret has been updated with the deployed component
             maxRetries: 3

--- a/src/test/packages/22-git-and-flux/zarf.yaml
+++ b/src/test/packages/22-git-and-flux/zarf.yaml
@@ -1,25 +1,29 @@
 kind: ZarfPackageConfig
 metadata:
-  name: git-data-check-secrets
+  name: git-data-test
   version: 1.0.0
-  description: Demo Zarf loading resources into a gitops service - while checking that the component secret gets updated with each component
+  description: A Git package with additional test cases for different scenarios
 
 components:
-  - name: flux-demo
-    required: true
-    images:
-      - ghcr.io/stefanprodan/podinfo:6.0.0
-    repos:
-      # Do a full Git Repo Mirror of a flux repo
-      - https://github.com/stefanprodan/podinfo.git
-
   - name: full-repo
     required: true
     repos:
       # Do a full Git Repo Mirror
-      - https://github.com/kelseyhightower/nocode.git
-      # Perform a full repo mirror of a simple repository with a single branch - this causes an "already up to date" error in go-git
+      - https://github.com/defenseunicorns/zarf-public-test.git
+      # The following performs a full Git Repo Mirror forcing a fallback to host `git`
+      - https://racer159.visualstudio.com/zarf-public-test/_git/zarf-public-test
+      # Perform a full repo mirror of a simple repository with a single branch - (this causes an "already up to date" error in go-git)
       - https://github.com/defenseunicorns/golang-tekton-hello-world.git
+
+  - name: specific-tag
+    required: true
+    repos:
+      # The following performs a tag Git Repo Mirror with `go-git` (internal to Zarf)
+      - https://github.com/defenseunicorns/zarf-public-test.git@v0.0.1
+      # The following performs a refspec tag Git Repo Mirror with `go-git`
+      - https://github.com/defenseunicorns/zarf-public-test.git@refs/tags/v0.0.1
+      # The following performs a tag Git Repo Mirror forcing a fallback to host `git`
+      - https://racer159.visualstudio.com/zarf-public-test/_git/zarf-public-test@v0.0.1
     actions:
       onDeploy:
         before:
@@ -28,13 +32,13 @@ components:
             description: Check that the package secret has been updated with the deployed component
             maxRetries: 3
 
-  - name: specific-tag
+  - name: specific-branch
     required: true
     repos:
-      # Do a tag-provided Git Repo mirror
-      - https://github.com/defenseunicorns/zarf.git@v0.15.0
-      # Use the git refspec pattern to get a tag
-      - https://github.com/defenseunicorns/zarf.git@refs/tags/v0.16.0
+      # The following performs a branch Git Repo Mirror with `go-git` (internal to Zarf)
+      - https://github.com/defenseunicorns/zarf-public-test.git@refs/heads/dragons
+      # The following performs a branch Git Repo Mirror forcing a fallback to host `git`
+      - https://racer159.visualstudio.com/zarf-public-test/_git/zarf-public-test@refs/heads/dragons
     actions:
       onDeploy:
         before:
@@ -43,11 +47,13 @@ components:
             description: Check that the package secret has been updated with the deployed component
             maxRetries: 3
 
-  - name: specific-branch
+  - name: specific-hash
     required: true
     repos:
-      # Do a branch-provided Git Repo mirror
-      - https://github.com/DoD-Platform-One/big-bang.git@refs/heads/release-1.54.x
+      # The following performs a SHA Git Repo Mirror with `go-git` (internal to Zarf)
+      - https://github.com/defenseunicorns/zarf-public-test.git@01a23218923f24194133b5eb11268cf8d73ff1bb
+      # The following performs a SHA Git Repo Mirror forcing a fallback to host `git`
+      - https://racer159.visualstudio.com/zarf-public-test/_git/zarf-public-test@01a23218923f24194133b5eb11268cf8d73ff1bb
     actions:
       onDeploy:
         before:
@@ -55,22 +61,7 @@ components:
           - cmd: test $(./zarf tools kubectl get secret -n zarf zarf-package-git-data-check-secrets -o jsonpath='{.data.*}' | base64 --decode | jq -r .deployedComponents | jq '. | length') -eq 3
             description: Check that the package secret has been updated with the deployed component
             maxRetries: 3
-
-  - name: specific-hash
-    required: true
-    repos:
-      # Do a commit hash Git Repo mirror
-      - https://github.com/defenseunicorns/zarf.git@c74e2e9626da0400e0a41e78319b3054c53a5d4e
-      # Clone an azure repo (w/SHA) that breaks in go-git and has to fall back to the host git
-      - https://me0515@dev.azure.com/me0515/zarf-public-test/_git/zarf-public-test@524980951ff16e19dc25232e9aea8fd693989ba6
-    actions:
-      onDeploy:
-        before:
-          # Check to verify the package secret has been saved for the already deployed component
-          - cmd: test $(./zarf tools kubectl get secret -n zarf zarf-package-git-data-check-secrets -o jsonpath='{.data.*}' | base64 --decode | jq -r .deployedComponents | jq '. | length') -eq 4
-            description: Check that the package secret has been updated with the deployed component
-            maxRetries: 3
         onSuccess:
-          - cmd: test $(./zarf tools kubectl get secret -n zarf zarf-package-git-data-check-secrets -o jsonpath='{.data.*}' | base64 --decode | jq -r .deployedComponents | jq '. | length') -eq 5
+          - cmd: test $(./zarf tools kubectl get secret -n zarf zarf-package-git-data-check-secrets -o jsonpath='{.data.*}' | base64 --decode | jq -r .deployedComponents | jq '. | length') -eq 4
             description: Check that the package secret has been updated with the deployed component
             maxRetries: 3


### PR DESCRIPTION
## Description

Reduce the disk usage in tests by clearing the cache path for packages with images and simplifying the git data test

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
