### PR TITLE
fix: `ResolveRoot` behavior

### DIFF
--- a/src/pkg/oci/fetch.go
+++ b/src/pkg/oci/fetch.go
@@ -30,7 +30,10 @@ func (o *OrasRemote) ResolveRoot() (ocispec.Descriptor, error) {
 		return desc, nil
 	}
 
-	// if target platform is nil, oras.Resolve falls back to a o.repo.Resolve call
+	if o.targetPlatform == nil && desc.MediaType == ocispec.MediaTypeImageIndex {
+		return ocispec.Descriptor{}, fmt.Errorf("%q resolved to an image index, but no target platform was specified", o.repo.Reference.Reference)
+	}
+
 	resolveOpts := oras.ResolveOptions{
 		TargetPlatform: o.targetPlatform,
 	}


### PR DESCRIPTION
## Description

When using Zarf's OCI client: `OrasRemote`, there is backwards compatibility to support previous package references. Old packages were published under image manifests, while new packages are published under image indexes. Resolving the manifest stored within an image index requires knowing which os/arch (`ocispec.Platform`) to search for.

All internal usages of this client properly use the `oci.WithArch` or `oci.WithPlatform` modifiers that add a `targetPlatform` to the client so that `r.ResolveRoot` is able to properly leverage `oras.ResolveOptions` and locate the correct manifest within the index.

However, if no platform modifier is used, `targetPlatform` remains `nil`. This causes `oras.Resolve` to return the descriptor of the index, not the manifest. To remedy this, simply error after the backwards compat check if no modifier was used to add a `targetPlatform` onto the remote client.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
