### PR TITLE
Fix publish not publishing component tarballs

### DIFF
--- a/src/pkg/layout/component.go
+++ b/src/pkg/layout/component.go
@@ -136,7 +136,7 @@ func (c *Components) Unarchive(component types.ZarfComponent) (err error) {
 		return nil
 	}
 
-	message.Debugf("Unarchiving %q", tb)
+	message.Debugf("Unarchiving %q", filepath.Base(tb))
 	if err := archiver.Unarchive(tb, c.Base); err != nil {
 		return err
 	}

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -41,7 +41,7 @@ func (p *Packager) Deploy() (err error) {
 		message.Debug(err)
 	}
 
-	if err = p.source.LoadPackage(p.layout); err != nil {
+	if err = p.source.LoadPackage(p.layout, true); err != nil {
 		return fmt.Errorf("unable to load the package: %w", err)
 	}
 	if err = p.readZarfYAML(p.layout.ZarfYAML); err != nil {

--- a/src/pkg/packager/mirror.go
+++ b/src/pkg/packager/mirror.go
@@ -29,7 +29,7 @@ func (p *Packager) Mirror() (err error) {
 	spinner := message.NewProgressSpinner("Mirroring Zarf package %s", p.cfg.PkgOpts.PackageSource)
 	defer spinner.Stop()
 
-	if err = p.source.LoadPackage(p.layout); err != nil {
+	if err = p.source.LoadPackage(p.layout, true); err != nil {
 		return fmt.Errorf("unable to load the package: %w", err)
 	}
 	if err = p.readZarfYAML(p.layout.ZarfYAML); err != nil {

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -73,19 +73,11 @@ func (p *Packager) Publish() (err error) {
 			return err
 		}
 	} else {
-		if err = p.source.LoadPackage(p.layout); err != nil {
+		if err = p.source.LoadPackage(p.layout, false); err != nil {
 			return fmt.Errorf("unable to load the package: %w", err)
 		}
 		if err = p.readZarfYAML(p.layout.ZarfYAML); err != nil {
 			return err
-		}
-		// re-archive the components, as they are unarchived during the LoadPackage process
-		for _, component := range p.cfg.Pkg.Components {
-			if err = p.layout.Components.Archive(component, true); err != nil {
-				if !layout.IsNotLoaded(err) {
-					return err
-				}
-			}
 		}
 
 		referenceSuffix = p.arch

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -79,6 +79,14 @@ func (p *Packager) Publish() (err error) {
 		if err = p.readZarfYAML(p.layout.ZarfYAML); err != nil {
 			return err
 		}
+		// re-archive the components, as they are unarchived during the LoadPackage process
+		for _, component := range p.cfg.Pkg.Components {
+			if err = p.layout.Components.Archive(component, true); err != nil {
+				if !layout.IsNotLoaded(err) {
+					return err
+				}
+			}
+		}
 
 		referenceSuffix = p.arch
 	}

--- a/src/pkg/packager/sources/cluster.go
+++ b/src/pkg/packager/sources/cluster.go
@@ -41,7 +41,7 @@ type ClusterSource struct {
 // LoadPackage loads a package from a cluster.
 //
 // This is not implemented.
-func (s *ClusterSource) LoadPackage(_ *layout.PackagePaths) error {
+func (s *ClusterSource) LoadPackage(_ *layout.PackagePaths, _ bool) error {
 	return fmt.Errorf("not implemented")
 }
 

--- a/src/pkg/packager/sources/new.go
+++ b/src/pkg/packager/sources/new.go
@@ -28,7 +28,7 @@ import (
 //	`sources.ValidatePackageSignature` and `sources.ValidatePackageIntegrity` can be leveraged for this purpose.
 type PackageSource interface {
 	// LoadPackage loads a package from a source.
-	LoadPackage(dst *layout.PackagePaths) error
+	LoadPackage(dst *layout.PackagePaths, unarchiveAll bool) error
 
 	// LoadPackageMetadata loads a package's metadata from a source.
 	LoadPackageMetadata(dst *layout.PackagePaths, wantSBOM bool, skipValidation bool) error

--- a/src/pkg/packager/sources/split.go
+++ b/src/pkg/packager/sources/split.go
@@ -103,7 +103,7 @@ func (s *SplitTarballSource) Collect(dir string) (string, error) {
 }
 
 // LoadPackage loads a package from a split tarball.
-func (s *SplitTarballSource) LoadPackage(dst *layout.PackagePaths) (err error) {
+func (s *SplitTarballSource) LoadPackage(dst *layout.PackagePaths, unarchiveAll bool) (err error) {
 	tb, err := s.Collect(filepath.Dir(s.PackageSource))
 	if err != nil {
 		return err
@@ -117,7 +117,7 @@ func (s *SplitTarballSource) LoadPackage(dst *layout.PackagePaths) (err error) {
 	ts := &TarballSource{
 		s.ZarfPackageOptions,
 	}
-	return ts.LoadPackage(dst)
+	return ts.LoadPackage(dst, unarchiveAll)
 }
 
 // LoadPackageMetadata loads a package's metadata from a split tarball.

--- a/src/pkg/packager/sources/tarball.go
+++ b/src/pkg/packager/sources/tarball.go
@@ -75,7 +75,6 @@ func (s *TarballSource) LoadPackage(dst *layout.PackagePaths) (err error) {
 			return err
 		}
 
-		message.Debugf("Loaded %q --> %q", path, dstPath)
 		return nil
 	})
 	if err != nil {

--- a/src/pkg/packager/sources/tarball.go
+++ b/src/pkg/packager/sources/tarball.go
@@ -31,7 +31,7 @@ type TarballSource struct {
 }
 
 // LoadPackage loads a package from a tarball.
-func (s *TarballSource) LoadPackage(dst *layout.PackagePaths) (err error) {
+func (s *TarballSource) LoadPackage(dst *layout.PackagePaths, unarchiveAll bool) (err error) {
 	var pkg types.ZarfPackage
 
 	message.Debugf("Loading package from %q", s.PackageSource)
@@ -101,22 +101,24 @@ func (s *TarballSource) LoadPackage(dst *layout.PackagePaths) (err error) {
 		}
 	}
 
-	for _, component := range pkg.Components {
-		if err := dst.Components.Unarchive(component); err != nil {
-			if layout.IsNotLoaded(err) {
-				_, err := dst.Components.Create(component)
-				if err != nil {
+	if unarchiveAll {
+		for _, component := range pkg.Components {
+			if err := dst.Components.Unarchive(component); err != nil {
+				if layout.IsNotLoaded(err) {
+					_, err := dst.Components.Create(component)
+					if err != nil {
+						return err
+					}
+				} else {
 					return err
 				}
-			} else {
-				return err
 			}
 		}
-	}
 
-	if dst.SBOMs.Path != "" {
-		if err := dst.SBOMs.Unarchive(); err != nil {
-			return err
+		if dst.SBOMs.Path != "" {
+			if err := dst.SBOMs.Unarchive(); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/src/pkg/packager/sources/url.go
+++ b/src/pkg/packager/sources/url.go
@@ -49,7 +49,7 @@ func (s *URLSource) Collect(dir string) (string, error) {
 }
 
 // LoadPackage loads a package from an http, https or sget URL.
-func (s *URLSource) LoadPackage(dst *layout.PackagePaths) (err error) {
+func (s *URLSource) LoadPackage(dst *layout.PackagePaths, unarchiveAll bool) (err error) {
 	tmp, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {
 		return err
@@ -69,7 +69,7 @@ func (s *URLSource) LoadPackage(dst *layout.PackagePaths) (err error) {
 		s.ZarfPackageOptions,
 	}
 
-	return ts.LoadPackage(dst)
+	return ts.LoadPackage(dst, unarchiveAll)
 }
 
 // LoadPackageMetadata loads a package's metadata from an http, https or sget URL.

--- a/src/test/e2e/50_oci_package_test.go
+++ b/src/test/e2e/50_oci_package_test.go
@@ -57,6 +57,11 @@ func (suite *RegistryClientTestSuite) Test_0_Publish() {
 	suite.NoError(err, stdOut, stdErr)
 	suite.Contains(stdErr, "Published "+ref)
 
+	// Pull the package via OCI.
+	stdOut, stdErr, err = e2e.Zarf("package", "pull", "oci://"+ref, "--insecure")
+	suite.NoError(err, stdOut, stdErr)
+	suite.Contains(stdErr, fmt.Sprintf("Pulled %q", "oci://"+ref))
+
 	// Publish w/ package missing `metadata.version` field.
 	example = filepath.Join(suite.PackagesDir, fmt.Sprintf("zarf-package-component-actions-%s.tar.zst", e2e.Arch))
 	_, stdErr, err = e2e.Zarf("package", "publish", example, "oci://"+ref, "--insecure")

--- a/src/test/e2e/50_oci_package_test.go
+++ b/src/test/e2e/50_oci_package_test.go
@@ -36,15 +36,15 @@ func (suite *RegistryClientTestSuite) SetupSuite() {
 	suite.Assertions = require.New(suite.T())
 	suite.PackagesDir = "build"
 
-	e2e.SetupDockerRegistry(suite.T(), 555)
-	suite.Reference.Registry = "localhost:555"
+	e2e.SetupDockerRegistry(suite.T(), 556)
+	suite.Reference.Registry = "localhost:556"
 }
 
 func (suite *RegistryClientTestSuite) TearDownSuite() {
 	local := fmt.Sprintf("zarf-package-helm-charts-%s-0.0.1.tar.zst", e2e.Arch)
 	e2e.CleanFiles(local)
 
-	e2e.TeardownRegistry(suite.T(), 555)
+	e2e.TeardownRegistry(suite.T(), 556)
 }
 
 func (suite *RegistryClientTestSuite) Test_0_Publish() {
@@ -58,9 +58,8 @@ func (suite *RegistryClientTestSuite) Test_0_Publish() {
 	suite.Contains(stdErr, "Published "+ref)
 
 	// Pull the package via OCI.
-	stdOut, stdErr, err = e2e.Zarf("package", "pull", "oci://"+ref, "--insecure")
+	stdOut, stdErr, err = e2e.Zarf("package", "pull", "oci://"+ref+"/helm-charts:0.0.1-"+e2e.Arch, "--insecure")
 	suite.NoError(err, stdOut, stdErr)
-	suite.Contains(stdErr, fmt.Sprintf("Pulled %q", "oci://"+ref))
 
 	// Publish w/ package missing `metadata.version` field.
 	example = filepath.Join(suite.PackagesDir, fmt.Sprintf("zarf-package-component-actions-%s.tar.zst", e2e.Arch))
@@ -152,8 +151,8 @@ func (suite *RegistryClientTestSuite) Test_4_Pull_And_Deploy() {
 func (suite *RegistryClientTestSuite) Test_5_Copy() {
 	t := suite.T()
 	ref := suite.Reference.String()
-	dstRegistryPort := 556
-	dstRef := strings.Replace(ref, fmt.Sprint(555), fmt.Sprint(dstRegistryPort), 1)
+	dstRegistryPort := 557
+	dstRef := strings.Replace(ref, fmt.Sprint(556), fmt.Sprint(dstRegistryPort), 1)
 
 	e2e.SetupDockerRegistry(t, dstRegistryPort)
 	defer e2e.TeardownRegistry(t, dstRegistryPort)

--- a/src/test/e2e/50_oci_package_test.go
+++ b/src/test/e2e/50_oci_package_test.go
@@ -36,15 +36,15 @@ func (suite *RegistryClientTestSuite) SetupSuite() {
 	suite.Assertions = require.New(suite.T())
 	suite.PackagesDir = "build"
 
-	e2e.SetupDockerRegistry(suite.T(), 556)
-	suite.Reference.Registry = "localhost:556"
+	e2e.SetupDockerRegistry(suite.T(), 555)
+	suite.Reference.Registry = "localhost:555"
 }
 
 func (suite *RegistryClientTestSuite) TearDownSuite() {
 	local := fmt.Sprintf("zarf-package-helm-charts-%s-0.0.1.tar.zst", e2e.Arch)
 	e2e.CleanFiles(local)
 
-	e2e.TeardownRegistry(suite.T(), 556)
+	e2e.TeardownRegistry(suite.T(), 555)
 }
 
 func (suite *RegistryClientTestSuite) Test_0_Publish() {
@@ -151,8 +151,8 @@ func (suite *RegistryClientTestSuite) Test_4_Pull_And_Deploy() {
 func (suite *RegistryClientTestSuite) Test_5_Copy() {
 	t := suite.T()
 	ref := suite.Reference.String()
-	dstRegistryPort := 557
-	dstRef := strings.Replace(ref, fmt.Sprint(556), fmt.Sprint(dstRegistryPort), 1)
+	dstRegistryPort := 556
+	dstRef := strings.Replace(ref, fmt.Sprint(555), fmt.Sprint(dstRegistryPort), 1)
 
 	e2e.SetupDockerRegistry(t, dstRegistryPort)
 	defer e2e.TeardownRegistry(t, dstRegistryPort)


### PR DESCRIPTION
## Description

Re-archives component tarballs during `package publish` as `LoadPackage` results in uncompressed component directories.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
