### PR TITLE
fix: added OCI Image Index mediaType

### DIFF
--- a/src/pkg/oci/push.go
+++ b/src/pkg/oci/push.go
@@ -190,6 +190,7 @@ func (o *OrasRemote) UpdateIndex(tag string, arch string, publishedDesc ocispec.
 				Versioned: specs.Versioned{
 					SchemaVersion: 2,
 				},
+				MediaType: ocispec.MediaTypeImageIndex,
 				Manifests: []ocispec.Descriptor{
 					{
 						MediaType: ocispec.MediaTypeImageManifest,


### PR DESCRIPTION
## Description

Added the OCI Image Index's mediaType for completeness sake per the OCI spec and to work around a known Sonatype Nexus Repository bug.

## Related Issue

Fixes #2351

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
