### PR TITLE
Officially deprecate component `group` and add messaging to CLI + docs

### DIFF
--- a/docs/3-create-a-zarf-package/4-zarf-schema.md
+++ b/docs/3-create-a-zarf-package/4-zarf-schema.md
@@ -760,22 +760,6 @@ Must be one of:
 </blockquote>
 </details>
 
-<details>
-<summary>
-<strong> <a name="components_items_group"></a>group</strong>
-</summary>
-&nbsp;
-<blockquote>
-
-**Description:** Create a user selector field based on all components in the same group
-
-|          |          |
-| -------- | -------- |
-| **Type** | `string` |
-
-</blockquote>
-</details>
-
 <details open>
 <summary>
 <strong> <a name="components_items_import"></a>import</strong>

--- a/src/pkg/packager/deprecated/common.go
+++ b/src/pkg/packager/deprecated/common.go
@@ -5,6 +5,7 @@
 package deprecated
 
 import (
+	"fmt"
 	"strings"
 
 	"slices"
@@ -65,6 +66,11 @@ func MigrateComponent(build types.ZarfBuildData, component types.ZarfComponent) 
 		if migratedComponent, warning = migrateSetVariableToSetVariables(migratedComponent); warning != "" {
 			warnings = append(warnings, warning)
 		}
+	}
+
+	// Show a warning if the component contains a group as that has been deprecated and will be removed.
+	if component.Group != "" {
+		warnings = append(warnings, fmt.Sprintf("Component %s is using group which has been deprecated and will be removed in v1.0.0.  Please migrate to another solution.", component.Name))
 	}
 
 	// Future migrations here.

--- a/src/test/e2e/01_component_choice_test.go
+++ b/src/test/e2e/01_component_choice_test.go
@@ -28,6 +28,7 @@ func TestComponentChoice(t *testing.T) {
 	// We currently don't have a pattern to actually test the interactive prompt, so just testing automation for now
 	stdOut, stdErr, err := e2e.Zarf("package", "deploy", path, "--components=first-choice,second-choice", "--confirm")
 	require.Error(t, err, stdOut, stdErr)
+	require.Contains(t, stdErr, "Component first-choice is using group which has been deprecated", "output should show a warning for group being deprecated.")
 
 	// Deploy a single choice and expect success
 	stdOut, stdErr, err = e2e.Zarf("package", "deploy", path, "--components=first-choice", "--confirm")

--- a/src/types/component.go
+++ b/src/types/component.go
@@ -29,7 +29,7 @@ type ZarfComponent struct {
 
 	// Key to match other components to produce a user selector field, used to create a BOOLEAN XOR for a set of components
 	// Note: ignores default and required flags
-	Group string `json:"group,omitempty" jsonschema:"description=Create a user selector field based on all components in the same group"`
+	Group string `json:"group,omitempty" jsonschema:"description=[Deprecated] Create a user selector field based on all components in the same group. This will be removed in Zarf v1.0.0.,deprecated=true"`
 
 	// (Deprecated) Path to cosign public key for signed online resources
 	DeprecatedCosignKeyPath string `json:"cosignKeyPath,omitempty" jsonschema:"description=[Deprecated] Specify a path to a public key to validate signed online resources. This will be removed in Zarf v1.0.0.,deprecated=true"`

--- a/src/ui/lib/api-types.ts
+++ b/src/ui/lib/api-types.ts
@@ -310,7 +310,8 @@ export interface ZarfComponent {
      */
     files?: ZarfFile[];
     /**
-     * Create a user selector field based on all components in the same group
+     * [Deprecated] Create a user selector field based on all components in the same group. This
+     * will be removed in Zarf v1.0.0.
      */
     group?: string;
     /**

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -249,7 +249,7 @@
         },
         "group": {
           "type": "string",
-          "description": "Create a user selector field based on all components in the same group"
+          "description": "[Deprecated] Create a user selector field based on all components in the same group. This will be removed in Zarf v1.0.0."
         },
         "cosignKeyPath": {
           "type": "string",


### PR DESCRIPTION
## Description

Officially deprecate component `group` and add messaging to CLI + docs

## Related Issue

Fixes #1792 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
