### PR TITLE
fix: handle panic during checksum validation

### DIFF
--- a/src/pkg/packager/sources/validate.go
+++ b/src/pkg/packager/sources/validate.go
@@ -83,10 +83,17 @@ func ValidatePackageIntegrity(loaded *layout.PackagePaths, aggregateChecksum str
 	checkedMap[loaded.Signature] = true
 
 	err = lineByLine(checksumPath, func(line string) error {
+		// If the line is empty (i.e. there is no checksum) simply skip it - this can result from a package with no images/components
 		if line == "" {
 			return nil
 		}
+
 		split := strings.Split(line, " ")
+		// If the line is not splitable into two pieces the file is likely corrupted
+		if len(split) != 2 {
+			return fmt.Errorf("invalid checksum line: %s", line)
+		}
+
 		sha := split[0]
 		rel := split[1]
 

--- a/src/pkg/packager/sources/validate.go
+++ b/src/pkg/packager/sources/validate.go
@@ -83,6 +83,9 @@ func ValidatePackageIntegrity(loaded *layout.PackagePaths, aggregateChecksum str
 	checkedMap[loaded.Signature] = true
 
 	err = lineByLine(checksumPath, func(line string) error {
+		if line == "" {
+			return nil
+		}
 		split := strings.Split(line, " ")
 		sha := split[0]
 		rel := split[1]


### PR DESCRIPTION
## Description

Handles a condition where execution would panic when a package contained no checksums.

## Related Issue

Fixes https://github.com/defenseunicorns/zarf/issues/2261

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
