### PR TITLE
chore: Add PIE Build Mode Artifacts to GoReleaser Configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,7 @@ universal_binaries:
 builds:
   - env:
       - CGO_ENABLED=0
+      - GOFLAGS="-buildmode=pie" # Building a Position Independent Executable (PIE)
     goos:
       - linux
       - darwin


### PR DESCRIPTION

## Description
Added the GOFLAGS="-buildmode=pie" environment variable to our GoReleaser build configuration.

This change instructs the Go compiler to build the binary as a PIE, a crucial security feature.

PIE binaries are more resistant to specific attacks because they support Address Space Layout Randomization (ASLR), making it significantly harder for attackers to predict the memory location of specific code segments.

This change applies to all our target operating systems (Linux, Darwin/ macOS, and Windows), aligning with best practices for secure software development.


## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
