### PR TITLE
chore: update warn to caution in webhooks docs

### DIFF
--- a/examples/component-choice/README.md
+++ b/examples/component-choice/README.md
@@ -2,6 +2,12 @@ import ExampleYAML from "@site/src/components/ExampleYAML";
 
 # Component Choice
 
+:::caution
+
+Component Choice is currently a [Deprecated Feature](../../docs/9-roadmap.md#alpha). This feature is will be removed in Zarf v1.0.0. Please migrate any existing packages you may have that utilize it.
+
+:::
+
 This example demonstrates how to define packages that can be chosen by the user on `zarf package deploy`.  This is done through the `group` key inside of the component specification that defines a group of components a user can select from.
 
 A package creator can also use the `default` key to specify which component will be chosen if a user uses the `--confirm` flag.

--- a/examples/component-choice/README.md
+++ b/examples/component-choice/README.md
@@ -4,7 +4,7 @@ import ExampleYAML from "@site/src/components/ExampleYAML";
 
 :::caution
 
-Component Choice is currently a [Deprecated Feature](../../docs/9-roadmap.md#alpha). This feature is will be removed in Zarf v1.0.0. Please migrate any existing packages you may have that utilize it.
+Component Choice is currently a [Deprecated Feature](../../docs/9-roadmap.md#alpha). This feature will be removed in Zarf v1.0.0. Please migrate any existing packages you may have that utilize it.
 
 :::
 

--- a/examples/component-webhooks/README.md
+++ b/examples/component-webhooks/README.md
@@ -2,7 +2,7 @@ import ExampleYAML from '@site/src/components/ExampleYAML';
 
 # Component Webhooks
 
-:::warn
+:::caution
 
 Component Webhooks is currently an [Alpha Feature](../../docs/9-roadmap.md#alpha). This feature is not extensively tested and may be affected by breaking changes in the future. We encourage you to experiment with this feature and provide feedback to the Zarf team as we begin to stabilize this feature.
 


### PR DESCRIPTION
## Description

Updates `warn` to `caution` in webhooks docs

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
