### PR TITLE
fix: first step to split up the e2e need a cluster, versus ones that do not

### DIFF
--- a/.github/workflows/test-e2e-shim.yml
+++ b/.github/workflows/test-e2e-shim.yml
@@ -37,6 +37,13 @@ jobs:
         run: |
           echo skipped
 
+  validate-e2e-tests-without-cluster:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skipped
+        run: |
+          echo skipped
+
   validate-k3d:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-e2e-shim.yml
+++ b/.github/workflows/test-e2e-shim.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           echo skipped
 
-  validate-e2e-tests-without-cluster:
+  validate-without-cluster:
     runs-on: ubuntu-latest
     steps:
       - name: Skipped

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -43,7 +43,7 @@ jobs:
           path: build/
           retention-days: 1
 
-  validate-e2e-tests-without-cluster:
+  validate-without-cluster:
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -43,6 +43,38 @@ jobs:
           path: build/
           retention-days: 1
 
+  validate-e2e-tests-without-cluster:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: build-artifacts
+          path: build/
+
+      - name: Setup golang
+        uses: ./.github/actions/golang
+
+      - name: Make Zarf executable
+        run: |
+          chmod +x build/zarf
+
+      # Before we run the regular tests we need to aggressively cleanup files to reduce disk pressure
+      - name: Cleanup files
+        uses: ./.github/actions/cleanup-files
+
+      - name: Run tests
+        run: |
+          make test-e2e-without-cluster ARCH=amd64
+
+      - name: Save logs
+        if: always()
+        uses: ./.github/actions/save-logs
+
   # Run the tests on k3d
   validate-k3d:
     runs-on: ubuntu-latest
@@ -73,7 +105,7 @@ jobs:
 
       - name: Run tests
         run: |
-          make test-e2e ARCH=amd64
+          make test-e2e-with-cluster ARCH=amd64
 
       - name: Save logs
         if: always()
@@ -109,7 +141,7 @@ jobs:
         #       in a previous step. This test run will use Zarf to create a K3s cluster, and a brand new cluster will be
         #       used for each test
         run: |
-          sudo env "PATH=$PATH" CI=true APPLIANCE_MODE=true make test-e2e ARCH=amd64
+          sudo env "PATH=$PATH" CI=true APPLIANCE_MODE=true make test-e2e-with-cluster ARCH=amd64
 
       - name: Save logs
         if: always()
@@ -147,7 +179,7 @@ jobs:
 
       - name: Run tests
         run: |
-          make test-e2e ARCH=amd64
+          make test-e2e-with-cluster ARCH=amd64
 
       - name: Save logs
         if: always()
@@ -183,7 +215,7 @@ jobs:
 
       - name: Run tests
         run: |
-          make test-e2e ARCH=amd64
+          make test-e2e-with-cluster ARCH=amd64
 
       - name: Save logs
         if: always()

--- a/.github/workflows/test-upgrade.yml
+++ b/.github/workflows/test-upgrade.yml
@@ -90,7 +90,7 @@ jobs:
         # NOTE: "PATH=$PATH" preserves the default user $PATH. This is needed to maintain the version of go installed
         #       in a previous step. This test run will use this PR's Zarf to create a K3s cluster.
         run: |
-          sudo env "PATH=$PATH" CI=true APPLIANCE_MODE=true APPLIANCE_MODE_KEEP=true make test-e2e ARCH=amd64
+          sudo env "PATH=$PATH" CI=true APPLIANCE_MODE=true APPLIANCE_MODE_KEEP=true make test-e2e-with-cluster ARCH=amd64
 
       - name: "Describe nodes, pods and deployments"
         # NOTE: We describe nodes, pods and deployments here to help understand failures

--- a/Makefile
+++ b/Makefile
@@ -142,9 +142,17 @@ build-injector-linux: ## Build the Zarf injector for AMD64 and ARM64
 
 ## NOTE: Requires an existing cluster or the env var APPLIANCE_MODE=true
 .PHONY: test-e2e
-test-e2e: build-examples ## Run all of the core Zarf CLI E2E tests (builds any deps that aren't present)
+test-e2e: test-e2e-without-cluster test-e2e-with-cluster  ## Run all of the core Zarf CLI E2E tests (builds any deps that aren't present)
+
+.PHONY: test-e2e-with-cluster
+test-e2e-with-cluster: build-examples ## Run all of the core Zarf CLI E2E tests that DO require a cluster (builds any deps that aren't present)
 	@test -s ./build/zarf-init-$(ARCH)-$(CLI_VERSION).tar.zst || $(MAKE) init-package
-	cd src/test/e2e && go test -failfast -v -timeout 35m
+	cd src/test/e2e && go test ./main_test.go ./[2-9]*.go -failfast -v -timeout 35m
+
+.PHONY: test-e2e-without-cluster
+test-e2e-without-cluster: build-examples ## Run all of the core Zarf CLI E2E tests  that DO NOT require a cluster (builds any deps that aren't present)
+	@test -s ./build/zarf-init-$(ARCH)-$(CLI_VERSION).tar.zst || $(MAKE) init-package
+	cd src/test/e2e && go test ./main_test.go ./[01]* -failfast -v -timeout 35m
 
 ## NOTE: Requires an existing cluster
 .PHONY: test-external

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BUILD_ARGS := -s -w -X 'github.com/defenseunicorns/zarf/src/config.CLIVersion=$(
 
 .PHONY: help
 help: ## Display this help information
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
 	  | sort | awk 'BEGIN {FS = ":.*?## "}; \
 	  {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 


### PR DESCRIPTION

## Description

updated the makefile and the github action to reduce the work for non-cluster e2e tests. 

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Other (security config, docs update, etc)

## Checklist before merging

- [x ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
