### PR TITLE
Return an error after processing all charts if any of them failed during image discovery

### DIFF
--- a/src/cmd/prepare.go
+++ b/src/cmd/prepare.go
@@ -113,7 +113,7 @@ var prepareFindImages = &cobra.Command{
 
 		// Find all the images the package might need
 		if _, err := pkgClient.FindImages(baseDir, repoHelmChartPath, kubeVersionOverride); err != nil {
-			message.Fatalf(err, lang.CmdPrepareFindImagesErr, baseDir)
+			message.Fatalf(err, lang.CmdPrepareFindImagesErr, baseDir, err.Error())
 		}
 	},
 }

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -321,7 +321,7 @@ const (
 	CmdPrepareFindImagesShort = "Evaluates components in a zarf file to identify images specified in their helm charts and manifests"
 	CmdPrepareFindImagesLong  = "Evaluates components in a zarf file to identify images specified in their helm charts and manifests.\n\n" +
 		"Components that have repos that host helm charts can be processed by providing the --repo-chart-path."
-	CmdPrepareFindImagesErr = "Unable to find images for the package definition %s"
+	CmdPrepareFindImagesErr = "Unable to find images for the package definition %s: %s"
 
 	CmdPrepareGenerateConfigShort = "Generates a config file for Zarf"
 	CmdPrepareGenerateConfigLong  = "Generates a Zarf config file for controlling how the Zarf CLI operates. Optionally accepts a filename to write the config to.\n\n" +

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -84,11 +84,13 @@ func TestUseCLI(t *testing.T) {
 	t.Run("zarf prepare find-images --kube-version", func(t *testing.T) {
 		t.Parallel()
 		// Test `zarf prepare find-images` on a chart that has a `kubeVersion` declaration greater than the default (v1.20.0)
-		_, stdErr, _ := e2e.Zarf("prepare", "find-images", "src/test/packages/00-kube-version-override")
+		stdOut, stdErr, err := e2e.Zarf("prepare", "find-images", "src/test/packages/00-kube-version-override")
+		require.Error(t, err, stdOut, stdErr)
 		require.Contains(t, stdErr, "Problem rendering the helm template for https://charts.jetstack.io/", "The kubeVersion declaration should prevent this from templating")
+		require.Contains(t, stdErr, "following charts had errors: [https://charts.jetstack.io/]", "Zarf should print an ending error message")
 
 		// Test `zarf prepare find-images` with `--kube-version` specified and greater than the declared minimum (v1.21.0)
-		stdOut, stdErr, err := e2e.Zarf("prepare", "find-images", "--kube-version=v1.22.0", "src/test/packages/00-kube-version-override")
+		stdOut, stdErr, err = e2e.Zarf("prepare", "find-images", "--kube-version=v1.22.0", "src/test/packages/00-kube-version-override")
 		require.NoError(t, err, stdOut, stdErr)
 		require.Contains(t, stdOut, "quay.io/jetstack/cert-manager-controller:v1.11.1", "The chart image should be found by Zarf")
 	})


### PR DESCRIPTION
## Description

This changes the find image behavior to return an error if any charts failed to template during `zarf prepare find-images`

## Related Issue

Fixes #1999 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
