### PR TITLE
Remove the image manifest check from find successors

### DIFF
--- a/src/pkg/oci/pull.go
+++ b/src/pkg/oci/pull.go
@@ -211,9 +211,6 @@ func (o *OrasRemote) CopyWithProgress(layers []ocispec.Descriptor, store oras.Ta
 	}
 
 	copyOpts.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		if desc.MediaType != ocispec.MediaTypeImageManifest {
-			return nil, nil
-		}
 		nodes, err := content.Successors(ctx, fetcher, desc)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Description

This removes a check from find successors that would cause it to not find successors for manifests that are not images.

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
