### PR TITLE
Refine the documentation for `manifests`

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -66,13 +66,16 @@ jobs:
       - name: Setup K3d
         uses: ./.github/actions/k3d
 
+      - name: Make Zarf executable
+        run: |
+          chmod +x build/zarf
+
       # Before we run the regular tests we need to aggressively cleanup files to reduce disk pressure
       - name: Cleanup files
         uses: ./.github/actions/cleanup-files
 
       - name: Run tests
         run: |
-          chmod +x build/zarf
           make test-e2e ARCH=amd64
 
       - name: Save logs
@@ -96,6 +99,10 @@ jobs:
       - name: Setup golang
         uses: ./.github/actions/golang
 
+      - name: Make Zarf executable
+        run: |
+          chmod +x build/zarf
+
       # Before we run the regular tests we need to aggressively cleanup files to reduce disk pressure
       - name: Cleanup files
         uses: ./.github/actions/cleanup-files
@@ -105,7 +112,6 @@ jobs:
         #       in a previous step. This test run will use Zarf to create a K3s cluster, and a brand new cluster will be
         #       used for each test
         run: |
-          chmod +x build/zarf
           sudo env "PATH=$PATH" CI=true APPLIANCE_MODE=true make test-e2e ARCH=amd64
 
       - name: Save logs
@@ -134,13 +140,16 @@ jobs:
           kind delete cluster && kind create cluster
           kubectl scale deploy -n kube-system coredns --replicas=1
 
+      - name: Make Zarf executable
+        run: |
+          chmod +x build/zarf
+
       # Before we run the regular tests we need to aggressively cleanup files to reduce disk pressure
       - name: Cleanup files
         uses: ./.github/actions/cleanup-files
 
       - name: Run tests
         run: |
-          chmod +x build/zarf
           make test-e2e ARCH=amd64
 
       - name: Save logs
@@ -167,13 +176,16 @@ jobs:
       - name: Setup Minikube
         run: minikube start --driver=docker
 
+      - name: Make Zarf executable
+        run: |
+          chmod +x build/zarf
+
       # Before we run the regular tests we need to aggressively cleanup files to reduce disk pressure
       - name: Cleanup files
         uses: ./.github/actions/cleanup-files
 
       - name: Run tests
         run: |
-          chmod +x build/zarf
           make test-e2e ARCH=amd64
 
       - name: Save logs

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -66,6 +66,10 @@ jobs:
       - name: Setup K3d
         uses: ./.github/actions/k3d
 
+      # Before we run the regular tests we need to aggressively cleanup files to reduce disk pressure
+      - name: Cleanup files
+        uses: ./.github/actions/cleanup-files
+
       - name: Run tests
         run: |
           chmod +x build/zarf
@@ -91,6 +95,10 @@ jobs:
 
       - name: Setup golang
         uses: ./.github/actions/golang
+
+      # Before we run the regular tests we need to aggressively cleanup files to reduce disk pressure
+      - name: Cleanup files
+        uses: ./.github/actions/cleanup-files
 
       - name: Run tests
         # NOTE: "PATH=$PATH" preserves the default user $PATH. This is needed to maintain the version of go installed
@@ -126,6 +134,10 @@ jobs:
           kind delete cluster && kind create cluster
           kubectl scale deploy -n kube-system coredns --replicas=1
 
+      # Before we run the regular tests we need to aggressively cleanup files to reduce disk pressure
+      - name: Cleanup files
+        uses: ./.github/actions/cleanup-files
+
       - name: Run tests
         run: |
           chmod +x build/zarf
@@ -154,6 +166,10 @@ jobs:
 
       - name: Setup Minikube
         run: minikube start --driver=docker
+
+      # Before we run the regular tests we need to aggressively cleanup files to reduce disk pressure
+      - name: Cleanup files
+        uses: ./.github/actions/cleanup-files
 
       - name: Run tests
         run: |

--- a/docs-website/src/components/SchemaItemProperties.js
+++ b/docs-website/src/components/SchemaItemProperties.js
@@ -38,13 +38,13 @@ const SchemaItemProperties = ({ item, include, invert }) => {
             Object.keys(itemSchema.properties)
               .filter(includesElement)
               .sort()
-              .sort((key) => (itemSchema.required.includes(key) ? -1 : 1))
+              .sort((key) => (itemSchema.required && itemSchema.required.includes(key) ? -1 : 1))
               .map((key) => {
                 return (
                   <tr key={key}>
                     <td>
                       <code>{key}</code>
-                      {itemSchema.required.includes(key) && <em>*</em>}
+                      {itemSchema.required && itemSchema.required.includes(key) && <em>*</em>}
                     </td>
                     <td>
                       <em>{itemSchema.properties[key].type ?? "object"}</em>

--- a/docs/3-create-a-zarf-package/2-zarf-components.md
+++ b/docs/3-create-a-zarf-package/2-zarf-components.md
@@ -37,7 +37,7 @@ Component actions are explored in the [component actions documentation](7-compon
 
 <Properties item="ZarfComponent" include={["files"]} />
 
-Can be:
+Files can be:
 
 - Relative paths to either a file or directory (from the `zarf.yaml` file)
 - A remote URL (http/https)
@@ -58,11 +58,11 @@ Can be:
 
 <Properties item="ZarfComponent" include={["charts"]} />
 
-Can be when using the `localPath` key:
+Charts using the `localPath` key can be:
 
 - Relative paths to either a file or directory (from the `zarf.yaml` file)
 
-Can be when using the `url` key:
+Charts using the `url` key can be:
 
 - A remote URL (http/https) to a Git repository
 - A remote URL (oci://) to an OCI registry
@@ -85,12 +85,12 @@ Can be when using the `url` key:
 
 <Properties item="ZarfComponent" include={["manifests"]} />
 
-Can be when using the `files` key:
+Manifests under the `files` key can be:
 
 - Relative paths to a Kubernetes manifest file (from the `zarf.yaml` file)
 - Verified using the `url@shasum` syntax for data integrity (optional and only for remote URLs)
 
-Can be when using the `kustomizations` key:
+Manifests under the `kustomizations` key can be:
 
 - Any valid Kustomize reference both local and [remote](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md) (ie. anything you could do a `kustomize build` on)
 
@@ -104,6 +104,12 @@ Can be when using the `kustomizations` key:
 <ExampleYAML src={require('../../examples/manifests/zarf.yaml')} component="nginx-remote" />
 </TabItem>
 <TabItem value="Kustomizations">
+
+:::note
+
+In order to maintain consistency throughout the deployment lifecycle, Zarf dynamically generates a Helm Chart from the named manifest entries that you specify.  This means that any given set of files under a manifest entry will be applied according to Helm Chart template and manifest install ordering.
+
+:::
 
 :::info
 

--- a/docs/3-create-a-zarf-package/2-zarf-components.md
+++ b/docs/3-create-a-zarf-package/2-zarf-components.md
@@ -29,13 +29,13 @@ There are certain fields that will be common across all component definitions. T
 
 ### Actions
 
-<Properties item="ZarfComponent" include={["actions"]} />
+<Properties item="ZarfComponentActions" />
 
-Component actions are explored in the [component actions documentation](7-component-actions.md).
+Actions allow for custom functionality to be run at different points in the Zarf lifecycle.  They are explored more in the [component actions documentation](7-component-actions.md).
 
 ### Files
 
-<Properties item="ZarfComponent" include={["files"]} />
+<Properties item="ZarfFile" />
 
 Files can be:
 
@@ -56,7 +56,7 @@ Files can be:
 
 ### Helm Charts
 
-<Properties item="ZarfComponent" include={["charts"]} />
+<Properties item="ZarfChart" />
 
 Charts using the `localPath` key can be:
 
@@ -83,7 +83,7 @@ Charts using the `url` key can be:
 
 ### Kubernetes Manifests
 
-<Properties item="ZarfComponent" include={["manifests"]} />
+<Properties item="ZarfManifest" />
 
 Manifests under the `files` key can be:
 
@@ -93,6 +93,12 @@ Manifests under the `files` key can be:
 Manifests under the `kustomizations` key can be:
 
 - Any valid Kustomize reference both local and [remote](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md) (ie. anything you could do a `kustomize build` on)
+
+:::note
+
+In order to maintain consistency throughout the deployment lifecycle, Zarf dynamically generates a Helm Chart from the named manifest entries that you specify.  This means that any given set of files under a manifest entry will be applied according to [Helm Chart template and manifest install ordering](https://github.com/helm/helm/blob/main/pkg/releaseutil/manifest_sorter.go#L78).
+
+:::
 
 #### Manifest Examples
 
@@ -104,12 +110,6 @@ Manifests under the `kustomizations` key can be:
 <ExampleYAML src={require('../../examples/manifests/zarf.yaml')} component="nginx-remote" />
 </TabItem>
 <TabItem value="Kustomizations">
-
-:::note
-
-In order to maintain consistency throughout the deployment lifecycle, Zarf dynamically generates a Helm Chart from the named manifest entries that you specify.  This means that any given set of files under a manifest entry will be applied according to [Helm Chart template and manifest install ordering](https://github.com/helm/helm/blob/main/pkg/releaseutil/manifest_sorter.go#L78).
-
-:::
 
 :::info
 
@@ -164,13 +164,13 @@ The [`podinfo-flux`](/examples/podinfo-flux/) example showcases a simple GitOps 
 
 ### Data Injections
 
-<Properties item="ZarfComponent" include={["dataInjections"]} />
+<Properties item="ZarfDataInjection" />
 
 <ExampleYAML src={require('../../examples/kiwix/zarf.yaml')} component="kiwix-serve" />
 
 ### Component Imports
 
-<Properties item="ZarfComponent" include={["import"]} />
+<Properties item="ZarfComponentImport" />
 
 <Tabs queryString="import-examples">
 <TabItem value="Local Path">
@@ -191,7 +191,7 @@ This process will also merge `variables` and `constants` defined in the imported
 
 ### Extensions
 
-<Properties item="ZarfComponent" include={["extensions"]} />
+<Properties item="ZarfComponentExtensions" />
 
 <ExampleYAML src={require('../../examples/big-bang/zarf.yaml')} component="bigbang" />
 

--- a/docs/3-create-a-zarf-package/2-zarf-components.md
+++ b/docs/3-create-a-zarf-package/2-zarf-components.md
@@ -96,7 +96,7 @@ Manifests under the `kustomizations` key can be:
 
 :::note
 
-In order to maintain consistency throughout the deployment lifecycle, Zarf dynamically generates a Helm Chart from the named manifest entries that you specify.  This means that any given set of files under a manifest entry will be applied according to [Helm Chart template and manifest install ordering](https://github.com/helm/helm/blob/main/pkg/releaseutil/manifest_sorter.go#L78).
+Zarf dynamically generates a Helm Chart from the named manifest entries that you specify.  This means that any given set of files under a manifest entry will be applied according to [Helm Chart template and manifest install ordering](https://github.com/helm/helm/blob/main/pkg/releaseutil/manifest_sorter.go#L78) and not necessarily in the order that files are declared.  If ordering is important, consider moving each file into its own manifest entry in the `manifests` array.
 
 :::
 

--- a/docs/3-create-a-zarf-package/2-zarf-components.md
+++ b/docs/3-create-a-zarf-package/2-zarf-components.md
@@ -107,7 +107,7 @@ Manifests under the `kustomizations` key can be:
 
 :::note
 
-In order to maintain consistency throughout the deployment lifecycle, Zarf dynamically generates a Helm Chart from the named manifest entries that you specify.  This means that any given set of files under a manifest entry will be applied according to Helm Chart template and manifest install ordering.
+In order to maintain consistency throughout the deployment lifecycle, Zarf dynamically generates a Helm Chart from the named manifest entries that you specify.  This means that any given set of files under a manifest entry will be applied according to [Helm Chart template and manifest install ordering](https://github.com/helm/helm/blob/main/pkg/releaseutil/manifest_sorter.go#L78).
 
 :::
 

--- a/docs/3-create-a-zarf-package/2-zarf-components.md
+++ b/docs/3-create-a-zarf-package/2-zarf-components.md
@@ -29,13 +29,13 @@ There are certain fields that will be common across all component definitions. T
 
 ### Actions
 
-<Properties item="ZarfComponentActions" />
+<Properties item="ZarfComponent" include={["actions"]} />
 
-Actions allow for custom functionality to be run at different points in the Zarf lifecycle.  They are explored more in the [component actions documentation](7-component-actions.md).
+Component actions are explored more in the [component actions documentation](7-component-actions.md).
 
 ### Files
 
-<Properties item="ZarfFile" />
+<Properties item="ZarfComponent" include={["files"]} />
 
 Files can be:
 
@@ -56,7 +56,7 @@ Files can be:
 
 ### Helm Charts
 
-<Properties item="ZarfChart" />
+<Properties item="ZarfComponent" include={["charts"]} />
 
 Charts using the `localPath` key can be:
 
@@ -83,7 +83,7 @@ Charts using the `url` key can be:
 
 ### Kubernetes Manifests
 
-<Properties item="ZarfManifest" />
+<Properties item="ZarfComponent" include={["manifests"]} />
 
 Manifests under the `files` key can be:
 
@@ -164,13 +164,13 @@ The [`podinfo-flux`](/examples/podinfo-flux/) example showcases a simple GitOps 
 
 ### Data Injections
 
-<Properties item="ZarfDataInjection" />
+<Properties item="ZarfComponent" include={["dataInjections"]} />
 
 <ExampleYAML src={require('../../examples/kiwix/zarf.yaml')} component="kiwix-serve" />
 
 ### Component Imports
 
-<Properties item="ZarfComponentImport" />
+<Properties item="ZarfComponent" include={["import"]} />
 
 <Tabs queryString="import-examples">
 <TabItem value="Local Path">
@@ -191,7 +191,7 @@ This process will also merge `variables` and `constants` defined in the imported
 
 ### Extensions
 
-<Properties item="ZarfComponentExtensions" />
+<Properties item="ZarfComponent" include={["extensions"]} />
 
 <ExampleYAML src={require('../../examples/big-bang/zarf.yaml')} component="bigbang" />
 

--- a/docs/3-create-a-zarf-package/2-zarf-components.md
+++ b/docs/3-create-a-zarf-package/2-zarf-components.md
@@ -31,7 +31,7 @@ There are certain fields that will be common across all component definitions. T
 
 <Properties item="ZarfComponent" include={["actions"]} />
 
-Component actions are explored more in the [component actions documentation](7-component-actions.md).
+Component actions are explored in the [component actions documentation](7-component-actions.md).
 
 ### Files
 

--- a/docs/3-create-a-zarf-package/3-zarf-init-package.md
+++ b/docs/3-create-a-zarf-package/3-zarf-init-package.md
@@ -38,6 +38,12 @@ Given the registry is a core part of any Kubernetes deployment you MUST either s
 
 :::
 
+:::info
+
+The Zarf Registry is initially injected as a series of config maps that bootstraps itself into the cluster and then binds to a NodePort to allow the kubelet to pull images and setup the final registry deployment.  Doing this keeps Zarf cluster agnostic however does require that the kubelet be able to reach out to a cluster NodePort service which may require changes to firewall configurations like allowing UDP traffic between nodes if using something like VXLAN tunneling.
+
+:::
+
 :::tip
 
 You can further customize how the registry behaves by setting variables such as `REGISTRY_PVC_SIZE` with a [config file](../2-the-zarf-cli/index.md#using-a-config-file-to-make-cli-command-flags-declarative) or `--set` on `zarf init`.

--- a/examples/helm-charts/README.md
+++ b/examples/helm-charts/README.md
@@ -2,7 +2,7 @@ import ExampleYAML from "@site/src/components/ExampleYAML";
 
 # Helm Charts
 
-This example shows the many ways you can deploy Helm Charts with Zarf.
+This example shows the many ways you can deploy Helm Charts with Zarf. To learn more about how `charts` work in Zarf, see the [Helm Charts section](../../docs/3-create-a-zarf-package/2-zarf-components.md#helm-charts) of the package components documentation.
 
 ## `zarf.yaml` {#zarf.yaml}
 

--- a/examples/manifests/README.md
+++ b/examples/manifests/README.md
@@ -4,6 +4,8 @@ import ExampleYAML from "@site/src/components/ExampleYAML";
 
 This example shows you how to specify Kubernetes resources in a component's `manifests` list.  These files can either be local or remote and under the hood Zarf will wrap them in an auto-generated helm chart to manage their install, rollback, and uninstall logic.
 
+To learn more about how `manifests` work in Zarf, see the [Kubernetes Manifests section](../../docs/3-create-a-zarf-package/2-zarf-components.md#kubernetes-manifests) of the package components documentation.
+
 ## `zarf.yaml` {#zarf.yaml}
 
 :::info

--- a/src/test/common.go
+++ b/src/test/common.go
@@ -60,7 +60,7 @@ func (e2e *ZarfE2ETest) SetupWithCluster(t *testing.T) {
 
 // Zarf executes a Zarf command.
 func (e2e *ZarfE2ETest) Zarf(args ...string) (string, string, error) {
-	if !slices.Contains(args, "--tmpdir") {
+	if !slices.Contains(args, "--tmpdir") && !slices.Contains(args, "tools") {
 		tmpdir, err := os.MkdirTemp("", "zarf-")
 		if err != nil {
 			return "", "", err

--- a/src/test/common.go
+++ b/src/test/common.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"testing"
 
+	"slices"
+
 	"github.com/defenseunicorns/zarf/src/pkg/utils/exec"
 	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
 	"github.com/stretchr/testify/require"
@@ -58,6 +60,14 @@ func (e2e *ZarfE2ETest) SetupWithCluster(t *testing.T) {
 
 // Zarf executes a Zarf command.
 func (e2e *ZarfE2ETest) Zarf(args ...string) (string, string, error) {
+	if !slices.Contains(args, "--tmpdir") {
+		tmpdir, err := os.MkdirTemp("", "zarf-")
+		if err != nil {
+			return "", "", err
+		}
+		defer os.RemoveAll(tmpdir)
+		args = append(args, "--tmpdir", tmpdir)
+	}
 	return exec.CmdWithContext(context.TODO(), exec.PrintCfg(), e2e.ZarfBinPath, args...)
 }
 

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -129,14 +129,14 @@ func TestUseCLI(t *testing.T) {
 		require.FileExists(t, "binaries/eksctl_Darwin_arm64")
 		require.FileExists(t, "binaries/eksctl_Linux_x86_64")
 
-		e2e.CleanFiles("binaries/eksctl_Darwin_x86_64", "binaries/eksctl_Darwin_arm64", "binaries/eksctl_Linux_x86_64")
+		e2e.CleanFiles("binaries/eksctl_Darwin_x86_64", "binaries/eksctl_Darwin_arm64", "binaries/eksctl_Linux_x86_64", path)
 	})
 
 	t.Run("zarf package create with tmpdir and cache", func(t *testing.T) {
 		t.Parallel()
 		tmpdir := t.TempDir()
 		cacheDir := filepath.Join(t.TempDir(), ".cache-location")
-		stdOut, stdErr, err := e2e.Zarf("package", "create", "examples/dos-games", "--zarf-cache", cacheDir, "--tmpdir", tmpdir, "--log-level=debug", "--confirm")
+		stdOut, stdErr, err := e2e.Zarf("package", "create", "examples/dos-games", "--zarf-cache", cacheDir, "--tmpdir", tmpdir, "--log-level=debug", "-o=build", "--confirm")
 		require.Contains(t, stdErr, tmpdir, "The other tmp path should show as being created")
 		require.NoError(t, err, stdOut, stdErr)
 


### PR DESCRIPTION
## Description

This adds a note about Zarf generating Helm Charts for the manifests you specify along with associated caveats.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
