### PR TITLE
Throw warning instead of error when default CLIVersion is used when validating last non-breaking version

### DIFF
--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -256,6 +256,7 @@ const (
 	CmdPackageDeployFlagPublicKey                      = "Path to public key file for validating signed packages"
 	CmdPackageDeployValidateArchitectureErr            = "this package architecture is %s, but the target cluster has the %s architecture. These architectures must be the same"
 	CmdPackageDeployValidateLastNonBreakingVersionWarn = "the version of this Zarf binary '%s' is less than the LastNonBreakingVersion of '%s'. You may need to upgrade your Zarf version to at least '%s' to deploy this package"
+	CmdPackageDeployUnsetCLIVersionWarn                = "CLIVersion is set to the default value of '%s'. This could potentially cause issues with package creation and deployment. To avoid such issues, please set the value to a valid semantic version."
 	CmdPackageDeployErr                                = "Failed to deploy package: %s"
 
 	CmdPackageInspectFlagSbom      = "View SBOM contents while inspecting the package"

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -256,7 +256,7 @@ const (
 	CmdPackageDeployFlagPublicKey                      = "Path to public key file for validating signed packages"
 	CmdPackageDeployValidateArchitectureErr            = "this package architecture is %s, but the target cluster has the %s architecture. These architectures must be the same"
 	CmdPackageDeployValidateLastNonBreakingVersionWarn = "the version of this Zarf binary '%s' is less than the LastNonBreakingVersion of '%s'. You may need to upgrade your Zarf version to at least '%s' to deploy this package"
-	CmdPackageDeployUnsetCLIVersionWarn                = "CLIVersion is set to '%s' which can cause issues with package creation and deployment. To avoid such issues, please set the value to the valid semantic version for this version of Zarf."
+	CmdPackageDeployInvalidCLIVersionWarn              = "CLIVersion is set to '%s' which can cause issues with package creation and deployment. To avoid such issues, please set the value to the valid semantic version for this version of Zarf."
 	CmdPackageDeployErr                                = "Failed to deploy package: %s"
 
 	CmdPackageInspectFlagSbom      = "View SBOM contents while inspecting the package"

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -256,7 +256,7 @@ const (
 	CmdPackageDeployFlagPublicKey                      = "Path to public key file for validating signed packages"
 	CmdPackageDeployValidateArchitectureErr            = "this package architecture is %s, but the target cluster has the %s architecture. These architectures must be the same"
 	CmdPackageDeployValidateLastNonBreakingVersionWarn = "the version of this Zarf binary '%s' is less than the LastNonBreakingVersion of '%s'. You may need to upgrade your Zarf version to at least '%s' to deploy this package"
-	CmdPackageDeployUnsetCLIVersionWarn                = "CLIVersion is set to the default value of '%s'. This could potentially cause issues with package creation and deployment. To avoid such issues, please set the value to a valid semantic version."
+	CmdPackageDeployUnsetCLIVersionWarn                = "CLIVersion is set to '%s' which can cause issues with package creation and deployment. To avoid such issues, please set the value to the valid semantic version for this version of Zarf."
 	CmdPackageDeployErr                                = "Failed to deploy package: %s"
 
 	CmdPackageInspectFlagSbom      = "View SBOM contents while inspecting the package"

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -505,12 +505,6 @@ func (p *Packager) validateLastNonBreakingVersion() (err error) {
 		return nil
 	}
 
-	if cliVersion == "unset" || cliVersion == "UnknownVersion" {
-		warning := fmt.Sprintf(lang.CmdPackageDeployUnsetCLIVersionWarn, config.CLIVersion)
-		p.warnings = append(p.warnings, warning)
-		return nil
-	}
-
 	lastNonBreakingSemVer, err := semver.NewVersion(lastNonBreakingVersion)
 	if err != nil {
 		return fmt.Errorf("unable to parse lastNonBreakingVersion '%s' from Zarf package build data : %w", lastNonBreakingVersion, err)
@@ -518,7 +512,7 @@ func (p *Packager) validateLastNonBreakingVersion() (err error) {
 
 	cliSemVer, err := semver.NewVersion(cliVersion)
 	if err != nil {
-		warning := fmt.Sprintf("unable to parse Zarf CLI version '%s' : %s", cliVersion, err.Error())
+		warning := fmt.Sprintf(lang.CmdPackageDeployInvalidCLIVersionWarn, config.CLIVersion)
 		p.warnings = append(p.warnings, warning)
 		return nil
 	}

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -525,7 +525,6 @@ func (p *Packager) validateLastNonBreakingVersion() (err error) {
 			lastNonBreakingVersion,
 		)
 		p.warnings = append(p.warnings, warning)
-		return nil
 	}
 
 	return nil

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -496,14 +496,18 @@ func (p *Packager) validatePackageArchitecture() (err error) {
 	return nil
 }
 
-// validateLastNonBreakingVersion compares the Zarf CLI version against a package's LastNonBreakingVersion.
-// It will return an error if there is an error parsing either of the two versions,
-// and will throw a warning if the CLI version is less than the LastNonBreakingVersion.
+// validateLastNonBreakingVersion validates the Zarf CLI version against a package's LastNonBreakingVersion.
 func (p *Packager) validateLastNonBreakingVersion() (err error) {
 	cliVersion := config.CLIVersion
 	lastNonBreakingVersion := p.cfg.Pkg.Build.LastNonBreakingVersion
 
-	if lastNonBreakingVersion == "" || cliVersion == "UnknownVersion" || cliVersion == "unset" {
+	if lastNonBreakingVersion == "" || cliVersion == "UnknownVersion" {
+		return nil
+	}
+
+	if cliVersion == "unset" {
+		unsetWarning := fmt.Sprintf(lang.CmdPackageDeployUnsetCLIVersionWarn, config.CLIVersion)
+		p.warnings = append(p.warnings, unsetWarning)
 		return nil
 	}
 

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -503,7 +503,7 @@ func (p *Packager) validateLastNonBreakingVersion() (err error) {
 	cliVersion := config.CLIVersion
 	lastNonBreakingVersion := p.cfg.Pkg.Build.LastNonBreakingVersion
 
-	if lastNonBreakingVersion == "" || cliVersion == "UnknownVersion" {
+	if lastNonBreakingVersion == "" || cliVersion == "UnknownVersion" || cliVersion == "unset" {
 		return nil
 	}
 

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -501,13 +501,13 @@ func (p *Packager) validateLastNonBreakingVersion() (err error) {
 	cliVersion := config.CLIVersion
 	lastNonBreakingVersion := p.cfg.Pkg.Build.LastNonBreakingVersion
 
-	if lastNonBreakingVersion == "" || cliVersion == "UnknownVersion" {
+	if lastNonBreakingVersion == "" {
 		return nil
 	}
 
-	if cliVersion == "unset" {
-		unsetWarning := fmt.Sprintf(lang.CmdPackageDeployUnsetCLIVersionWarn, config.CLIVersion)
-		p.warnings = append(p.warnings, unsetWarning)
+	if cliVersion == "unset" || cliVersion == "UnknownVersion" {
+		warning := fmt.Sprintf(lang.CmdPackageDeployUnsetCLIVersionWarn, config.CLIVersion)
+		p.warnings = append(p.warnings, warning)
 		return nil
 	}
 
@@ -518,7 +518,9 @@ func (p *Packager) validateLastNonBreakingVersion() (err error) {
 
 	cliSemVer, err := semver.NewVersion(cliVersion)
 	if err != nil {
-		return fmt.Errorf("unable to parse Zarf CLI version '%s' : %w", cliVersion, err)
+		warning := fmt.Sprintf("unable to parse Zarf CLI version '%s' : %s", cliVersion, err.Error())
+		p.warnings = append(p.warnings, warning)
+		return nil
 	}
 
 	if cliSemVer.LessThan(lastNonBreakingSemVer) {
@@ -529,6 +531,7 @@ func (p *Packager) validateLastNonBreakingVersion() (err error) {
 			lastNonBreakingVersion,
 		)
 		p.warnings = append(p.warnings, warning)
+		return nil
 	}
 
 	return nil

--- a/src/pkg/packager/common_test.go
+++ b/src/pkg/packager/common_test.go
@@ -178,6 +178,13 @@ func TestValidateLastNonBreakingVersion(t *testing.T) {
 			returnError:            false,
 			throwWarning:           false,
 		},
+		{
+			name:                   "default CLI version",
+			cliVersion:             "unset",
+			lastNonBreakingVersion: "v0.27.0",
+			returnError:            false,
+			throwWarning:           false,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/src/pkg/packager/common_test.go
+++ b/src/pkg/packager/common_test.go
@@ -137,9 +137,9 @@ func TestValidateLastNonBreakingVersion(t *testing.T) {
 			name:                   "invalid semantic version (CLI version)",
 			cliVersion:             "invalidSemanticVersion",
 			lastNonBreakingVersion: "v0.0.1",
-			throwWarning:           false,
-			returnError:            true,
-			expectedErrorMessage:   "unable to parse Zarf CLI version",
+			returnError:            false,
+			throwWarning:           true,
+			expectedWarningMessage: "unable to parse Zarf CLI version 'invalidSemanticVersion' : Invalid Semantic Version",
 		},
 		{
 			name:                   "invalid semantic version (lastNonBreakingVersion)",
@@ -171,11 +171,12 @@ func TestValidateLastNonBreakingVersion(t *testing.T) {
 			throwWarning:           false,
 		},
 		{
-			name:                   "default CLI version in E2E tests",
-			cliVersion:             "UnknownVersion", // This is used as a default version in the E2E tests
+			name:                   "CLI version in E2E tests",
+			cliVersion:             "UnknownVersion",
 			lastNonBreakingVersion: "v0.27.0",
 			returnError:            false,
-			throwWarning:           false,
+			throwWarning:           true,
+			expectedWarningMessage: fmt.Sprintf(lang.CmdPackageDeployUnsetCLIVersionWarn, "UnknownVersion"),
 		},
 		{
 			name:                   "default CLI version",

--- a/src/pkg/packager/common_test.go
+++ b/src/pkg/packager/common_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/defenseunicorns/zarf/src/internal/cluster"
 	"github.com/defenseunicorns/zarf/src/pkg/k8s"
 	"github.com/defenseunicorns/zarf/src/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -183,12 +182,17 @@ func TestValidateLastNonBreakingVersion(t *testing.T) {
 			cliVersion:             "unset",
 			lastNonBreakingVersion: "v0.27.0",
 			returnError:            false,
-			throwWarning:           false,
+			throwWarning:           true,
+			expectedWarningMessage: fmt.Sprintf(lang.CmdPackageDeployUnsetCLIVersionWarn, config.CLIVersion),
 		},
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
 			config.CLIVersion = testCase.cliVersion
 
 			p := &Packager{
@@ -205,14 +209,14 @@ func TestValidateLastNonBreakingVersion(t *testing.T) {
 
 			switch {
 			case testCase.returnError:
-				assert.ErrorContains(t, err, testCase.expectedErrorMessage)
-				assert.Empty(t, p.warnings, "Expected no warnings for test case: %s", testCase.name)
+				require.ErrorContains(t, err, testCase.expectedErrorMessage)
+				require.Empty(t, p.warnings, "Expected no warnings for test case: %s", testCase.name)
 			case testCase.throwWarning:
-				assert.Contains(t, p.warnings, testCase.expectedWarningMessage)
-				assert.NoError(t, err, "Expected no error for test case: %s", testCase.name)
+				require.Contains(t, p.warnings, testCase.expectedWarningMessage)
+				require.NoError(t, err, "Expected no error for test case: %s", testCase.name)
 			default:
-				assert.NoError(t, err, "Expected no error for test case: %s", testCase.name)
-				assert.Empty(t, p.warnings, "Expected no warnings for test case: %s", testCase.name)
+				require.NoError(t, err, "Expected no error for test case: %s", testCase.name)
+				require.Empty(t, p.warnings, "Expected no warnings for test case: %s", testCase.name)
 			}
 		})
 	}

--- a/src/pkg/packager/common_test.go
+++ b/src/pkg/packager/common_test.go
@@ -139,7 +139,7 @@ func TestValidateLastNonBreakingVersion(t *testing.T) {
 			lastNonBreakingVersion: "v0.0.1",
 			returnError:            false,
 			throwWarning:           true,
-			expectedWarningMessage: "unable to parse Zarf CLI version 'invalidSemanticVersion' : Invalid Semantic Version",
+			expectedWarningMessage: fmt.Sprintf(lang.CmdPackageDeployInvalidCLIVersionWarn, "invalidSemanticVersion"),
 		},
 		{
 			name:                   "invalid semantic version (lastNonBreakingVersion)",
@@ -169,22 +169,6 @@ func TestValidateLastNonBreakingVersion(t *testing.T) {
 			lastNonBreakingVersion: "",
 			returnError:            false,
 			throwWarning:           false,
-		},
-		{
-			name:                   "CLI version in E2E tests",
-			cliVersion:             "UnknownVersion",
-			lastNonBreakingVersion: "v0.27.0",
-			returnError:            false,
-			throwWarning:           true,
-			expectedWarningMessage: fmt.Sprintf(lang.CmdPackageDeployUnsetCLIVersionWarn, "UnknownVersion"),
-		},
-		{
-			name:                   "default CLI version",
-			cliVersion:             "unset",
-			lastNonBreakingVersion: "v0.27.0",
-			returnError:            false,
-			throwWarning:           true,
-			expectedWarningMessage: fmt.Sprintf(lang.CmdPackageDeployUnsetCLIVersionWarn, config.CLIVersion),
 		},
 	}
 


### PR DESCRIPTION
## Description
Print a warning rather than return an error when an invalid CLIVersion is used when validating last non-breaking version

## Related Issue

Fixes https://github.com/defenseunicorns/zarf/issues/1972

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
