### PR TITLE
fix(release): hotfix `publish` not respecting source package architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish Zarf Packages on Tag
+name: Release CLI and Packages on Tag
 
 permissions:
   contents: read

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -76,6 +76,9 @@ brews:
       owner: defenseunicorns
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     homepage: "https://zarf.dev/"
     description: "DevSecOps for Air Gap"

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -77,7 +77,7 @@ func (p *Packager) Publish() (err error) {
 	if p.cfg.CreateOpts.IsSkeleton {
 		platform = zoci.PlatformForSkeleton()
 	} else {
-		platform = oci.PlatformForArch(config.GetArch())
+		platform = oci.PlatformForArch(p.arch)
 	}
 	remote, err := zoci.NewRemote(ref, platform)
 	if err != nil {


### PR DESCRIPTION
## Description

`zarf package publish <src>` would publish to CLI/runtime arch only and not respect source package's architecture, leading to packages existing at the wrong platform in the published index.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
