### PR TITLE
ci: pin k3s image version in k3d github action

### DIFF
--- a/.github/actions/k3d/action.yaml
+++ b/.github/actions/k3d/action.yaml
@@ -7,5 +7,5 @@ runs:
     - run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
       shell: bash
 
-    - run: k3d cluster delete && k3d cluster create --k3s-arg="--disable=traefik@server:0"
+    - run: k3d cluster delete && k3d cluster create --k3s-arg="--disable=traefik@server:0" --image="rancher/k3s:v1.28.4-k3s2"
       shell: bash


### PR DESCRIPTION
## Description
This PR pins the `k3s` image version used in our `k3d` action to the same version we use for the init package:

https://github.com/defenseunicorns/zarf/blob/02389274c61b59385ac339d6d690a148878427f9/packages/distros/k3s/zarf.yaml#L17

This is to workaround the containerd bug that tries to use HTTPS requests to pull images from Zarf's HTTP registry:

https://github.com/containerd/containerd/issues/10014

Related CI failures:

https://github.com/defenseunicorns/zarf/actions/runs/8621639619/job/23631060696?pr=2315
https://github.com/defenseunicorns/zarf/actions/runs/8619947296/job/23632023109?pr=2429

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
