### PR TITLE
Allow shasums to be present in images

### DIFF
--- a/.github/workflows/test-e2e-shim.yml
+++ b/.github/workflows/test-e2e-shim.yml
@@ -11,6 +11,9 @@ on:
       - "docs/**"
       - "CODEOWNERS"
 
+permissions:
+  contents: read
+
 # This is here to act as a shim for branch protection rules to work correctly.
 # This is ugly but this seems to be the best way to do this since:
 #  - Job names in a workflow must be unique

--- a/src/internal/cluster/injector.go
+++ b/src/internal/cluster/injector.go
@@ -140,7 +140,7 @@ func (c *Cluster) loadSeedImages(tempPath types.TempPaths, injectorSeedRefs []st
 		if err != nil {
 			return seedImages, fmt.Errorf("failed to create ref for image %s: %w", src, err)
 		}
-		img, err := utils.LoadOCIImage(tempPath.Images, ref.Reference)
+		img, err := utils.LoadOCIImage(tempPath.Images, ref)
 		if err != nil {
 			return seedImages, err
 		}

--- a/src/internal/cluster/injector.go
+++ b/src/internal/cluster/injector.go
@@ -129,12 +129,12 @@ func (c *Cluster) StopInjectionMadness() error {
 	return c.DeleteService(ZarfNamespaceName, "zarf-injector")
 }
 
-func (c *Cluster) loadSeedImages(tempPath types.TempPaths, injectorSeedRefs []string, spinner *message.Spinner) ([]transform.Image, error) {
+func (c *Cluster) loadSeedImages(tempPath types.TempPaths, injectorSeedSrcs []string, spinner *message.Spinner) ([]transform.Image, error) {
 	seedImages := []transform.Image{}
 	refToDigest := make(map[string]string)
 
 	// Load the injector-specific images and save them as seed-images
-	for _, src := range injectorSeedRefs {
+	for _, src := range injectorSeedSrcs {
 		spinner.Updatef("Loading the seed image '%s' from the package", src)
 		ref, err := transform.ParseImageRef(src)
 		if err != nil {

--- a/src/internal/cluster/injector.go
+++ b/src/internal/cluster/injector.go
@@ -136,8 +136,11 @@ func (c *Cluster) loadSeedImages(tempPath types.TempPaths, injectorSeedTags []st
 	// Load the injector-specific images and save them as seed-images
 	for _, src := range injectorSeedTags {
 		spinner.Updatef("Loading the seed image '%s' from the package", src)
-
-		img, err := utils.LoadOCIImage(tempPath.Images, src)
+		ref, err := transform.ParseImageRef(src)
+		if err != nil {
+			return seedImages, fmt.Errorf("failed to create tag for image %s: %w", src, err)
+		}
+		img, err := utils.LoadOCIImage(tempPath.Images, ref.Reference)
 		if err != nil {
 			return seedImages, err
 		}

--- a/src/internal/cluster/injector.go
+++ b/src/internal/cluster/injector.go
@@ -29,7 +29,7 @@ import (
 var payloadChunkSize = 1024 * 768
 
 // StartInjectionMadness initializes a Zarf injection into the cluster.
-func (c *Cluster) StartInjectionMadness(tempPath types.TempPaths, injectorSeedRefs []string) {
+func (c *Cluster) StartInjectionMadness(tempPath types.TempPaths, injectorSeedSrcs []string) {
 	spinner := message.NewProgressSpinner("Attempting to bootstrap the seed image into the cluster")
 	defer spinner.Stop()
 
@@ -59,7 +59,7 @@ func (c *Cluster) StartInjectionMadness(tempPath types.TempPaths, injectorSeedRe
 	}
 
 	spinner.Updatef("Loading the seed image from the package")
-	if seedImages, err = c.loadSeedImages(tempPath, injectorSeedRefs, spinner); err != nil {
+	if seedImages, err = c.loadSeedImages(tempPath, injectorSeedSrcs, spinner); err != nil {
 		spinner.Fatalf(err, "Unable to load the injector seed image from the package")
 	}
 

--- a/src/internal/cluster/injector.go
+++ b/src/internal/cluster/injector.go
@@ -131,7 +131,7 @@ func (c *Cluster) StopInjectionMadness() error {
 
 func (c *Cluster) loadSeedImages(tempPath types.TempPaths, injectorSeedSrcs []string, spinner *message.Spinner) ([]transform.Image, error) {
 	seedImages := []transform.Image{}
-	refToDigest := make(map[string]string)
+	localReferenceToDigest := make(map[string]string)
 
 	// Load the injector-specific images and save them as seed-images
 	for _, src := range injectorSeedSrcs {
@@ -155,10 +155,10 @@ func (c *Cluster) loadSeedImages(tempPath types.TempPaths, injectorSeedSrcs []st
 			return seedImages, err
 		}
 		// This is done _without_ the domain (different from pull.go) since the injector only handles local images
-		refToDigest[ref.Path+ref.TagOrDigest] = imgDigest.String()
+		localReferenceToDigest[ref.Path+ref.TagOrDigest] = imgDigest.String()
 	}
 
-	if err := utils.AddImageNameAnnotation(tempPath.SeedImages, refToDigest); err != nil {
+	if err := utils.AddImageNameAnnotation(tempPath.SeedImages, localReferenceToDigest); err != nil {
 		return seedImages, fmt.Errorf("unable to format OCI layout: %w", err)
 	}
 

--- a/src/internal/cluster/injector.go
+++ b/src/internal/cluster/injector.go
@@ -29,7 +29,7 @@ import (
 var payloadChunkSize = 1024 * 768
 
 // StartInjectionMadness initializes a Zarf injection into the cluster.
-func (c *Cluster) StartInjectionMadness(tempPath types.TempPaths, injectorSeedTags []string) {
+func (c *Cluster) StartInjectionMadness(tempPath types.TempPaths, injectorSeedRefs []string) {
 	spinner := message.NewProgressSpinner("Attempting to bootstrap the seed image into the cluster")
 	defer spinner.Stop()
 
@@ -59,7 +59,7 @@ func (c *Cluster) StartInjectionMadness(tempPath types.TempPaths, injectorSeedTa
 	}
 
 	spinner.Updatef("Loading the seed image from the package")
-	if seedImages, err = c.loadSeedImages(tempPath, injectorSeedTags, spinner); err != nil {
+	if seedImages, err = c.loadSeedImages(tempPath, injectorSeedRefs, spinner); err != nil {
 		spinner.Fatalf(err, "Unable to load the injector seed image from the package")
 	}
 
@@ -129,16 +129,16 @@ func (c *Cluster) StopInjectionMadness() error {
 	return c.DeleteService(ZarfNamespaceName, "zarf-injector")
 }
 
-func (c *Cluster) loadSeedImages(tempPath types.TempPaths, injectorSeedTags []string, spinner *message.Spinner) ([]transform.Image, error) {
+func (c *Cluster) loadSeedImages(tempPath types.TempPaths, injectorSeedRefs []string, spinner *message.Spinner) ([]transform.Image, error) {
 	seedImages := []transform.Image{}
-	tagToDigest := make(map[string]string)
+	refToDigest := make(map[string]string)
 
 	// Load the injector-specific images and save them as seed-images
-	for _, src := range injectorSeedTags {
+	for _, src := range injectorSeedRefs {
 		spinner.Updatef("Loading the seed image '%s' from the package", src)
 		ref, err := transform.ParseImageRef(src)
 		if err != nil {
-			return seedImages, fmt.Errorf("failed to create tag for image %s: %w", src, err)
+			return seedImages, fmt.Errorf("failed to create ref for image %s: %w", src, err)
 		}
 		img, err := utils.LoadOCIImage(tempPath.Images, ref.Reference)
 		if err != nil {
@@ -147,11 +147,7 @@ func (c *Cluster) loadSeedImages(tempPath types.TempPaths, injectorSeedTags []st
 
 		crane.SaveOCI(img, tempPath.SeedImages)
 
-		imgRef, err := transform.ParseImageRef(src)
-		if err != nil {
-			return seedImages, err
-		}
-		seedImages = append(seedImages, imgRef)
+		seedImages = append(seedImages, ref)
 
 		// Get the image digest so we can set an annotation in the image.json later
 		imgDigest, err := img.Digest()
@@ -159,10 +155,10 @@ func (c *Cluster) loadSeedImages(tempPath types.TempPaths, injectorSeedTags []st
 			return seedImages, err
 		}
 		// This is done _without_ the domain (different from pull.go) since the injector only handles local images
-		tagToDigest[imgRef.Path+imgRef.TagOrDigest] = imgDigest.String()
+		refToDigest[ref.Path+ref.TagOrDigest] = imgDigest.String()
 	}
 
-	if err := utils.AddImageNameAnnotation(tempPath.SeedImages, tagToDigest); err != nil {
+	if err := utils.AddImageNameAnnotation(tempPath.SeedImages, refToDigest); err != nil {
 		return seedImages, fmt.Errorf("unable to format OCI layout: %w", err)
 	}
 

--- a/src/internal/packager/images/common.go
+++ b/src/internal/packager/images/common.go
@@ -20,7 +20,7 @@ import (
 type ImgConfig struct {
 	ImagesPath string
 
-	ImgList []string
+	ImgList []transform.Image
 
 	RegInfo types.RegistryInfo
 
@@ -39,17 +39,12 @@ func (i *ImgConfig) GetLegacyImgTarballPath() string {
 }
 
 // LoadImageFromPackage returns a v1.Image from the image ref specified, or an error if the image cannot be found.
-func (i ImgConfig) LoadImageFromPackage(src string) (v1.Image, error) {
+func (i ImgConfig) LoadImageFromPackage(ref transform.Image) (v1.Image, error) {
 	// If the package still has a images.tar that contains all of the images, use crane to load the specific ref (tag) we want
 	if _, statErr := os.Stat(i.GetLegacyImgTarballPath()); statErr == nil {
-		return crane.LoadTag(i.GetLegacyImgTarballPath(), src, config.GetCraneOptions(i.Insecure, i.Architectures...)...)
-	}
-
-	ref, err := transform.ParseImageRef(src)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create ref for image %s: %w", src, err)
+		return crane.LoadTag(i.GetLegacyImgTarballPath(), ref.Reference, config.GetCraneOptions(i.Insecure, i.Architectures...)...)
 	}
 
 	// Load the image from the OCI formatted images directory
-	return utils.LoadOCIImage(i.ImagesPath, ref.Reference)
+	return utils.LoadOCIImage(i.ImagesPath, ref)
 }

--- a/src/internal/packager/images/common.go
+++ b/src/internal/packager/images/common.go
@@ -38,16 +38,16 @@ func (i *ImgConfig) GetLegacyImgTarballPath() string {
 	return fmt.Sprintf("%s.tar", i.ImagesPath)
 }
 
-// LoadImageFromPackage returns a v1.Image from the image tag specified, or an error if the image cannot be found.
+// LoadImageFromPackage returns a v1.Image from the image ref specified, or an error if the image cannot be found.
 func (i ImgConfig) LoadImageFromPackage(src string) (v1.Image, error) {
-	// If the package still has a images.tar that contains all of the images, use crane to load the specific tag we want
+	// If the package still has a images.tar that contains all of the images, use crane to load the specific ref (tag) we want
 	if _, statErr := os.Stat(i.GetLegacyImgTarballPath()); statErr == nil {
 		return crane.LoadTag(i.GetLegacyImgTarballPath(), src, config.GetCraneOptions(i.Insecure, i.Architectures...)...)
 	}
 
 	ref, err := transform.ParseImageRef(src)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create tag for image %s: %w", src, err)
+		return nil, fmt.Errorf("failed to create ref for image %s: %w", src, err)
 	}
 
 	// Load the image from the OCI formatted images directory

--- a/src/internal/packager/images/common.go
+++ b/src/internal/packager/images/common.go
@@ -16,11 +16,11 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
-// ImgConfig is the main struct for managing container images.
-type ImgConfig struct {
+// ImageConfig is the main struct for managing container images.
+type ImageConfig struct {
 	ImagesPath string
 
-	ImgList []transform.Image
+	ImageList []transform.Image
 
 	RegInfo types.RegistryInfo
 
@@ -34,17 +34,17 @@ type ImgConfig struct {
 }
 
 // GetLegacyImgTarballPath returns the ImagesPath as if it were a path to a tarball instead of a directory.
-func (i *ImgConfig) GetLegacyImgTarballPath() string {
+func (i *ImageConfig) GetLegacyImgTarballPath() string {
 	return fmt.Sprintf("%s.tar", i.ImagesPath)
 }
 
-// LoadImageFromPackage returns a v1.Image from the image ref specified, or an error if the image cannot be found.
-func (i ImgConfig) LoadImageFromPackage(ref transform.Image) (v1.Image, error) {
-	// If the package still has a images.tar that contains all of the images, use crane to load the specific ref (tag) we want
+// LoadImageFromPackage returns a v1.Image from the specified image, or an error if the image cannot be found.
+func (i ImageConfig) LoadImageFromPackage(refInfo transform.Image) (v1.Image, error) {
+	// If the package still has a images.tar that contains all of the images, use crane to load the specific reference (crane tag) we want
 	if _, statErr := os.Stat(i.GetLegacyImgTarballPath()); statErr == nil {
-		return crane.LoadTag(i.GetLegacyImgTarballPath(), ref.Reference, config.GetCraneOptions(i.Insecure, i.Architectures...)...)
+		return crane.LoadTag(i.GetLegacyImgTarballPath(), refInfo.Reference, config.GetCraneOptions(i.Insecure, i.Architectures...)...)
 	}
 
 	// Load the image from the OCI formatted images directory
-	return utils.LoadOCIImage(i.ImagesPath, ref)
+	return utils.LoadOCIImage(i.ImagesPath, refInfo)
 }

--- a/src/internal/packager/images/pull.go
+++ b/src/internal/packager/images/pull.go
@@ -107,7 +107,7 @@ func (i *ImgConfig) PullAll() error {
 	}
 
 	onMetadataProgress := func(finishedImage refAndImg, iteration int) {
-		spinner.Updatef("Fetching image metadata (%d of %d): %s", iteration+1, len(i.ImgList), finishedImage.ref)
+		spinner.Updatef("Fetching image metadata (%d of %d): %s", iteration+1, len(i.ImgList), finishedImage.ref.Reference)
 		imageMap[finishedImage.ref] = finishedImage.img
 	}
 
@@ -174,7 +174,7 @@ func (i *ImgConfig) PullAll() error {
 	for ref, img := range refToImage {
 		imgDigest, err := img.Digest()
 		if err != nil {
-			return fmt.Errorf("unable to get digest for image %s: %w", ref, err)
+			return fmt.Errorf("unable to get digest for image %s: %w", ref.Reference, err)
 		}
 		refToDigest[ref.Reference] = imgDigest.String()
 	}

--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -102,7 +102,7 @@ func (i *ImgConfig) PushToZarfRegistry() error {
 				return err
 			}
 
-			message.Debugf("crane.Push() %s:%s -> %s)", i.ImagesPath, ref, offlineNameCRC)
+			message.Debugf("crane.Push() %s:%s -> %s)", i.ImagesPath, ref.Reference, offlineNameCRC)
 
 			if err = crane.Push(img, offlineNameCRC, pushOptions...); err != nil {
 				return err
@@ -116,7 +116,7 @@ func (i *ImgConfig) PushToZarfRegistry() error {
 			return err
 		}
 
-		message.Debugf("crane.Push() %s:%s -> %s)", i.ImagesPath, ref, offlineName)
+		message.Debugf("crane.Push() %s:%s -> %s)", i.ImagesPath, ref.Reference, offlineName)
 
 		if err = crane.Push(img, offlineName, pushOptions...); err != nil {
 			return err

--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -20,7 +20,7 @@ import (
 
 // PushToZarfRegistry pushes a provided image into the configured Zarf registry
 // This function will optionally shorten the image name while appending a checksum of the original image name.
-func (i *ImgConfig) PushToZarfRegistry() error {
+func (i *ImageConfig) PushToZarfRegistry() error {
 	message.Debug("images.PushToZarfRegistry()")
 
 	logs.Warn.SetOutput(&message.DebugWriter{})
@@ -29,7 +29,7 @@ func (i *ImgConfig) PushToZarfRegistry() error {
 	imageMap := map[transform.Image]v1.Image{}
 	var totalSize int64
 	// Build an image list from the references
-	for _, ref := range i.ImgList {
+	for _, ref := range i.ImageList {
 		img, err := i.LoadImageFromPackage(ref)
 		if err != nil {
 			return err
@@ -49,7 +49,7 @@ func (i *ImgConfig) PushToZarfRegistry() error {
 
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
 	httpTransport.TLSClientConfig.InsecureSkipVerify = i.Insecure
-	progressBar := message.NewProgressBar(totalSize, fmt.Sprintf("Pushing %d images to the zarf registry", len(i.ImgList)))
+	progressBar := message.NewProgressBar(totalSize, fmt.Sprintf("Pushing %d images to the zarf registry", len(i.ImageList)))
 	craneTransport := utils.NewTransport(httpTransport, progressBar)
 
 	pushOptions := config.GetCraneOptions(i.Insecure, i.Architectures...)
@@ -123,7 +123,7 @@ func (i *ImgConfig) PushToZarfRegistry() error {
 		}
 	}
 
-	progressBar.Successf("Pushed %d images to the zarf registry", len(i.ImgList))
+	progressBar.Successf("Pushed %d images to the zarf registry", len(i.ImageList))
 
 	return nil
 }

--- a/src/internal/packager/sbom/catalog.go
+++ b/src/internal/packager/sbom/catalog.go
@@ -47,7 +47,7 @@ var componentPrefix = "zarf-component-"
 
 // Catalog catalogs the given components and images to create an SBOM.
 // func Catalog(componentSBOMs map[string]*types.ComponentSBOM, imgList []string, imagesPath, sbomPath string) error {
-func Catalog(componentSBOMs map[string]*types.ComponentSBOM, imgList []string, tmpPaths types.TempPaths) error {
+func Catalog(componentSBOMs map[string]*types.ComponentSBOM, imgList []transform.Image, tmpPaths types.TempPaths) error {
 	imageCount := len(imgList)
 	componentCount := len(componentSBOMs)
 	builder := Builder{
@@ -82,13 +82,13 @@ func Catalog(componentSBOMs map[string]*types.ComponentSBOM, imgList []string, t
 			return err
 		}
 
-		jsonData, err := builder.createImageSBOM(img, ref)
+		jsonData, err := builder.createImageSBOM(img, ref.Reference)
 		if err != nil {
 			builder.spinner.Errorf(err, "Unable to create SBOM for image %s", ref)
 			return err
 		}
 
-		if err = builder.createSBOMViewerAsset(ref, jsonData); err != nil {
+		if err = builder.createSBOMViewerAsset(ref.Reference, jsonData); err != nil {
 			builder.spinner.Errorf(err, "Unable to create SBOM viewer for image %s", ref)
 			return err
 		}

--- a/src/internal/packager/sbom/catalog.go
+++ b/src/internal/packager/sbom/catalog.go
@@ -46,7 +46,6 @@ var transformRegex = regexp.MustCompile(`(?m)[^a-zA-Z0-9\.\-]`)
 var componentPrefix = "zarf-component-"
 
 // Catalog catalogs the given components and images to create an SBOM.
-// func Catalog(componentSBOMs map[string]*types.ComponentSBOM, imgList []string, imagesPath, sbomPath string) error {
 func Catalog(componentSBOMs map[string]*types.ComponentSBOM, imageList []transform.Image, tmpPaths types.TempPaths) error {
 	imageCount := len(imageList)
 	componentCount := len(componentSBOMs)
@@ -154,7 +153,7 @@ func Catalog(componentSBOMs map[string]*types.ComponentSBOM, imageList []transfo
 // some code/structure migrated from https://github.com/testifysec/go-witness/blob/v0.1.12/attestation/syft/syft.go.
 func (b *Builder) createImageSBOM(img v1.Image, src string) ([]byte, error) {
 	// Get the image reference.
-	ref, err := transform.ParseImageRef(src)
+	refInfo, err := transform.ParseImageRef(src)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ref for image %s: %w", src, err)
 	}
@@ -167,7 +166,7 @@ func (b *Builder) createImageSBOM(img v1.Image, src string) ([]byte, error) {
 		return nil, err
 	}
 
-	syftImage := image.NewImage(img, file.NewTempDirGenerator("zarf"), imageCachePath, image.WithTags(ref.Reference))
+	syftImage := image.NewImage(img, file.NewTempDirGenerator("zarf"), imageCachePath, image.WithTags(refInfo.Reference))
 	if err := syftImage.Read(); err != nil {
 		return nil, err
 	}
@@ -200,7 +199,7 @@ func (b *Builder) createImageSBOM(img v1.Image, src string) ([]byte, error) {
 	}
 
 	// Write the sbom to disk using the image ref as the filename
-	filename := fmt.Sprintf("%s.json", ref.Reference)
+	filename := fmt.Sprintf("%s.json", refInfo.Reference)
 	sbomFile, err := b.createSBOMFile(filename)
 	if err != nil {
 		return nil, err

--- a/src/internal/packager/sbom/catalog.go
+++ b/src/internal/packager/sbom/catalog.go
@@ -73,7 +73,7 @@ func Catalog(componentSBOMs map[string]*types.ComponentSBOM, imgList []transform
 	// Generate SBOM for each image
 	currImage := 1
 	for _, ref := range imgList {
-		builder.spinner.Updatef("Creating image SBOMs (%d of %d): %s", currImage, imageCount, ref)
+		builder.spinner.Updatef("Creating image SBOMs (%d of %d): %s", currImage, imageCount, ref.Reference)
 
 		// Get the image that we are creating an SBOM for
 		img, err := utils.LoadOCIImage(tmpPaths.Images, ref)
@@ -84,12 +84,12 @@ func Catalog(componentSBOMs map[string]*types.ComponentSBOM, imgList []transform
 
 		jsonData, err := builder.createImageSBOM(img, ref.Reference)
 		if err != nil {
-			builder.spinner.Errorf(err, "Unable to create SBOM for image %s", ref)
+			builder.spinner.Errorf(err, "Unable to create SBOM for image %s", ref.Reference)
 			return err
 		}
 
 		if err = builder.createSBOMViewerAsset(ref.Reference, jsonData); err != nil {
-			builder.spinner.Errorf(err, "Unable to create SBOM viewer for image %s", ref)
+			builder.spinner.Errorf(err, "Unable to create SBOM viewer for image %s", ref.Reference)
 			return err
 		}
 
@@ -156,7 +156,7 @@ func (b *Builder) createImageSBOM(img v1.Image, src string) ([]byte, error) {
 	// Get the image reference.
 	ref, err := transform.ParseImageRef(src)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create ref for image %s: %w", src, err)
+		return nil, fmt.Errorf("failed to create ref for image %s: %w", ref.Reference, err)
 	}
 
 	// Create the sbom.

--- a/src/internal/packager/sbom/catalog.go
+++ b/src/internal/packager/sbom/catalog.go
@@ -72,24 +72,24 @@ func Catalog(componentSBOMs map[string]*types.ComponentSBOM, imgList []string, t
 
 	// Generate SBOM for each image
 	currImage := 1
-	for _, tag := range imgList {
-		builder.spinner.Updatef("Creating image SBOMs (%d of %d): %s", currImage, imageCount, tag)
+	for _, ref := range imgList {
+		builder.spinner.Updatef("Creating image SBOMs (%d of %d): %s", currImage, imageCount, ref)
 
 		// Get the image that we are creating an SBOM for
-		img, err := utils.LoadOCIImage(tmpPaths.Images, tag)
+		img, err := utils.LoadOCIImage(tmpPaths.Images, ref)
 		if err != nil {
 			builder.spinner.Errorf(err, "Unable to load the image to generate an SBOM")
 			return err
 		}
 
-		jsonData, err := builder.createImageSBOM(img, tag)
+		jsonData, err := builder.createImageSBOM(img, ref)
 		if err != nil {
-			builder.spinner.Errorf(err, "Unable to create SBOM for image %s", tag)
+			builder.spinner.Errorf(err, "Unable to create SBOM for image %s", ref)
 			return err
 		}
 
-		if err = builder.createSBOMViewerAsset(tag, jsonData); err != nil {
-			builder.spinner.Errorf(err, "Unable to create SBOM viewer for image %s", tag)
+		if err = builder.createSBOMViewerAsset(ref, jsonData); err != nil {
+			builder.spinner.Errorf(err, "Unable to create SBOM viewer for image %s", ref)
 			return err
 		}
 
@@ -152,11 +152,11 @@ func Catalog(componentSBOMs map[string]*types.ComponentSBOM, imgList []string, t
 
 // createImageSBOM uses syft to generate SBOM for an image,
 // some code/structure migrated from https://github.com/testifysec/go-witness/blob/v0.1.12/attestation/syft/syft.go.
-func (b *Builder) createImageSBOM(img v1.Image, tagStr string) ([]byte, error) {
+func (b *Builder) createImageSBOM(img v1.Image, src string) ([]byte, error) {
 	// Get the image reference.
-	ref, err := transform.ParseImageRef(tagStr)
+	ref, err := transform.ParseImageRef(src)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create tag for image %s: %w", tagStr, err)
+		return nil, fmt.Errorf("failed to create ref for image %s: %w", src, err)
 	}
 
 	// Create the sbom.
@@ -199,7 +199,7 @@ func (b *Builder) createImageSBOM(img v1.Image, tagStr string) ([]byte, error) {
 		return nil, err
 	}
 
-	// Write the sbom to disk using the image tag as the filename
+	// Write the sbom to disk using the image ref as the filename
 	filename := fmt.Sprintf("%s.json", ref.Reference)
 	sbomFile, err := b.createSBOMFile(filename)
 	if err != nil {

--- a/src/internal/packager/sbom/catalog.go
+++ b/src/internal/packager/sbom/catalog.go
@@ -156,7 +156,7 @@ func (b *Builder) createImageSBOM(img v1.Image, src string) ([]byte, error) {
 	// Get the image reference.
 	ref, err := transform.ParseImageRef(src)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create ref for image %s: %w", ref.Reference, err)
+		return nil, fmt.Errorf("failed to create ref for image %s: %w", src, err)
 	}
 
 	// Create the sbom.

--- a/src/internal/packager/sbom/viewer.go
+++ b/src/internal/packager/sbom/viewer.go
@@ -73,11 +73,11 @@ func (b *Builder) loadFileJS(name string) template.JS {
 }
 
 // This could be optimized, but loop over all the images and components to create a list of json files.
-func (b *Builder) generateJSONList(componentToFiles map[string]*types.ComponentSBOM, imgList []transform.Image) ([]byte, error) {
+func (b *Builder) generateJSONList(componentToFiles map[string]*types.ComponentSBOM, imageList []transform.Image) ([]byte, error) {
 	var jsonList []string
 
-	for _, ref := range imgList {
-		normalized := b.getNormalizedFileName(ref.Reference)
+	for _, refInfo := range imageList {
+		normalized := b.getNormalizedFileName(refInfo.Reference)
 		jsonList = append(jsonList, normalized)
 	}
 

--- a/src/internal/packager/sbom/viewer.go
+++ b/src/internal/packager/sbom/viewer.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"html/template"
 
+	"github.com/defenseunicorns/zarf/src/pkg/transform"
 	"github.com/defenseunicorns/zarf/src/types"
 )
 
@@ -72,11 +73,11 @@ func (b *Builder) loadFileJS(name string) template.JS {
 }
 
 // This could be optimized, but loop over all the images and components to create a list of json files.
-func (b *Builder) generateJSONList(componentToFiles map[string]*types.ComponentSBOM, imgList []string) ([]byte, error) {
+func (b *Builder) generateJSONList(componentToFiles map[string]*types.ComponentSBOM, imgList []transform.Image) ([]byte, error) {
 	var jsonList []string
 
-	for _, tag := range imgList {
-		normalized := b.getNormalizedFileName(tag)
+	for _, ref := range imgList {
+		normalized := b.getNormalizedFileName(ref.Reference)
 		jsonList = append(jsonList, normalized)
 	}
 

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -147,7 +147,13 @@ func (p *Packager) Create(baseDir string) error {
 		}
 
 		// Combine all component images into a single entry for efficient layer reuse.
-		combinedImageList = append(combinedImageList, component.Images...)
+		for _, src := range component.Images {
+			ref, err := transform.ParseImageRef(src)
+			if err != nil {
+				return fmt.Errorf("failed to create tag for image %s: %w", src, err)
+			}
+			combinedImageList = append(combinedImageList, ref.Reference)
+		}
 
 		// Remove the temp directory for this component before archiving.
 		err = os.RemoveAll(filepath.Join(p.tmp.Components, component.Name, types.TempFolder))

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -148,11 +148,11 @@ func (p *Packager) Create(baseDir string) error {
 
 		// Combine all component images into a single entry for efficient layer reuse.
 		for _, src := range component.Images {
-			ref, err := transform.ParseImageRef(src)
+			refInfo, err := transform.ParseImageRef(src)
 			if err != nil {
 				return fmt.Errorf("failed to create ref for image %s: %w", src, err)
 			}
-			combinedImageList = append(combinedImageList, ref)
+			combinedImageList = append(combinedImageList, refInfo)
 		}
 
 		// Remove the temp directory for this component before archiving.
@@ -162,16 +162,16 @@ func (p *Packager) Create(baseDir string) error {
 		}
 	}
 
-	imgList := helpers.Unique(combinedImageList)
+	imageList := helpers.Unique(combinedImageList)
 
 	// Images are handled separately from other component assets.
-	if len(imgList) > 0 {
+	if len(imageList) > 0 {
 		message.HeaderInfof("📦 PACKAGE IMAGES")
 
 		doPull := func() error {
-			imgConfig := images.ImgConfig{
+			imgConfig := images.ImageConfig{
 				ImagesPath:        p.tmp.Images,
-				ImgList:           imgList,
+				ImageList:         imageList,
 				Insecure:          config.CommonOptions.Insecure,
 				Architectures:     []string{p.cfg.Pkg.Metadata.Architecture, p.cfg.Pkg.Build.Architecture},
 				RegistryOverrides: p.cfg.CreateOpts.RegistryOverrides,
@@ -189,7 +189,7 @@ func (p *Packager) Create(baseDir string) error {
 	if p.cfg.CreateOpts.SkipSBOM {
 		message.Debug("Skipping image SBOM processing per --skip-sbom flag")
 	} else {
-		if err := sbom.Catalog(componentSBOMs, imgList, p.tmp); err != nil {
+		if err := sbom.Catalog(componentSBOMs, imageList, p.tmp); err != nil {
 			return fmt.Errorf("unable to create an SBOM catalog for the package: %w", err)
 		}
 	}

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -116,7 +116,7 @@ func (p *Packager) Create(baseDir string) error {
 		return fmt.Errorf("package creation canceled")
 	}
 
-	var combinedImageList []string
+	var combinedImageList []transform.Image
 	componentSBOMs := map[string]*types.ComponentSBOM{}
 	for idx, component := range p.cfg.Pkg.Components {
 		onCreate := component.Actions.OnCreate
@@ -152,7 +152,7 @@ func (p *Packager) Create(baseDir string) error {
 			if err != nil {
 				return fmt.Errorf("failed to create ref for image %s: %w", src, err)
 			}
-			combinedImageList = append(combinedImageList, ref.Reference)
+			combinedImageList = append(combinedImageList, ref)
 		}
 
 		// Remove the temp directory for this component before archiving.

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -150,7 +150,7 @@ func (p *Packager) Create(baseDir string) error {
 		for _, src := range component.Images {
 			ref, err := transform.ParseImageRef(src)
 			if err != nil {
-				return fmt.Errorf("failed to create tag for image %s: %w", src, err)
+				return fmt.Errorf("failed to create ref for image %s: %w", src, err)
 			}
 			combinedImageList = append(combinedImageList, ref.Reference)
 		}
@@ -728,7 +728,7 @@ func (p *Packager) removeCopiesFromDifferentialPackage() error {
 		newRepoList := []string{}
 		// Generate a list of all unique images for this component
 		for _, img := range component.Images {
-			// If a image doesn't have a tag (or is a commonly reused tag), we will include this image in the differential package
+			// If a image doesn't have a ref (or is a commonly reused ref), we will include this image in the differential package
 			imgRef, err := transform.ParseImageRef(img)
 			if err != nil {
 				return fmt.Errorf("unable to parse image ref %s: %s", img, err.Error())

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -444,9 +444,9 @@ func (p *Packager) pushImagesToRegistry(componentImages []string, noImgChecksum 
 
 	imgList := helpers.Unique(combinedImageList)
 
-	imgConfig := images.ImgConfig{
+	imgConfig := images.ImageConfig{
 		ImagesPath:    p.tmp.Images,
-		ImgList:       imgList,
+		ImageList:     imgList,
 		NoChecksum:    noImgChecksum,
 		RegInfo:       p.cfg.State.RegistryInfo,
 		Insecure:      config.CommonOptions.Insecure,

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -442,11 +442,11 @@ func (p *Packager) pushImagesToRegistry(componentImages []string, noImgChecksum 
 		combinedImageList = append(combinedImageList, ref)
 	}
 
-	imgList := helpers.Unique(combinedImageList)
+	imageList := helpers.Unique(combinedImageList)
 
 	imgConfig := images.ImageConfig{
 		ImagesPath:    p.tmp.Images,
-		ImageList:     imgList,
+		ImageList:     imageList,
 		NoChecksum:    noImgChecksum,
 		RegInfo:       p.cfg.State.RegistryInfo,
 		Insecure:      config.CommonOptions.Insecure,

--- a/src/pkg/utils/image.go
+++ b/src/pkg/utils/image.go
@@ -43,8 +43,8 @@ func LoadOCIImage(imgPath string, imgRef transform.Image) (v1.Image, error) {
 	return nil, fmt.Errorf("unable to find image (%s) at the path (%s)", imgRef.Reference, imgPath)
 }
 
-// AddImageNameAnnotation adds an annotation to the index.json file so that the deploying code can figure out what the image ref <-> digest shasum will be.
-func AddImageNameAnnotation(ociPath string, refToDigest map[string]string) error {
+// AddImageNameAnnotation adds an annotation to the index.json file so that the deploying code can figure out what the image reference <-> digest shasum will be.
+func AddImageNameAnnotation(ociPath string, referenceToDigest map[string]string) error {
 	indexPath := filepath.Join(ociPath, "index.json")
 
 	// Read the file contents and turn it into a usable struct that we can manipulate
@@ -65,16 +65,16 @@ func AddImageNameAnnotation(ociPath string, refToDigest map[string]string) error
 
 		var baseImageName string
 
-		for ref, digest := range refToDigest {
+		for reference, digest := range referenceToDigest {
 			if digest == manifest.Digest.String() {
-				baseImageName = ref
+				baseImageName = reference
 			}
 		}
 
 		if baseImageName != "" {
 			manifest.Annotations[ocispec.AnnotationBaseImageName] = baseImageName
 			index.Manifests[idx] = manifest
-			delete(refToDigest, baseImageName)
+			delete(referenceToDigest, baseImageName)
 		}
 	}
 

--- a/src/pkg/utils/image.go
+++ b/src/pkg/utils/image.go
@@ -17,7 +17,7 @@ import (
 )
 
 // LoadOCIImage returns a v1.Image with the image ref specified from a location provided, or an error if the image cannot be found.
-func LoadOCIImage(imgPath string, imgRef transform.Image) (v1.Image, error) {
+func LoadOCIImage(imgPath string, refInfo transform.Image) (v1.Image, error) {
 	// Use the manifest within the index.json to load the specific image we want
 	layoutPath := layout.Path(imgPath)
 	imgIdx, err := layoutPath.ImageIndex()
@@ -31,16 +31,16 @@ func LoadOCIImage(imgPath string, imgRef transform.Image) (v1.Image, error) {
 
 	// Search through all the manifests within this package until we find the annotation that matches our ref
 	for _, manifest := range idxManifest.Manifests {
-		if manifest.Annotations[ocispec.AnnotationBaseImageName] == imgRef.Reference ||
+		if manifest.Annotations[ocispec.AnnotationBaseImageName] == refInfo.Reference ||
 			// A backwards compatibility shim for older Zarf versions that would leave docker.io off of image annotations
-			(manifest.Annotations[ocispec.AnnotationBaseImageName] == imgRef.Path+imgRef.TagOrDigest && imgRef.Host == "docker.io") {
+			(manifest.Annotations[ocispec.AnnotationBaseImageName] == refInfo.Path+refInfo.TagOrDigest && refInfo.Host == "docker.io") {
 
 			// This is the image we are looking for, load it and then return
 			return layoutPath.Image(manifest.Digest)
 		}
 	}
 
-	return nil, fmt.Errorf("unable to find image (%s) at the path (%s)", imgRef.Reference, imgPath)
+	return nil, fmt.Errorf("unable to find image (%s) at the path (%s)", refInfo.Reference, imgPath)
 }
 
 // AddImageNameAnnotation adds an annotation to the index.json file so that the deploying code can figure out what the image reference <-> digest shasum will be.

--- a/src/test/e2e/06_create_sbom_test.go
+++ b/src/test/e2e/06_create_sbom_test.go
@@ -25,9 +25,9 @@ func TestCreateSBOM(t *testing.T) {
 	require.NoError(t, err, stdOut, stdErr)
 	require.Contains(t, stdErr, "Creating SBOMs for 1 images and 0 components with files.")
 	// Test that the game package generates the SBOMs we expect (images only)
-	require.FileExists(t, filepath.Join(sbomPath, "dos-games", "sbom-viewer-defenseunicorns_zarf-game_multi-tile-dark.html"))
+	require.FileExists(t, filepath.Join(sbomPath, "dos-games", "sbom-viewer-docker.io_defenseunicorns_zarf-game_multi-tile-dark.html"))
 	require.FileExists(t, filepath.Join(sbomPath, "dos-games", "compare.html"))
-	require.FileExists(t, filepath.Join(sbomPath, "dos-games", "defenseunicorns_zarf-game_multi-tile-dark.json"))
+	require.FileExists(t, filepath.Join(sbomPath, "dos-games", "docker.io_defenseunicorns_zarf-game_multi-tile-dark.json"))
 
 	// Clean the SBOM path so it is force to be recreated
 	e2e.CleanFiles(sbomPath)
@@ -35,11 +35,11 @@ func TestCreateSBOM(t *testing.T) {
 	stdOut, stdErr, err = e2e.Zarf("package", "inspect", pkgName, "--sbom-out", sbomPath)
 	require.NoError(t, err, stdOut, stdErr)
 	// Test that the game package generates the SBOMs we expect (images only)
-	_, err = os.ReadFile(filepath.Join(sbomPath, "dos-games", "sbom-viewer-defenseunicorns_zarf-game_multi-tile-dark.html"))
+	_, err = os.ReadFile(filepath.Join(sbomPath, "dos-games", "sbom-viewer-docker.io_defenseunicorns_zarf-game_multi-tile-dark.html"))
 	require.NoError(t, err)
 	_, err = os.ReadFile(filepath.Join(sbomPath, "dos-games", "compare.html"))
 	require.NoError(t, err)
-	_, err = os.ReadFile(filepath.Join(sbomPath, "dos-games", "defenseunicorns_zarf-game_multi-tile-dark.json"))
+	_, err = os.ReadFile(filepath.Join(sbomPath, "dos-games", "docker.io_defenseunicorns_zarf-game_multi-tile-dark.json"))
 	require.NoError(t, err)
 
 	// Pull the current zarf binary version to find the corresponding init package
@@ -51,12 +51,12 @@ func TestCreateSBOM(t *testing.T) {
 	stdOut, stdErr, err = e2e.Zarf("package", "inspect", initName, "--sbom-out", sbomPath)
 	require.NoError(t, err, stdOut, stdErr)
 	// Test that we preserve the filepath
-	_, err = os.ReadFile(filepath.Join(sbomPath, "dos-games", "sbom-viewer-defenseunicorns_zarf-game_multi-tile-dark.html"))
+	_, err = os.ReadFile(filepath.Join(sbomPath, "dos-games", "sbom-viewer-docker.io_defenseunicorns_zarf-game_multi-tile-dark.html"))
 	require.NoError(t, err)
 	// Test that the init package generates the SBOMs we expect (images + component files)
-	_, err = os.ReadFile(filepath.Join(sbomPath, "init", "sbom-viewer-gitea_gitea_1.19.3-rootless.html"))
+	_, err = os.ReadFile(filepath.Join(sbomPath, "init", "sbom-viewer-docker.io_gitea_gitea_1.19.3-rootless.html"))
 	require.NoError(t, err)
-	_, err = os.ReadFile(filepath.Join(sbomPath, "init", "gitea_gitea_1.19.3-rootless.json"))
+	_, err = os.ReadFile(filepath.Join(sbomPath, "init", "docker.io_gitea_gitea_1.19.3-rootless.json"))
 	require.NoError(t, err)
 	_, err = os.ReadFile(filepath.Join(sbomPath, "init", "sbom-viewer-zarf-component-k3s.html"))
 	require.NoError(t, err)

--- a/src/test/e2e/26_simple_packages_test.go
+++ b/src/test/e2e/26_simple_packages_test.go
@@ -46,7 +46,7 @@ func TestDosGames(t *testing.T) {
 	require.NoError(t, err, stdOut, stdErr)
 
 	// Deploy the game image test package
-	stdOut, stdErr, err = e2e.Zarf("package", "create", testDeploy, "--confirm")
+	stdOut, stdErr, err = e2e.Zarf("package", "deploy", testDeploy, "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 }
 

--- a/src/test/e2e/26_simple_packages_test.go
+++ b/src/test/e2e/26_simple_packages_test.go
@@ -39,7 +39,7 @@ func TestDosGames(t *testing.T) {
 	require.NoError(t, err, stdOut, stdErr)
 
 	testCreate := filepath.Join("src", "test", "packages", "26-image-dos-games")
-	testDeploy := filepath.Join("build", fmt.Sprintf("zarf-package-dos-games-images-%s-1.0.0.tar.zst", e2e.Arch))
+	testDeploy := filepath.Join("build", fmt.Sprintf("zarf-package-dos-games-images-%s.tar.zst", e2e.Arch))
 
 	// Create the game image test package
 	stdOut, stdErr, err = e2e.Zarf("package", "create", testCreate, "-o", "build", "--confirm")

--- a/src/test/e2e/26_simple_packages_test.go
+++ b/src/test/e2e/26_simple_packages_test.go
@@ -7,6 +7,7 @@ package test
 import (
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"testing"
 
 	"github.com/defenseunicorns/zarf/src/internal/cluster"
@@ -17,7 +18,7 @@ func TestDosGames(t *testing.T) {
 	t.Log("E2E: Dos games")
 	e2e.SetupWithCluster(t)
 
-	path := fmt.Sprintf("build/zarf-package-dos-games-%s-1.0.0.tar.zst", e2e.Arch)
+	path := filepath.Join("build", fmt.Sprintf("zarf-package-dos-games-%s-1.0.0.tar.zst", e2e.Arch))
 
 	// Deploy the game
 	stdOut, stdErr, err := e2e.Zarf("package", "deploy", path, "--confirm")
@@ -36,13 +37,24 @@ func TestDosGames(t *testing.T) {
 
 	stdOut, stdErr, err = e2e.Zarf("package", "remove", "dos-games", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
+
+	testCreate := filepath.Join("src", "test", "packages", "26-image-dos-games")
+	testDeploy := filepath.Join("build", fmt.Sprintf("zarf-package-dos-games-images-%s-1.0.0.tar.zst", e2e.Arch))
+
+	// Create the game image test package
+	stdOut, stdErr, err = e2e.Zarf("package", "create", testCreate, "-o", "build", "--confirm")
+	require.NoError(t, err, stdOut, stdErr)
+
+	// Deploy the game image test package
+	stdOut, stdErr, err = e2e.Zarf("package", "create", testDeploy, "--confirm")
+	require.NoError(t, err, stdOut, stdErr)
 }
 
 func TestManifests(t *testing.T) {
 	t.Log("E2E: Local, Remote, and Kustomize Manifests")
 	e2e.SetupWithCluster(t)
 
-	path := fmt.Sprintf("build/zarf-package-manifests-%s-0.0.1.tar.zst", e2e.Arch)
+	path := filepath.Join("build", fmt.Sprintf("zarf-package-manifests-%s-0.0.1.tar.zst", e2e.Arch))
 
 	// Deploy the package
 	stdOut, stdErr, err := e2e.Zarf("package", "deploy", path, "--confirm")

--- a/src/test/packages/26-image-dos-games/zarf.yaml
+++ b/src/test/packages/26-image-dos-games/zarf.yaml
@@ -1,0 +1,12 @@
+kind: ZarfPackageConfig
+metadata:
+  name: dos-games-images
+  description: Simple example to test the various ways you can specify image references.
+
+components:
+  - name: baseline
+    required: true
+    images:
+      - defenseunicorns/zarf-game:multi-tile-dark
+      - defenseunicorns/zarf-game:multi-tile-dark@sha256:f78e442f0f3eb3e9459b5ae6b1a8fda62f8dfe818112e7d130a4e8ae72b3cbff
+      - defenseunicorns/zarf-game@sha256:f78e442f0f3eb3e9459b5ae6b1a8fda62f8dfe818112e7d130a4e8ae72b3cbff


### PR DESCRIPTION
## Description

This allows shasum references to work with Zarf by swapping the crane tag parsing code with the docker library.

## Related Issue

Fixes #1221 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
