### PR TITLE
Merge Common vars insteaad of using the global

### DIFF
--- a/src/pkg/k8s/configmap.go
+++ b/src/pkg/k8s/configmap.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,10 +29,12 @@ func (k *K8s) CreateConfigmap(namespace, name string, data map[string][]byte) (*
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    k.Labels,
 		},
 		BinaryData: data,
 	}
+
+	// Merge in common labels so that later modifications to the namespace can't mutate them
+	configMap.ObjectMeta.Labels = helpers.MergeMap[string](k.Labels, configMap.ObjectMeta.Labels)
 
 	createOptions := metav1.CreateOptions{}
 	return k.Clientset.CoreV1().ConfigMaps(namespace).Create(context.TODO(), configMap, createOptions)

--- a/src/pkg/k8s/namespace.go
+++ b/src/pkg/k8s/namespace.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"cuelang.org/go/pkg/strings"
+	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,16 +64,20 @@ func (k *K8s) DeleteNamespace(ctx context.Context, name string) error {
 
 // NewZarfManagedNamespace returns a corev1.Namespace with Zarf-managed labels
 func (k *K8s) NewZarfManagedNamespace(name string) *corev1.Namespace {
-	return &corev1.Namespace{
+	namespace := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),
 			Kind:       "Namespace",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: k.Labels,
+			Name: name,
 		},
 	}
+
+	// Merge in common labels so that later modifications to the namespace can't mutate them
+	namespace.ObjectMeta.Labels = helpers.MergeMap[string](k.Labels, namespace.ObjectMeta.Labels)
+
+	return namespace
 }
 
 // IsInitialNamespace returns true if the given namespace name is an initial k8s namespace: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#initial-namespaces

--- a/src/pkg/k8s/pods.go
+++ b/src/pkg/k8s/pods.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +19,7 @@ const waitLimit = 30
 
 // GeneratePod creates a new pod without adding it to the k8s cluster.
 func (k *K8s) GeneratePod(name, namespace string) *corev1.Pod {
-	return &corev1.Pod{
+	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),
 			Kind:       "Pod",
@@ -26,9 +27,13 @@ func (k *K8s) GeneratePod(name, namespace string) *corev1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    k.Labels,
 		},
 	}
+
+	// Merge in common labels so that later modifications to the pod can't mutate them
+	pod.ObjectMeta.Labels = helpers.MergeMap[string](k.Labels, pod.ObjectMeta.Labels)
+
+	return pod
 }
 
 // DeletePod removes a pod from the cluster by namespace & name.

--- a/src/pkg/k8s/services.go
+++ b/src/pkg/k8s/services.go
@@ -7,6 +7,7 @@ package k8s
 import (
 	"context"
 
+	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -22,7 +23,7 @@ func (k *K8s) ReplaceService(service *corev1.Service) (*corev1.Service, error) {
 
 // GenerateService returns a K8s service struct without writing to the cluster.
 func (k *K8s) GenerateService(namespace, name string) *corev1.Service {
-	return &corev1.Service{
+	service := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),
 			Kind:       "Service",
@@ -31,9 +32,13 @@ func (k *K8s) GenerateService(namespace, name string) *corev1.Service {
 			Name:        name,
 			Namespace:   namespace,
 			Annotations: make(Labels),
-			Labels:      k.Labels,
 		},
 	}
+
+	// Merge in common labels so that later modifications to the service can't mutate them
+	service.ObjectMeta.Labels = helpers.MergeMap[string](k.Labels, service.ObjectMeta.Labels)
+
+	return service
 }
 
 // DeleteService removes a service from the cluster by namespace and name.


### PR DESCRIPTION
## Description

This fixes accidental label sharing when using Zarf as a library or in edge cases within Zarf itself.

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
