### PR TITLE
fix: 1 CPU maxed out during zarf connect git

### DIFF
--- a/src/cmd/connect.go
+++ b/src/cmd/connect.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"runtime"
 	"syscall"
 
 	"github.com/defenseunicorns/zarf/src/config/lang"
@@ -73,17 +72,12 @@ var (
 			// Keep this open until an interrupt signal is received.
 			interruptChan := make(chan os.Signal, 1)
 			signal.Notify(interruptChan, os.Interrupt, syscall.SIGTERM)
-			go func() {
-				<-interruptChan
-				spinner.Successf(lang.CmdConnectTunnelClosed, url)
-				os.Exit(0)
-			}()
-
 			exec.SuppressGlobalInterrupt = true
 
-			for {
-				runtime.Gosched()
-			}
+			// Wait for the interrupt signal.
+			<-interruptChan
+			spinner.Successf(lang.CmdConnectTunnelClosed, url)
+			os.Exit(0)
 		},
 	}
 


### PR DESCRIPTION
## Description
removed the loop that kept calling `runtime.Gosched()`, it was trying to be nice, and yet using all the CPU time (1 thread) @jeff-mccoy please verify,

Fixes #1357 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
