### PR TITLE
fix: use env var for PR title in commitlint workflow to prevent untrusted script injection

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -24,4 +24,6 @@ jobs:
         run: npm install --save-dev @commitlint/{config-conventional,cli}
 
       - name: Lint PR title
-        run: echo "${{ github.event.pull_request.title }}" | npx commitlint
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | npx commitlint


### PR DESCRIPTION
## Description
Our OSSF scorecard workflow flagged this as a `Critical` security risk. Unsure of whether there is a real attack vector in our specific case. Using an environment variable to capture untrusted input in workflows is a documented security hardening best practice by GitHub as well.

This should also boost our OSSF scorecard score since we have a `0` on this check.

<img width="969" alt="image" src="https://github.com/defenseunicorns/zarf/assets/87675701/a07c699f-3601-44f2-b181-36f91f3637f8">

`Dangerous-Workflow` check:
- https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#dangerous-workflow

Risk of script injections:
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections

Example script injection attack:
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#example-of-a-script-injection-attack

Recommended fix that this PR implements:
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable

## Type of change
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
