### PR TITLE
fix not being able to template version when creating to oci directly

### DIFF
--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -40,17 +40,6 @@ func (p *Packager) Create() (err error) {
 		return fmt.Errorf("unable to read the zarf.yaml file: %s", err.Error())
 	}
 
-	if helpers.IsOCIURL(p.cfg.CreateOpts.Output) {
-		ref, err := oci.ReferenceFromMetadata(p.cfg.CreateOpts.Output, &p.cfg.Pkg.Metadata, p.arch)
-		if err != nil {
-			return err
-		}
-		err = p.setOCIRemote(ref)
-		if err != nil {
-			return err
-		}
-	}
-
 	// Load the images and repos from the 'reference' package
 	if err := p.loadDifferentialData(); err != nil {
 		return err
@@ -83,6 +72,17 @@ func (p *Packager) Create() (err error) {
 	// After components are composed, template the active package.
 	if err := p.fillActiveTemplate(); err != nil {
 		return fmt.Errorf("unable to fill values in template: %s", err.Error())
+	}
+
+	if helpers.IsOCIURL(p.cfg.CreateOpts.Output) {
+		ref, err := oci.ReferenceFromMetadata(p.cfg.CreateOpts.Output, &p.cfg.Pkg.Metadata, p.arch)
+		if err != nil {
+			return err
+		}
+		err = p.setOCIRemote(ref)
+		if err != nil {
+			return err
+		}
 	}
 
 	// After templates are filled process any create extensions


### PR DESCRIPTION
## Description

If you try to template the value of `version` in a zarf.yaml and then create output to oci directly it fails due to checking the oci url before templating the file

## Example package

```yaml
kind: ZarfPackageConfig
metadata:
  name: example
  version: "###ZARF_PKG_TMPL_VERSION###"

components:
  - name: some-component
```

failing command:
`zarf package create --set VERSION=1.0 --output oci://somerepo:tag`


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
