### PR TITLE
fix: race condition bug in TestValidateLastNonBreakingVersion unit test

### DIFF
--- a/src/pkg/packager/common_test.go
+++ b/src/pkg/packager/common_test.go
@@ -207,8 +207,6 @@ func TestValidateLastNonBreakingVersion(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
 			config.CLIVersion = testCase.cliVersion
 
 			p := &Packager{


### PR DESCRIPTION
## Description

Each test case in `TestValidateLastNonBreakingVersion()` updates a global variable `config.CLIVersion`, so the test cases should not be ran concurrently.

## Related Issue

Fixes #2136

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
