### PR TITLE
fix: revert storageclass checks for git server and seed registry

### DIFF
--- a/packages/gitea/zarf.yaml
+++ b/packages/gitea/zarf.yaml
@@ -66,12 +66,6 @@ components:
     actions:
       onDeploy:
         before:
-          - description: Check that the cluster has the specified storage class
-            maxTotalSeconds: 3
-            wait:
-              cluster:
-                kind: storageclass
-                name: "\"${ZARF_STORAGE_CLASS}\""
           - cmd: ./zarf internal update-gitea-pvc --no-progress 
             setVariables:
               - name: GIT_SERVER_CREATE_PVC

--- a/packages/zarf-registry/zarf.yaml
+++ b/packages/zarf-registry/zarf.yaml
@@ -111,15 +111,6 @@ components:
     images:
       # The seed image (or images) that will be injected (see zarf-config.toml)
       - "###ZARF_PKG_TMPL_REGISTRY_IMAGE_DOMAIN######ZARF_PKG_TMPL_REGISTRY_IMAGE###:###ZARF_PKG_TMPL_REGISTRY_IMAGE_TAG###"
-    actions:
-      onDeploy:
-        before:
-          - description: Check that the cluster has the specified storage class
-            maxTotalSeconds: 3
-            wait:
-              cluster:
-                kind: storageclass
-                name: "\"${ZARF_STORAGE_CLASS}\""
 
   - name: zarf-registry
     description: |


### PR DESCRIPTION
## Description

https://github.com/defenseunicorns/zarf/pull/2180 introduced a bug and this PR removes the cause of the bug.

Actions conditionals are being added to Zarf in https://github.com/defenseunicorns/zarf/pull/2276 to allow these sort of checks to account for various use cases in a more clean way.

Also reopened https://github.com/defenseunicorns/zarf/issues/1824

## Related Issue

Relates to https://github.com/defenseunicorns/zarf/issues/2273

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
