### PR TITLE
fix: add prefix understanding to IsVendorCmd

### DIFF
--- a/src/cmd/common/vendor.go
+++ b/src/cmd/common/vendor.go
@@ -10,6 +10,7 @@ import (
 
 	"slices"
 
+	"github.com/defenseunicorns/zarf/src/config"
 	"github.com/spf13/cobra"
 )
 
@@ -46,6 +47,10 @@ func CheckVendorOnlyFromPath(cmd *cobra.Command) bool {
 
 // IsVendorCmd checks if the command is a vendor command.
 func IsVendorCmd(args []string, vendoredCmds []string) bool {
+	if config.ActionsCommandZarfPrefix != "" {
+		args = args[1:]
+	}
+
 	if len(args) > 2 {
 		if args[1] == "tools" || args[1] == "t" {
 			if slices.Contains(vendoredCmds, args[2]) {


### PR DESCRIPTION
## Description

Another fix for Zarf UI split - this makes vendor commands aware of the Zarf command prefix.

## Related Issue

Relates to #1814 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
