### PR TITLE
Document the use of -count=1 flag to disable test caching

### DIFF
--- a/docs/12-contribute-to-zarf/2-testing.md
+++ b/docs/12-contribute-to-zarf/2-testing.md
@@ -29,11 +29,16 @@ make test-e2e ARCH="[amd64|arm64]"
 APPLIANCE_MODE=true make test-e2e ARCH="[amd64|arm64]"
 
 # If you already have everything build, you can run this inside this folder. This lets you customize the test run.
-go test ./src/test/... -v -failfast
+go test ./src/test/... -v -failfast -count=1
 
 # Let's say you only want to run one test. You would run:
-go test ./src/test/... -v -failfast -run TestFooBarBaz
+go test ./src/test/... -v -failfast -run TestFooBarBaz -count=1
 ```
+
+:::note
+The `-count=1` flag is the idiomatic way to disable
+test caching explicitly.
+:::
 
 :::note
 The Zarf binary and built packages are required to be stored in the ./build directory. However, if you intend to run tests locally using 'go test ./...', the zarf-init package must also be present in this directory.


### PR DESCRIPTION
## Description
Document the use of -count=1 flag to disable test caching

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
