### PR TITLE
ci: pin third-party gh actions by hash

### DIFF
--- a/.github/workflows/publish-application-packages.yml
+++ b/.github/workflows/publish-application-packages.yml
@@ -23,7 +23,7 @@ jobs:
           ref: ${{ github.event.inputs.branchName }}
 
       - name: Install The Latest Release Version of Zarf
-        uses: defenseunicorns/setup-zarf@main
+        uses: defenseunicorns/setup-zarf@f95763914e20e493bb5d45d63e30e17138f981d6 # v1.0.0
 
       - name: "Login to GHCR"
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0

--- a/.github/workflows/scan-lint.yml
+++ b/.github/workflows/scan-lint.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Run Revive Action by pulling pre-built image
-        uses: docker://morphy/revive-action:v2
+        uses: docker://morphy/revive-action@sha256:087d4e61077087755711ab7e9fae3cc899b7bb07ff8f6a30c3dfb240b1620ae8 # v2.5.7
         with:
           config: revive.toml
           # Exclude patterns, separated by semicolons (optional)

--- a/.github/workflows/test-upgrade.yml
+++ b/.github/workflows/test-upgrade.yml
@@ -63,7 +63,7 @@ jobs:
           chmod +x build/zarf
 
       - name: Install release version of Zarf
-        uses: defenseunicorns/setup-zarf@main
+        uses: defenseunicorns/setup-zarf@f95763914e20e493bb5d45d63e30e17138f981d6 # v1.0.0
         with:
           download-init-package: true
 


### PR DESCRIPTION
## Description
Fixes the following warnings from our OSSF scorecard report:

<img width="1728" alt="scorecard" src="https://github.com/defenseunicorns/zarf/assets/87675701/e664e3ed-8a1c-4561-ad72-fa863680ec4c">

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
