### PR TITLE
update the bundle adr to express its migration to uds-cli

### DIFF
--- a/adr/0017-zarf-bundle.md
+++ b/adr/0017-zarf-bundle.md
@@ -4,7 +4,7 @@ Date: 2023-06-13
 
 ## Status
 
-Pending
+[Migrated](https://github.com/defenseunicorns/uds-cli)
 
 ## Context
 
@@ -75,6 +75,8 @@ Cons:
 > :warning: **NOTE**: The package manager could also be made to be OCI-only but would come with the same OCI pros/cons.
 
 ## Decision
+
+> :warning: **NOTE**: This functionality was migrated to [uds-cli](https://github.com/defenseunicorns/uds-cli) - this ADR is kept here for historical purposes.
 
 The current proposition (subject to change before acceptance) is **Zarf Bundles**, which a following PR will focus on and create a POC of.
 


### PR DESCRIPTION
## Description

This updates the bundle ADR to express that it was moved to UDS CLI instead.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
