### PR TITLE
fix: package publish progress bar frozen at zero

### DIFF
--- a/src/pkg/oci/common.go
+++ b/src/pkg/oci/common.go
@@ -28,7 +28,7 @@ const (
 type OrasRemote struct {
 	repo           *remote.Repository
 	root           *Manifest
-	Transport      *helpers.Transport
+	progTransport  *helpers.Transport
 	targetPlatform *ocispec.Platform
 	log            *slog.Logger
 }
@@ -46,7 +46,7 @@ func WithPlainHTTP(plainHTTP bool) Modifier {
 // WithInsecureSkipVerify sets the insecure TLS flag for the remote
 func WithInsecureSkipVerify(insecure bool) Modifier {
 	return func(o *OrasRemote) {
-		o.Transport.Base.(*http.Transport).TLSClientConfig.InsecureSkipVerify = insecure
+		o.progTransport.Base.(*http.Transport).TLSClientConfig.InsecureSkipVerify = insecure
 	}
 }
 
@@ -85,7 +85,7 @@ func NewOrasRemote(url string, platform ocispec.Platform, mods ...Modifier) (*Or
 	client.Client.Transport = transport
 	o := &OrasRemote{
 		repo:           &remote.Repository{Client: client},
-		Transport:      helpers.NewTransport(transport, nil),
+		progTransport:  helpers.NewTransport(transport, nil),
 		targetPlatform: &platform,
 		log:            slog.Default(),
 	}
@@ -103,14 +103,14 @@ func NewOrasRemote(url string, platform ocispec.Platform, mods ...Modifier) (*Or
 
 // SetProgressWriter sets the progress writer for the remote
 func (o *OrasRemote) SetProgressWriter(bar helpers.ProgressWriter) {
-	o.Transport.ProgressBar = bar
-	o.repo.Client.(*auth.Client).Client.Transport = o.Transport
+	o.progTransport.ProgressBar = bar
+	o.repo.Client.(*auth.Client).Client.Transport = o.progTransport
 }
 
 // ClearProgressWriter clears the progress writer for the remote
 func (o *OrasRemote) ClearProgressWriter() {
-	o.Transport.ProgressBar = nil
-	o.repo.Client.(*auth.Client).Client.Transport = o.Transport
+	o.progTransport.ProgressBar = nil
+	o.repo.Client.(*auth.Client).Client.Transport = o.progTransport
 }
 
 // Repo gives you access to the underlying remote repository

--- a/src/pkg/oci/common.go
+++ b/src/pkg/oci/common.go
@@ -101,6 +101,18 @@ func NewOrasRemote(url string, platform ocispec.Platform, mods ...Modifier) (*Or
 	return o, nil
 }
 
+// SetProgressWriter sets the progress writer for the remote
+func (o *OrasRemote) SetProgressWriter(bar helpers.ProgressWriter) {
+	o.Transport.ProgressBar = bar
+	o.repo.Client.(*auth.Client).Client.Transport = o.Transport
+}
+
+// ClearProgressWriter clears the progress writer for the remote
+func (o *OrasRemote) ClearProgressWriter() {
+	o.Transport.ProgressBar = nil
+	o.repo.Client.(*auth.Client).Client.Transport = o.Transport
+}
+
 // Repo gives you access to the underlying remote repository
 func (o *OrasRemote) Repo() *remote.Repository {
 	return o.repo

--- a/src/pkg/zoci/push.go
+++ b/src/pkg/zoci/push.go
@@ -69,7 +69,8 @@ func (r *Remote) PublishPackage(ctx context.Context, pkg *types.ZarfPackage, pat
 
 	progressBar := message.NewProgressBar(total, fmt.Sprintf("Publishing %s:%s", r.Repo().Reference.Repository, r.Repo().Reference.Reference))
 	defer progressBar.Stop()
-	r.Transport.ProgressBar = progressBar
+	r.SetProgressWriter(progressBar)
+	defer r.ClearProgressWriter()
 
 	publishedDesc, err := oras.Copy(ctx, src, root.Digest.String(), r.Repo(), "", copyOpts)
 	if err != nil {


### PR DESCRIPTION
## Description

Small change to fix `publish`'s progress bar. The progress writer was not getting attached to the underlying client, leading to the progress bar never receiving the byte updates.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
