### PR TITLE
feat: add REGISTRY_CA_BUNDLE variable to registry package and chart

### DIFF
--- a/packages/zarf-registry/chart/templates/_helpers.tpl
+++ b/packages/zarf-registry/chart/templates/_helpers.tpl
@@ -22,3 +22,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Merge all configmaps
+*/}}
+{{- define "docker-registry.configMaps" -}}
+{{- if .Values.caBundle }}
+- name: {{ template "docker-registry.fullname" . }}-ca-bundle
+  data:
+    ca-certificates.crt: |
+{{ .Values.caBundle | indent 6 }}
+{{- end }}
+{{- end -}}

--- a/packages/zarf-registry/chart/templates/configmap.yaml
+++ b/packages/zarf-registry/chart/templates/configmap.yaml
@@ -1,0 +1,16 @@
+{{- range (include "docker-registry.configMaps" . | fromYamlArray ) }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ default $.Chart.Name $.Values.nameOverride | trunc 63 | trimSuffix "-" }}
+    chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    heritage: {{ $.Release.Service }}
+    release: {{ $.Release.Name }}
+type: Opaque
+data:
+{{ toYaml .data | indent 2 }}
+{{- end }}

--- a/packages/zarf-registry/chart/templates/deployment.yaml
+++ b/packages/zarf-registry/chart/templates/deployment.yaml
@@ -77,6 +77,12 @@ spec:
               mountPath: /var/lib/registry/
             - name: config
               mountPath: "/etc/docker/registry"
+{{- if .Values.caBundle }}
+            - mountPath: /etc/ssl/certs/ca-certificates.crt
+              name: {{ template "docker-registry.fullname" . }}-ca-bundle
+              subPath: ca-certificates.crt
+              readOnly: true
+{{- end }}
       affinity:
 {{- if (eq "ReadWriteMany" .Values.persistence.accessMode) }}
         podAntiAffinity:
@@ -110,4 +116,9 @@ spec:
         - name: data
           emptyDir:
             sizeLimit: {{ .Values.persistence.size }}
+{{- end }}
+{{- if .Values.caBundle }}
+        - name: {{ template "docker-registry.fullname" . }}-ca-bundle
+          configMap:
+            name: {{ template "docker-registry.fullname" . }}-ca-bundle
 {{- end }}

--- a/packages/zarf-registry/chart/values.yaml
+++ b/packages/zarf-registry/chart/values.yaml
@@ -54,6 +54,23 @@ autoscaling:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 80
 
+caBundle: ""
+## One or more concatenated certificates
+## Will be mounted to /etc/ssl/certs/ca-certificates.crt
+# caBundle: |
+#   # Root CA 1
+#   -----BEGIN CERTIFICATE-----
+#   ...
+#   -----END CERTIFICATE-----
+#   # Intermediate CA 1
+#   -----BEGIN CERTIFICATE-----
+#   ...
+#   -----END CERTIFICATE-----
+#   # Root CA 2
+#   -----BEGIN CERTIFICATE-----
+#   ...
+#   -----END CERTIFICATE-----
+
 extraEnvVars: []
 ## Additional ENV variables to set
 # - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY

--- a/packages/zarf-registry/registry-values.yaml
+++ b/packages/zarf-registry/registry-values.yaml
@@ -40,5 +40,8 @@ autoscaling:
   maxReplicas: "###ZARF_VAR_REGISTRY_HPA_MAX###"
   targetCPUUtilizationPercentage: 80
 
+caBundle: |
+  ###ZARF_VAR_REGISTRY_CA_BUNDLE###
+
 extraEnvVars:
   ###ZARF_VAR_REGISTRY_EXTRA_ENVS###

--- a/packages/zarf-registry/registry-values.yaml
+++ b/packages/zarf-registry/registry-values.yaml
@@ -40,8 +40,7 @@ autoscaling:
   maxReplicas: "###ZARF_VAR_REGISTRY_HPA_MAX###"
   targetCPUUtilizationPercentage: 80
 
-caBundle: |
-  ###ZARF_VAR_REGISTRY_CA_BUNDLE###
+caBundle: ###ZARF_VAR_REGISTRY_CA_BUNDLE###
 
 extraEnvVars:
   ###ZARF_VAR_REGISTRY_EXTRA_ENVS###

--- a/packages/zarf-registry/zarf.yaml
+++ b/packages/zarf-registry/zarf.yaml
@@ -47,6 +47,11 @@ variables:
     description: Enable the Horizontal Pod Autoscaler for the registry
     default: "true"
 
+  - name: REGISTRY_CA_BUNDLE
+    description: Bundle of trusted certificates to mount into the registry container
+    default: ""
+    autoIndent: true
+
   - name: REGISTRY_EXTRA_ENVS
     description: Array of additional environment variables passed to the registry container
     default: ""

--- a/packages/zarf-registry/zarf.yaml
+++ b/packages/zarf-registry/zarf.yaml
@@ -48,9 +48,10 @@ variables:
     default: "true"
 
   - name: REGISTRY_CA_BUNDLE
-    description: Bundle of trusted certificates to mount into the registry container
+    description: Filepath to a bundle of trusted certificates to mount into the registry container
     default: ""
     autoIndent: true
+    type: file
 
   - name: REGISTRY_EXTRA_ENVS
     description: Array of additional environment variables passed to the registry container

--- a/src/pkg/utils/io.go
+++ b/src/pkg/utils/io.go
@@ -170,7 +170,7 @@ func ReplaceTextTemplate(path string, mappings map[string]*TextTemplate, depreca
 				value = template.Value
 
 				// Check if the value is a file type and load the value contents from the file
-				if template.Type == types.FileVariableType {
+				if template.Type == types.FileVariableType && value != "" {
 					if isText, err := IsTextFile(value); err != nil || !isText {
 						message.Warnf("Refusing to load a non-text file for templating %s", templateKey)
 						line = matches[regexTemplateLine.SubexpIndex("postTemplate")]


### PR DESCRIPTION
## Description

Allows users to specify a CA bundle to the Registry when performing a `zarf init`.  

An example of how to use this to supply a Root CA Bundle in commercial AWS (although you don't need to):

Create a `zarf-config.yaml` similar to the following:

```yaml
package:
  deploy:
    set:
      REGISTRY_CA_BUNDLE: my-custom-ca.pem
```

Initialize the cluster:
`ZARF_CONFIG=./zarf-config.yaml zarf init --confirm`


## Related Issue

Fixes #2007

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
