### PR TITLE
fix: populate `p.sbomViewFiles` on `deploy` and `mirror`

### DIFF
--- a/src/pkg/layout/sbom.go
+++ b/src/pkg/layout/sbom.go
@@ -69,15 +69,16 @@ func (s *SBOMs) Archive() (err error) {
 }
 
 // StageSBOMViewFiles copies SBOM viewer HTML files to the Zarf SBOM directory.
-func (s *SBOMs) StageSBOMViewFiles() (warnings []string, err error) {
+func (s *SBOMs) StageSBOMViewFiles() (sbomViewFiles, warnings []string, err error) {
 	if s.IsTarball() {
-		return nil, fmt.Errorf("unable to process the SBOM files for this package: %s is a tarball", s.Path)
+		return nil, nil, fmt.Errorf("unable to process the SBOM files for this package: %s is a tarball", s.Path)
 	}
 
 	// If SBOMs were loaded, temporarily place them in the deploy directory
 	if !helpers.InvalidPath(s.Path) {
-		if _, err := filepath.Glob(filepath.Join(s.Path, "sbom-viewer-*")); err != nil {
-			return nil, err
+		sbomViewFiles, err = filepath.Glob(filepath.Join(s.Path, "sbom-viewer-*"))
+		if err != nil {
+			return nil, nil, err
 		}
 
 		if _, err := s.OutputSBOMFiles(SBOMDir, ""); err != nil {
@@ -87,7 +88,7 @@ func (s *SBOMs) StageSBOMViewFiles() (warnings []string, err error) {
 		}
 	}
 
-	return warnings, nil
+	return sbomViewFiles, warnings, nil
 }
 
 // OutputSBOMFiles outputs SBOM files into outputDir.

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -54,7 +54,8 @@ func (p *Packager) Deploy() (err error) {
 		return err
 	}
 
-	sbomWarnings, err := p.layout.SBOMs.StageSBOMViewFiles()
+	var sbomWarnings []string
+	p.sbomViewFiles, sbomWarnings, err = p.layout.SBOMs.StageSBOMViewFiles()
 	if err != nil {
 		return err
 	}

--- a/src/pkg/packager/mirror.go
+++ b/src/pkg/packager/mirror.go
@@ -27,7 +27,8 @@ func (p *Packager) Mirror() (err error) {
 		return err
 	}
 
-	sbomWarnings, err := p.layout.SBOMs.StageSBOMViewFiles()
+	var sbomWarnings []string
+	p.sbomViewFiles, sbomWarnings, err = p.layout.SBOMs.StageSBOMViewFiles()
 	if err != nil {
 		return err
 	}

--- a/src/test/e2e/20_zarf_init_test.go
+++ b/src/test/e2e/20_zarf_init_test.go
@@ -69,6 +69,7 @@ func TestZarfInit(t *testing.T) {
 	_, initStdErr, err := e2e.Zarf("init", "--components="+initComponents, "--nodeport", "31337", "-l", "trace", "--confirm")
 	require.NoError(t, err)
 	require.Contains(t, initStdErr, "an inventory of all software contained in this package")
+	require.NotContains(t, initStdErr, "This package does NOT contain an SBOM. If you require an SBOM, please contact the creator of this package to request a version that includes an SBOM.")
 
 	logText := e2e.GetLogFileContents(t, e2e.StripMessageFormatting(initStdErr))
 


### PR DESCRIPTION
## Description
Refactoring that took place in https://github.com/defenseunicorns/zarf/pull/2223 introduced a bug on `deploy` where the user is not prompted to view SBOMs. This occurs because `p.sbomViewFiles` is not being populated correctly. This PR fixes this issue by populating `p.sbomViewFiles`.

## Related Issue
N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
