### PR TITLE
fix: add redirect so old zarf base link is compatiable

### DIFF
--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -6,6 +6,9 @@ import remarkGemoji from "remark-gemoji";
 
 // https://astro.build/config
 export default defineConfig({
+  redirects: {
+    '/docs/zarf-overview': '/'
+  },
   markdown: {
     remarkPlugins: [remarkGemoji],
     rehypePlugins: [


### PR DESCRIPTION
## Description

fix: add redirect so old zarf base link is compatiable

## Related Issue

Fixes NA

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
