### PR TITLE
Ensure Zarf image manifests are pulled as blobs

### DIFF
--- a/src/pkg/oci/pull.go
+++ b/src/pkg/oci/pull.go
@@ -122,6 +122,10 @@ func (o *OrasRemote) LayersFromRequestedComponents(requestedComponents []string)
 			manifestDescriptor := helpers.Find(index.Manifests, func(layer ocispec.Descriptor) bool {
 				return layer.Annotations[ocispec.AnnotationBaseImageName] == image
 			})
+
+			// even though these are technically image manifests, we store them as Zarf blobs
+			manifestDescriptor.MediaType = ZarfLayerMediaTypeBlob
+
 			manifest, err := o.FetchManifest(manifestDescriptor)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Description
When pulling from GHCR we noticed that Zarf image manifests were coming from the `/manifests/` path when they should actually be coming from `/blobs/`. Even though they are technically image manifests, Zarf stores in them OCI as blobs, so this PR changes the MediaType on the image manifest to be a Zarf blob
