### PR TITLE
feat: add option to skip cosign lookup during find images

### DIFF
--- a/docs/2-the-zarf-cli/100-cli-commands/zarf_dev_find-images.md
+++ b/docs/2-the-zarf-cli/100-cli-commands/zarf_dev_find-images.md
@@ -23,6 +23,7 @@ zarf dev find-images [ PACKAGE ] [flags]
       --kube-version string         Override the default helm template KubeVersion when performing a package chart template
       --registry-url string         Override the ###ZARF_REGISTRY### value (default "127.0.0.1:31999")
   -p, --repo-chart-path string      If git repos hold helm charts, often found with gitops tools, specify the chart path, e.g. "/" or "/chart"
+      --skip-cosign                 Skip searching for cosign artifacts related to discovered images
       --why string                  Prints the source manifest for the specified image
 ```
 

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -301,6 +301,8 @@ func init() {
 	devFindImagesCmd.Flags().StringVar(&pkgConfig.FindImagesOpts.KubeVersionOverride, "kube-version", "", lang.CmdDevFlagKubeVersion)
 	// check which manifests are using this particular image
 	devFindImagesCmd.Flags().StringVar(&pkgConfig.FindImagesOpts.Why, "why", "", lang.CmdDevFlagFindImagesWhy)
+	// skip searching cosign artifacts in find images
+	devFindImagesCmd.Flags().BoolVar(&pkgConfig.FindImagesOpts.SkipCosign, "skip-cosign", false, lang.CmdDevFlagFindImagesSkipCosign)
 
 	defaultRegistry := fmt.Sprintf("%s:%d", helpers.IPV4Localhost, types.ZarfInClusterContainerRegistryNodePort)
 	devFindImagesCmd.Flags().StringVar(&pkgConfig.FindImagesOpts.RegistryURL, "registry-url", defaultRegistry, lang.CmdDevFlagFindImagesRegistry)

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -385,13 +385,14 @@ $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a sk
 		"NOTE: This file must not already exist. If no filename is provided, the config will be written to the current working directory as zarf-config.toml."
 	CmdDevGenerateConfigErr = "Unable to write the config file %s, make sure the file doesn't already exist"
 
-	CmdDevFlagExtractPath        = `The path inside of an archive to use to calculate the sha256sum (i.e. for use with "files.extractPath")`
-	CmdDevFlagSet                = "Specify package variables to set on the command line (KEY=value). Note, if using a config file, this will be set by [package.create.set]."
-	CmdDevFlagRepoChartPath      = `If git repos hold helm charts, often found with gitops tools, specify the chart path, e.g. "/" or "/chart"`
-	CmdDevFlagGitAccount         = "User or organization name for the git account that the repos are created under."
-	CmdDevFlagKubeVersion        = "Override the default helm template KubeVersion when performing a package chart template"
-	CmdDevFlagFindImagesRegistry = "Override the ###ZARF_REGISTRY### value"
-	CmdDevFlagFindImagesWhy      = "Prints the source manifest for the specified image"
+	CmdDevFlagExtractPath          = `The path inside of an archive to use to calculate the sha256sum (i.e. for use with "files.extractPath")`
+	CmdDevFlagSet                  = "Specify package variables to set on the command line (KEY=value). Note, if using a config file, this will be set by [package.create.set]."
+	CmdDevFlagRepoChartPath        = `If git repos hold helm charts, often found with gitops tools, specify the chart path, e.g. "/" or "/chart"`
+	CmdDevFlagGitAccount           = "User or organization name for the git account that the repos are created under."
+	CmdDevFlagKubeVersion          = "Override the default helm template KubeVersion when performing a package chart template"
+	CmdDevFlagFindImagesRegistry   = "Override the ###ZARF_REGISTRY### value"
+	CmdDevFlagFindImagesWhy        = "Prints the source manifest for the specified image"
+	CmdDevFlagFindImagesSkipCosign = "Skip searching for cosign artifacts related to discovered images"
 
 	CmdDevLintShort = "Lints the given package for valid schema and recommended practices"
 	CmdDevLintLong  = "Verifies the package schema, checks if any variables won't be evaluated, and checks for unpinned images/repos/files"
@@ -477,7 +478,7 @@ $ zarf tools registry digest reg.example.com/stefanprodan/podinfo:6.4.0
 	CmdToolsGetGitPasswdShort       = "[Deprecated] Returns the push user's password for the Git server"
 	CmdToolsGetGitPasswdLong        = "[Deprecated] Reads the password for a user with push access to the configured Git server in Zarf State. Note that this command has been replaced by 'zarf tools get-creds git' and will be removed in Zarf v1.0.0."
 	CmdToolsGetGitPasswdDeprecation = "Deprecated: This command has been replaced by 'zarf tools get-creds git' and will be removed in Zarf v1.0.0."
-	CmdToolsYqExample = `
+	CmdToolsYqExample               = `
 # yq defaults to 'eval' command if no command is specified. See "zarf tools yq eval --help" for more examples.
 
 # read the "stuff" node from "myfile.yml"

--- a/src/types/runtime.go
+++ b/src/types/runtime.go
@@ -57,7 +57,8 @@ type ZarfFindImagesOptions struct {
 	RepoHelmChartPath   string `json:"repoHelmChartPath" jsonschema:"description=Path to the helm chart directory"`
 	KubeVersionOverride string `json:"kubeVersionOverride" jsonschema:"description=Kubernetes version to use for the helm chart"`
 	RegistryURL         string `json:"registryURL" jsonschema:"description=Manual override for ###ZARF_REGISTRY###"`
-	Why                 string `json:"why" jsonschema:"description=Find the location of the image given as an argument and print it to the console."`
+	Why                 string `json:"why" jsonschema:"description=Find the location of the image given as an argument and print it to the console"`
+	SkipCosign          bool   `json:"skip-cosign" jsonschema:"description=Optionally skip lookup of cosign artifacts when finding images"`
 }
 
 // ZarfDeployOptions tracks the user-defined preferences during a package deploy.


### PR DESCRIPTION
## Description

For larger packages it can take a long time to parse through the cosign lookups, having an option to not do this is nice for faster feedback cycles.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
