### PR TITLE
fix: improve cmd failure messaging

### DIFF
--- a/src/pkg/packager/actions.go
+++ b/src/pkg/packager/actions.go
@@ -161,14 +161,14 @@ retryCmd:
 	select {
 	case <-timeout:
 		// If we reached this point, the timeout was reached or command failed with no retries.
-		if cfg.MaxTotalSeconds < 1 && cfg.MaxRetries < 1 {
-			return fmt.Errorf("command \"%s\" failed (no retries)", cmdEscaped)
+		if cfg.MaxTotalSeconds < 1 {
+			return fmt.Errorf("command %q failed after %d retries", cmdEscaped, cfg.MaxRetries)
 		} else {
-			return fmt.Errorf("command \"%s\" timed out after %d seconds", cmdEscaped, cfg.MaxTotalSeconds)
+			return fmt.Errorf("command %q timed out after %d seconds", cmdEscaped, cfg.MaxTotalSeconds)
 		}
 	default:
 		// If we reached this point, the retry limit was reached.
-		return fmt.Errorf("command \"%s\" failed after %d retries", cmdEscaped, cfg.MaxRetries)
+		return fmt.Errorf("command %q failed after %d retries", cmdEscaped, cfg.MaxRetries)
 	}
 }
 

--- a/src/pkg/packager/actions.go
+++ b/src/pkg/packager/actions.go
@@ -160,9 +160,12 @@ retryCmd:
 
 	select {
 	case <-timeout:
-		// If we reached this point, the timeout was reached.
-		return fmt.Errorf("command \"%s\" timed out after %d seconds", cmdEscaped, cfg.MaxTotalSeconds)
-
+		// If we reached this point, the timeout was reached or command failed with no retries.
+		if cfg.MaxTotalSeconds < 1 && cfg.MaxRetries < 1 {
+			return fmt.Errorf("command \"%s\" failed (no retries)", cmdEscaped)
+		} else {
+			return fmt.Errorf("command \"%s\" timed out after %d seconds", cmdEscaped, cfg.MaxTotalSeconds)
+		}
 	default:
 		// If we reached this point, the retry limit was reached.
 		return fmt.Errorf("command \"%s\" failed after %d retries", cmdEscaped, cfg.MaxRetries)

--- a/src/test/e2e/02_component_actions_test.go
+++ b/src/test/e2e/02_component_actions_test.go
@@ -150,5 +150,7 @@ func TestComponentActions(t *testing.T) {
 		stdOut, stdErr, err = e2e.Zarf("package", "deploy", path, "--components=on-deploy-immediate-failure", "--confirm")
 		require.Error(t, err, stdOut, stdErr)
 		require.Contains(t, stdErr, "Failed to deploy package")
+		// regression test to ensure that failed commands are not erroneously flagged as a timeout
+		require.NotContains(t, stdErr, "timed out")
 	})
 }


### PR DESCRIPTION
…s with no retries

## Description

Add check to see whether action failure was actually due to timeout or not. Currently Zarf reports an error of "timed out after 0 seconds" when a `cmd` within an action fails (with no retries) even if no timeout was set.

## Related Issue

Fixes #2299

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
