### PR TITLE
Resolve edge cases with `--tmpdir` behavior

### DIFF
--- a/src/internal/packager/git/pull.go
+++ b/src/internal/packager/git/pull.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/pkg/transform"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -18,7 +19,7 @@ import (
 func (g *Git) DownloadRepoToTemp(gitURL string) error {
 	g.Spinner.Updatef("g.DownloadRepoToTemp(%s)", gitURL)
 
-	path, err := utils.MakeTempDir()
+	path, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {
 		return fmt.Errorf("unable to create tmpdir: %w", err)
 	}

--- a/src/internal/packager/helm/post-render.go
+++ b/src/internal/packager/helm/post-render.go
@@ -55,7 +55,7 @@ func (h *Helm) newRenderer() (*renderer, error) {
 
 func (r *renderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error) {
 	// This is very low cost and consistent for how we replace elsewhere, also good for debugging
-	tempDir, err := utils.MakeTempDir()
+	tempDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create tmpdir:  %w", err)
 	}

--- a/src/pkg/oci/utils.go
+++ b/src/pkg/oci/utils.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
@@ -107,7 +108,7 @@ func DownloadPackageTarball(url, destinationTarball string, concurrency int) err
 		return err
 	}
 
-	tmp, err := utils.MakeTempDir()
+	tmp, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -246,7 +246,6 @@ func createPaths(basePath string) (paths types.TempPaths, err error) {
 		return paths, err
 	}
 
-	message.Debug("Using temporary directory:", basePath)
 	paths = types.TempPaths{
 		Base: basePath,
 

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -241,16 +241,11 @@ func isValidFileExtension(filename string) bool {
 }
 
 func createPaths(basePath string) (paths types.TempPaths, err error) {
-	if basePath == "" {
-		basePath, err = utils.MakeTempDir()
-		if err != nil {
-			return paths, err
-		}
-	} else {
-		if err := utils.CreateDirectory(basePath, 0700); err != nil {
-			return paths, fmt.Errorf("unable to create temp directory: %w", err)
-		}
+	basePath, err = utils.MakeTempDir(basePath)
+	if err != nil {
+		return paths, err
 	}
+
 	message.Debug("Using temporary directory:", basePath)
 	paths = types.TempPaths{
 		Base: basePath,

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -619,7 +619,7 @@ func (p *Packager) loadDifferentialData() error {
 	// Save the fact that this is a differential build into the build data of the package
 	p.cfg.Pkg.Build.Differential = true
 
-	tmpDir, _ := utils.MakeTempDir()
+	tmpDir, _ := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	defer os.RemoveAll(tmpDir)
 
 	// Load the package spec of the package we're using as a 'reference' for the differential build

--- a/src/pkg/utils/io.go
+++ b/src/pkg/utils/io.go
@@ -60,13 +60,13 @@ type TextTemplate struct {
 
 // MakeTempDir creates a temp directory with the zarf- prefix.
 func MakeTempDir(basePath string) (string, error) {
-	if basePath != "" && InvalidPath(basePath) {
+	if basePath != "" {
 		if err := CreateDirectory(basePath, 0700); err != nil {
 			return "", err
 		}
 	}
 	tmp, err := os.MkdirTemp(basePath, tmpPathPrefix)
-	message.Debugf("Creating temp path: '%s'", tmp)
+	message.Debug("Using temporary directory:", basePath)
 	return tmp, err
 }
 

--- a/src/pkg/utils/io.go
+++ b/src/pkg/utils/io.go
@@ -59,8 +59,13 @@ type TextTemplate struct {
 }
 
 // MakeTempDir creates a temp directory with the zarf- prefix.
-func MakeTempDir() (string, error) {
-	tmp, err := os.MkdirTemp("", tmpPathPrefix)
+func MakeTempDir(basePath string) (string, error) {
+	if InvalidPath(basePath) {
+		if err := CreateDirectory(basePath, 0700); err != nil {
+			return "", err
+		}
+	}
+	tmp, err := os.MkdirTemp(basePath, tmpPathPrefix)
 	message.Debugf("Creating temp path: '%s'", tmp)
 	return tmp, err
 }

--- a/src/pkg/utils/io.go
+++ b/src/pkg/utils/io.go
@@ -60,7 +60,7 @@ type TextTemplate struct {
 
 // MakeTempDir creates a temp directory with the zarf- prefix.
 func MakeTempDir(basePath string) (string, error) {
-	if InvalidPath(basePath) {
+	if basePath != "" && InvalidPath(basePath) {
 		if err := CreateDirectory(basePath, 0700); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
## Description

This PR resolves edge cases with `--tmpdir` behavior by always using the specified temp dir in commands and always making a unique sub folder for each zarf run.

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
