### PR TITLE
fix: allow usage of local image archives again 

### DIFF
--- a/src/pkg/packager/create_stages.go
+++ b/src/pkg/packager/create_stages.go
@@ -128,6 +128,9 @@ func (p *Packager) assemble() error {
 
 		// Combine all component images into a single entry for efficient layer reuse.
 		for _, src := range component.Images {
+			if strings.HasSuffix(src, ".tar") || strings.HasSuffix(src, ".tar.gz") || strings.HasSuffix(src, ".tgz") {
+				continue
+			}
 			refInfo, err := transform.ParseImageRef(src)
 			if err != nil {
 				return fmt.Errorf("failed to create ref for image %s: %w", src, err)


### PR DESCRIPTION
## Description

a check in create_stages during package creation tries to parses references for the images provided for components in the zarf.yaml config. By default the reference parsing assumes that the source of the image is that of a container registry. If the image is a tarball instead, the reference parser errors out.

The changes in this commit check if the image reference is that of a tarball and skips the reference check if it is so allowing the image to be loaded by the cli.

## Related Issue

Fixes #2181 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
