### PR TITLE
fix: restore destroy script functionality

### DIFF
--- a/packages/distros/k3s/common/zarf.yaml
+++ b/packages/distros/k3s/common/zarf.yaml
@@ -41,6 +41,8 @@ components:
         before:
           - cmd: /opt/zarf/zarf-clean-k3s.sh
             description: Remove 'k3s' from the system
+          - cmd: rm /opt/zarf/zarf-clean-k3s.sh
+            description: Remove the cleanup script
     files:
       # K3s removal script
       - source: zarf-clean-k3s.sh

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -199,6 +199,11 @@ func (p *Packager) deployInitComponent(component types.ZarfComponent) (charts []
 	isRegistry := component.Name == "zarf-registry"
 	isInjector := component.Name == "zarf-injector"
 	isAgent := component.Name == "zarf-agent"
+	isK3s := component.Name == "k3s"
+
+	if isK3s {
+		p.cfg.InitOpts.ApplianceMode = true
+	}
 
 	// Always init the state before the first component that requires the cluster (on most deployments, the zarf-seed-registry)
 	if requiresCluster(component) && p.cfg.State == nil {

--- a/src/test/e2e/99_appliance_remove_test.go
+++ b/src/test/e2e/99_appliance_remove_test.go
@@ -25,11 +25,24 @@ func TestApplianceRemove(t *testing.T) {
 
 	path := fmt.Sprintf("build/zarf-init-%s-%s.tar.zst", e2e.Arch, initPackageVersion)
 
-	// Destroy the cluster to test Zarf cleaning up after itself
+	// Package remove the cluster to test Zarf cleaning up after itself
 	stdOut, stdErr, err := e2e.Zarf("package", "remove", path, "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 
 	// Check that the cluster is now gone
+	_, _, err = e2e.Kubectl("get", "nodes")
+	require.Error(t, err)
+
+	// TODO (@WSTARR) - This needs to be refactored to use the remove logic instead of reaching into a magic directory
+	// Re-init the cluster so that we can test that the destroy scripts run
+	stdOut, stdErr, err = e2e.Zarf("init", "--components=k3s", "--confirm")
+	require.NoError(t, err, stdOut, stdErr)
+
+	// Re-init the cluster so that we can test that the destroy scripts run
+	stdOut, stdErr, err = e2e.Zarf("destroy", "--confirm")
+	require.NoError(t, err, stdOut, stdErr)
+
+	// Check that the cluster gone again
 	_, _, err = e2e.Kubectl("get", "nodes")
 	require.Error(t, err)
 }

--- a/src/test/e2e/99_appliance_remove_test.go
+++ b/src/test/e2e/99_appliance_remove_test.go
@@ -34,11 +34,11 @@ func TestApplianceRemove(t *testing.T) {
 	require.Error(t, err)
 
 	// TODO (@WSTARR) - This needs to be refactored to use the remove logic instead of reaching into a magic directory
-	// Re-init the cluster so that we can test that the destroy scripts run
+	// Re-init the cluster so that we can test if the destroy scripts run
 	stdOut, stdErr, err = e2e.Zarf("init", "--components=k3s", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 
-	// Re-init the cluster so that we can test that the destroy scripts run
+	// Destroy the cluster to test Zarf cleaning up after itself
 	stdOut, stdErr, err = e2e.Zarf("destroy", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 


### PR DESCRIPTION
## Description

This fixes ApplianceMode not being set and not triggering destroy scripts.

## Related Issue

Fixes #2268
Relates to #2275 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
