### PR TITLE
Move find port function into library code

### DIFF
--- a/src/internal/cluster/tunnel.go
+++ b/src/internal/cluster/tunnel.go
@@ -195,7 +195,7 @@ func (c *Cluster) checkForZarfConnectLabel(name string) (TunnelInfo, error) {
 		zt.remotePort = svc.Spec.Ports[0].TargetPort.IntValue()
 		// if targetPort == 0, look for Port (which is required)
 		if zt.remotePort == 0 {
-			zt.remotePort = c.findPodContainerPort(svc)
+			zt.remotePort = c.FindPodContainerPort(svc)
 		}
 
 		// Add the url suffix too.
@@ -207,26 +207,4 @@ func (c *Cluster) checkForZarfConnectLabel(name string) (TunnelInfo, error) {
 	}
 
 	return zt, nil
-}
-
-// findPodContainerPort will find the container port in the pod and assign it to tunnel's remotePort.
-func (c *Cluster) findPodContainerPort(svc v1.Service) int {
-	selectorLabelsOfPods := k8s.MakeLabels(svc.Spec.Selector)
-	pods := c.WaitForPodsAndContainers(k8s.PodLookup{
-		Namespace: svc.Namespace,
-		Selector:  selectorLabelsOfPods,
-	}, nil)
-
-	for _, pod := range pods {
-		// Find the matching name on the port in the pod
-		for _, container := range pod.Spec.Containers {
-			for _, port := range container.Ports {
-				if port.Name == svc.Spec.Ports[0].TargetPort.String() {
-					return int(port.ContainerPort)
-				}
-			}
-		}
-	}
-
-	return 0
 }

--- a/src/pkg/k8s/pods.go
+++ b/src/pkg/k8s/pods.go
@@ -161,7 +161,9 @@ func (k *K8s) WaitForPodsAndContainers(target PodLookup, include PodFilter) []co
 	return []corev1.Pod{}
 }
 
-// FindPodContainerPort will find a pod's container from a service and return it.
+// FindPodContainerPort will find a pod's container port from a service and return it.
+//
+// Returns 0 if no port is found.
 func (k *K8s) FindPodContainerPort(svc corev1.Service) int {
 	selectorLabelsOfPods := MakeLabels(svc.Spec.Selector)
 	pods := k.WaitForPodsAndContainers(PodLookup{

--- a/src/pkg/k8s/pods.go
+++ b/src/pkg/k8s/pods.go
@@ -160,3 +160,25 @@ func (k *K8s) WaitForPodsAndContainers(target PodLookup, include PodFilter) []co
 
 	return []corev1.Pod{}
 }
+
+// FindPodContainerPort will find a pod's container from a service and return it.
+func (k *K8s) FindPodContainerPort(svc corev1.Service) int {
+	selectorLabelsOfPods := MakeLabels(svc.Spec.Selector)
+	pods := k.WaitForPodsAndContainers(PodLookup{
+		Namespace: svc.Namespace,
+		Selector:  selectorLabelsOfPods,
+	}, nil)
+
+	for _, pod := range pods {
+		// Find the matching name on the port in the pod
+		for _, container := range pod.Spec.Containers {
+			for _, port := range container.Ports {
+				if port.Name == svc.Spec.Ports[0].TargetPort.String() {
+					return int(port.ContainerPort)
+				}
+			}
+		}
+	}
+
+	return 0
+}


### PR DESCRIPTION
## Description

This moves a helper function for finding a containers port from a service pod into library code to be used by other binaries.

## Related Issue

Relates to #1814 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
