### PR TITLE
Adds set config function for library usage

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -188,3 +188,12 @@ func GetAbsHomePath(path string) string {
 	}
 	return path
 }
+
+// SetCommonOptions sets Zarf config options
+func SetCommonOptions(opts types.ZarfCommonOptions) {
+	CommonOptions.Insecure = opts.Insecure
+	CommonOptions.TempDirectory = opts.TempDirectory
+	CommonOptions.OCIConcurrency = opts.OCIConcurrency
+	CommonOptions.Confirm = opts.Confirm
+	CommonOptions.CachePath = opts.CachePath
+}


### PR DESCRIPTION
## Description
Taking advice from this [comment](https://github.com/defenseunicorns/uds-cli/pull/26#discussion_r1307945876), this PR adds a `SetCommonOptions` to give Zarf library users a mechanism for cleanly setting Zarf configs

Tested by calling the new fn using Zarf as a library:
```
	zarfConfig.SetCommonOptions(zarfTypes.ZarfCommonOptions{
		Insecure:       config.CommonOptions.Insecure,
		TempDirectory:  config.CommonOptions.TempDirectory,
		OCIConcurrency: config.CommonOptions.OCIConcurrency,
		Confirm:        config.CommonOptions.Confirm,
		CachePath:      config.CommonOptions.CachePath,
	})
```

And ensuring Zarf packages installed with the expected options