### PR TITLE
fix: handle registry caBundle as a multiline string

### DIFF
--- a/packages/zarf-registry/registry-values.yaml
+++ b/packages/zarf-registry/registry-values.yaml
@@ -40,7 +40,8 @@ autoscaling:
   maxReplicas: "###ZARF_VAR_REGISTRY_HPA_MAX###"
   targetCPUUtilizationPercentage: 80
 
-caBundle: ###ZARF_VAR_REGISTRY_CA_BUNDLE###
+caBundle: |
+  ###ZARF_VAR_REGISTRY_CA_BUNDLE###
 
 extraEnvVars:
   ###ZARF_VAR_REGISTRY_EXTRA_ENVS###


### PR DESCRIPTION
## Description

I added support for custom root CA Bundles to the registry some time back.  I encountered the need to do this again and discovered it was not properly formatting the cert in the registry configMap.  This minor change fixes that.

## Related Issue


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
