### PR TITLE
fix: use default GITHUB_TOKEN for ossf/scorecard-action

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -31,7 +31,6 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
           publish_results: true
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF


### PR DESCRIPTION
## Description

Zarf's branch protection was switched to rulesets instead of classic branch protection (temporarily in evaluate mode). A PAT is no longer needed. See: https://github.com/ossf/scorecard-action#authentication-with-fine-grained-pat-optional

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
