### PR TITLE
fix: update deprecated syft packages command to syft scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,10 +219,11 @@ test-docs-and-schema:
 
 # INTERNAL: used to test for new CVEs that may have been introduced
 test-cves:
-	go run main.go tools sbom packages . -o json --exclude './docs-website' --exclude './examples' | grype --fail-on low
+	go run main.go tools sbom scan . -o json --exclude './docs-website' --exclude './examples' | grype --fail-on low
 
 cve-report: ## Create a CVE report for the current project (must `brew install grype` first)
-	go run main.go tools sbom packages . -o json --exclude './docs-website' --exclude './examples' | grype -o template -t hack/.templates/grype.tmpl > build/zarf-known-cves.csv
+	@test -d ./build || mkdir ./build
+	go run main.go tools sbom scan . -o json --exclude './docs-website' --exclude './examples' | grype -o template -t hack/.templates/grype.tmpl > build/zarf-known-cves.csv
 
 lint-go: ## Run revive to lint the go code (must `brew install revive` first)
 	revive -config revive.toml -exclude src/cmd/viper.go -formatter stylish ./src/...

--- a/docs/3-create-a-zarf-package/6-package-sboms.md
+++ b/docs/3-create-a-zarf-package/6-package-sboms.md
@@ -30,7 +30,7 @@ Given the Syft CLI is vendored into Zarf you can run these commands with the Zar
 
 ```bash
 # Syft is vendored as `zarf tools sbom`
-$ zarf tools sbom packages file:path/to/yourproject/file -o json > my-sbom.json
+$ zarf tools sbom scan file:path/to/yourproject/file -o json > my-sbom.json
 ```
 
 :::


### PR DESCRIPTION
## Description
`syft packages` was deprecated in favor of `syft scan` in `v0.100.0`

https://github.com/anchore/syft/pull/2446
https://github.com/anchore/syft/compare/v0.99.0...v0.100.0

<img width="1539" alt="deprecated" src="https://github.com/defenseunicorns/zarf/assets/87675701/0bc6fa1f-8397-482e-bd7d-3e3987355b48">

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
