### PR TITLE
fix: updated to not clobber whatever k3d cluster may be running, updated gitea to same version as zarf init

### DIFF
--- a/src/test/external/ext_in_cluster_test.go
+++ b/src/test/external/ext_in_cluster_test.go
@@ -34,7 +34,7 @@ func (suite *ExtInClusterTestSuite) SetupSuite() {
 	suite.Assertions = require.New(suite.T())
 
 	// Install a gitea chart to the k8s cluster to act as the 'remote' git server
-	giteaChartURL := "https://dl.gitea.io/charts/gitea-5.0.8.tgz"
+	giteaChartURL := "https://dl.gitea.io/charts/gitea-8.3.0.tgz"
 	helmInstallArgs := []string{"install", "gitea", giteaChartURL, "-f", "gitea-values.yaml", "-n=git-server", "--create-namespace"}
 	err := exec.CmdWithPrint("helm", helmInstallArgs...)
 	suite.NoError(err, "unable to install gitea chart")

--- a/src/test/external/ext_out_cluster_test.go
+++ b/src/test/external/ext_out_cluster_test.go
@@ -23,6 +23,7 @@ const (
 	giteaIP      = "172.31.0.99"
 	giteaHost    = "gitea.localhost"
 	registryHost = "registry.localhost"
+	clusterName  = "zarf-external-test"
 )
 
 var outClusterCredentialArgs = []string{
@@ -42,7 +43,7 @@ func (suite *ExtOutClusterTestSuite) SetupSuite() {
 	suite.Assertions = require.New(suite.T())
 
 	// Teardown any leftovers from previous tests
-	_ = exec.CmdWithPrint("k3d", "cluster", "delete")
+	_ = exec.CmdWithPrint("k3d", "cluster", "delete", clusterName)
 	_ = exec.CmdWithPrint("k3d", "registry", "delete", registryHost)
 	_ = exec.CmdWithPrint("docker", "network", "remove", network)
 
@@ -55,7 +56,7 @@ func (suite *ExtOutClusterTestSuite) SetupSuite() {
 	suite.NoError(err, "unable to create the k3d registry")
 
 	// Create a k3d cluster with the proper networking and aliases
-	err = exec.CmdWithPrint("k3d", "cluster", "create", "--registry-use", "k3d-"+registryHost+":5000", "--host-alias", giteaIP+":"+giteaHost, "--network", network)
+	err = exec.CmdWithPrint("k3d", "cluster", "create", clusterName, "--registry-use", "k3d-"+registryHost+":5000", "--host-alias", giteaIP+":"+giteaHost, "--network", network)
 	suite.NoError(err, "unable to create the k3d cluster")
 
 	// Install a gitea server via docker compose to act as the 'remote' git server
@@ -75,7 +76,7 @@ func (suite *ExtOutClusterTestSuite) SetupSuite() {
 
 func (suite *ExtOutClusterTestSuite) TearDownSuite() {
 	// Tear down all of that stuff we made for local runs
-	err := exec.CmdWithPrint("k3d", "cluster", "delete")
+	err := exec.CmdWithPrint("k3d", "cluster", "delete", clusterName)
 	suite.NoError(err, "unable to teardown cluster")
 
 	err = exec.CmdWithPrint("docker", "compose", "down")


### PR DESCRIPTION

## Description

Very small change to make sure that running the external tests locally do not just clobber a k3d cluster you might have running that uses the default name.

updated the test to use the same version of gitea as the one in the current zarf init
## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
