### PR TITLE
chore: configure agent server to avoid slowloris attack

### DIFF
--- a/src/internal/agent/http/server.go
+++ b/src/internal/agent/http/server.go
@@ -7,6 +7,7 @@ package http
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/defenseunicorns/zarf/src/internal/agent/hooks"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
@@ -34,8 +35,9 @@ func NewAdmissionServer(port string) *http.Server {
 	mux.Handle("/metrics", promhttp.Handler())
 
 	return &http.Server{
-		Addr:    fmt.Sprintf(":%s", port),
-		Handler: mux,
+		Addr:              fmt.Sprintf(":%s", port),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second, // Set ReadHeaderTimeout to avoid Slowloris attacks
 	}
 }
 
@@ -49,8 +51,9 @@ func NewProxyServer(port string) *http.Server {
 	mux.Handle("/metrics", promhttp.Handler())
 
 	return &http.Server{
-		Addr:    fmt.Sprintf(":%s", port),
-		Handler: mux,
+		Addr:              fmt.Sprintf(":%s", port),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second, // Set ReadHeaderTimeout to avoid Slowloris attacks
 	}
 }
 


### PR DESCRIPTION


## Description

- included timeout to avoid slowloris attack - `gosec` https://github.com/securego/gosec G112: Potential slowloris attack

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
