### PR TITLE
feat: add extraEnvVars value to registry chart abd REGISTRY_EXTRA_ENVS to registry package

### DIFF
--- a/packages/zarf-registry/chart/templates/deployment.yaml
+++ b/packages/zarf-registry/chart/templates/deployment.yaml
@@ -61,15 +61,22 @@ spec:
               value: "Registry Realm"
             - name: REGISTRY_AUTH_HTPASSWD_PATH
               value: "/etc/docker/registry/htpasswd"
+{{- if .Values.persistence.enabled }}
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
+{{- end }}
 {{- if .Values.persistence.deleteEnabled }}
             - name: REGISTRY_STORAGE_DELETE_ENABLED
               value: "true"
 {{- end }}
+{{- with .Values.extraEnvVars }}
+{{ toYaml .  | indent 12 }}
+{{- end }}
           volumeMounts:
+{{- if .Values.persistence.enabled }}
             - name: data
               mountPath: /var/lib/registry/
+{{- end }}
             - name: config
               mountPath: "/etc/docker/registry"
       affinity:
@@ -97,6 +104,8 @@ spec:
               path: config.yml
             - key: htpasswd
               path: htpasswd
+{{- if .Values.persistence.enabled }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "docker-registry.fullname" . }}{{- end }}
+{{- end }}

--- a/packages/zarf-registry/chart/values.yaml
+++ b/packages/zarf-registry/chart/values.yaml
@@ -53,3 +53,8 @@ autoscaling:
   minReplicas: 1
   maxReplicas: 5
   targetCPUUtilizationPercentage: 80
+
+extraEnvVars: []
+## Additional ENV variables to set
+# - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
+#   value: "/var/lib/example"

--- a/packages/zarf-registry/registry-values.yaml
+++ b/packages/zarf-registry/registry-values.yaml
@@ -1,4 +1,5 @@
 persistence:
+  enabled: ###ZARF_VAR_REGISTRY_PVC_ENABLED###
   storageClass: "###ZARF_STORAGE_CLASS###"
   size: "###ZARF_VAR_REGISTRY_PVC_SIZE###"
   existingClaim: "###ZARF_VAR_REGISTRY_EXISTING_PVC###"
@@ -38,3 +39,6 @@ autoscaling:
   minReplicas: "###ZARF_VAR_REGISTRY_HPA_MIN###"
   maxReplicas: "###ZARF_VAR_REGISTRY_HPA_MAX###"
   targetCPUUtilizationPercentage: 80
+
+extraEnvVars:
+  ###ZARF_VAR_REGISTRY_EXTRA_ENVS###

--- a/packages/zarf-registry/zarf.yaml
+++ b/packages/zarf-registry/zarf.yaml
@@ -7,6 +7,10 @@ variables:
     description: "Optional: Use an existing PVC for the registry instead of creating a new one. If this is set, the REGISTRY_PVC_SIZE variable will be ignored."
     default: ""
 
+  - name: REGISTRY_PVC_ENABLED
+    description: Toggle the creation and use of a PVC off/on
+    default: "true"
+
   - name: REGISTRY_PVC_SIZE
     description: The size of the persistent volume claim for the registry
     default: 20Gi
@@ -42,6 +46,11 @@ variables:
   - name: REGISTRY_HPA_ENABLE
     description: Enable the Horizontal Pod Autoscaler for the registry
     default: "true"
+
+  - name: REGISTRY_EXTRA_ENVS
+    description: Array of additional environment variables passed to the registry container
+    default: ""
+    autoIndent: true
 
 constants:
   - name: REGISTRY_IMAGE


### PR DESCRIPTION
## Description

Alter registry Helm chart to allow the PVC mount and filesystem storage driver to be toggled off.
Add extraEnvVars value and templating to helm chart to allow for arbitrary environment variables.
Add REGISTRY_PVC_ENABLED variable to registry package to toggle PVC creation and filesystem storage driver off/on.
Add REGISTRY_EXTRA_ENVS variable to registry package to expose extraEnvVars helm chart value.

Example of how to back the registry with S3:

```bash
zarf init --confirm --set REGISTRY_PVC_ENABLED=false --set REGISTRY_EXTRA_ENVS=' 
- name: REGISTRY_STORAGE
  value: s3
- name: REGISTRY_STORAGE_S3_REGION
  value: us-east-2
- name: REGISTRY_STORAGE_S3_BUCKET
  value: registry-test-bucket-zarf
- name: REGISTRY_STORAGE_S3_ACCESSKEY
  value: AKIAIOSFODNN7EXAMPLE
- name: REGISTRY_STORAGE_S3_SECRETKEY
  value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
'
```


## Related Issue

Fixes #1993

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
