### PR TITLE
fix: hotfix skeleton publish

### DIFF
--- a/src/pkg/packager/composer/list.go
+++ b/src/pkg/packager/composer/list.go
@@ -347,9 +347,6 @@ func (ic *ImportChain) MergeConstants(existing []types.ZarfPackageConstant) (mer
 
 // CompatibleComponent determines if this component is compatible with the given create options
 func CompatibleComponent(c types.ZarfComponent, arch, flavor string) bool {
-	if arch == zoci.SkeletonArch {
-		return true
-	}
 	satisfiesArch := c.Only.Cluster.Architecture == "" || c.Only.Cluster.Architecture == arch
 	satisfiesFlavor := c.Only.Flavor == "" || c.Only.Flavor == flavor
 	return satisfiesArch && satisfiesFlavor

--- a/src/pkg/packager/creator/skeleton.go
+++ b/src/pkg/packager/creator/skeleton.go
@@ -48,13 +48,15 @@ func (sc *SkeletonCreator) LoadPackageDefinition(dst *layout.PackagePaths) (pkg 
 		return types.ZarfPackage{}, nil, err
 	}
 
-	pkg.Metadata.Architecture = zoci.SkeletonArch
+	pkg.Metadata.Architecture = config.GetArch()
 
 	// Compose components into a single zarf.yaml file
 	pkg, composeWarnings, err := ComposeComponents(pkg, sc.createOpts.Flavor)
 	if err != nil {
 		return types.ZarfPackage{}, nil, err
 	}
+
+	pkg.Metadata.Architecture = zoci.SkeletonArch
 
 	warnings = append(warnings, composeWarnings...)
 


### PR DESCRIPTION
## Description

Hotfixes skeleton publish. However, this breakage has revealed that the entire `skeleton` creation + publishing flow is flawed and requires an overhaul. Currently, while `skeleton` says it has an `arch` of `skeleton`, it is actually honoring the `--architecture` flag and resulting in a `skeleton` package that is single architecture. It is also not honoring `flavor`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

