### PR TITLE
fix: always return a nil on error during a cluster creation call

### DIFF
--- a/src/internal/cluster/common.go
+++ b/src/internal/cluster/common.go
@@ -47,12 +47,12 @@ func NewClusterWithWait(timeout time.Duration) (*Cluster, error) {
 
 	c.K8s, err = k8s.New(message.Debugf, labels)
 	if err != nil {
-		return c, err
+		return nil, err
 	}
 
 	err = c.WaitForHealthyCluster(timeout)
 	if err != nil {
-		return c, err
+		return nil, err
 	}
 
 	spinner.Success()
@@ -64,6 +64,7 @@ func NewClusterWithWait(timeout time.Duration) (*Cluster, error) {
 func NewCluster() (*Cluster, error) {
 	c := &Cluster{}
 	var err error
+
 	c.K8s, err = k8s.New(message.Debugf, labels)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

This hotfixes an issue with cluster connections failing to try to record package secrets if a cluster connection fails.

https://github.com/defenseunicorns/doug-translate/actions/runs/6505302332/job/17668716413?pr=4

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
