### PR TITLE
wait for the registry deployment to be fully ready before continuing

### DIFF
--- a/packages/zarf-registry/zarf.yaml
+++ b/packages/zarf-registry/zarf.yaml
@@ -135,7 +135,7 @@ components:
         after:
           - wait:
               cluster:
-                kind: pod
+                kind: deployment
                 namespace: zarf
                 name: app=docker-registry
-                condition: Ready
+                condition: Available


### PR DESCRIPTION
## Description

This changes the registry wait command to wait for the full deployment of the registry rather than a pod to avoid race conditions during bootup.

## Related Issue

Fixes #N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
