### PR TITLE
fix: differential package create with non local sources

### DIFF
--- a/src/pkg/packager/creator/normal.go
+++ b/src/pkg/packager/creator/normal.go
@@ -48,14 +48,16 @@ type PackageCreator struct {
 	cfg *types.PackagerConfig
 }
 
+func localizeDifferentialPackagePath(path string, cwd string) string {
+	if path != "" && !filepath.IsAbs(path) && !helpers.IsURL(path) {
+		return filepath.Join(cwd, path)
+	}
+	return path
+}
+
 // NewPackageCreator returns a new PackageCreator.
 func NewPackageCreator(createOpts types.ZarfCreateOptions, cfg *types.PackagerConfig, cwd string) *PackageCreator {
-	if createOpts.DifferentialPackagePath != "" &&
-		!filepath.IsAbs(createOpts.DifferentialPackagePath) &&
-		!helpers.IsURL(createOpts.DifferentialPackagePath) {
-		createOpts.DifferentialPackagePath = filepath.Join(cwd, createOpts.DifferentialPackagePath)
-	}
-
+	createOpts.DifferentialPackagePath = localizeDifferentialPackagePath(createOpts.DifferentialPackagePath, cwd)
 	return &PackageCreator{createOpts, cfg}
 }
 

--- a/src/pkg/packager/creator/normal.go
+++ b/src/pkg/packager/creator/normal.go
@@ -50,7 +50,9 @@ type PackageCreator struct {
 
 // NewPackageCreator returns a new PackageCreator.
 func NewPackageCreator(createOpts types.ZarfCreateOptions, cfg *types.PackagerConfig, cwd string) *PackageCreator {
-	if createOpts.DifferentialPackagePath != "" && !filepath.IsAbs(createOpts.DifferentialPackagePath) {
+	if createOpts.DifferentialPackagePath != "" &&
+		!filepath.IsAbs(createOpts.DifferentialPackagePath) &&
+		!helpers.IsURL(createOpts.DifferentialPackagePath) {
 		createOpts.DifferentialPackagePath = filepath.Join(cwd, createOpts.DifferentialPackagePath)
 	}
 

--- a/src/pkg/packager/creator/normal.go
+++ b/src/pkg/packager/creator/normal.go
@@ -48,7 +48,7 @@ type PackageCreator struct {
 	cfg *types.PackagerConfig
 }
 
-func localizeDifferentialPackagePath(path string, cwd string) string {
+func updateRelativeDifferentialPackagePath(path string, cwd string) string {
 	if path != "" && !filepath.IsAbs(path) && !helpers.IsURL(path) {
 		return filepath.Join(cwd, path)
 	}
@@ -57,7 +57,7 @@ func localizeDifferentialPackagePath(path string, cwd string) string {
 
 // NewPackageCreator returns a new PackageCreator.
 func NewPackageCreator(createOpts types.ZarfCreateOptions, cfg *types.PackagerConfig, cwd string) *PackageCreator {
-	createOpts.DifferentialPackagePath = localizeDifferentialPackagePath(createOpts.DifferentialPackagePath, cwd)
+	createOpts.DifferentialPackagePath = updateRelativeDifferentialPackagePath(createOpts.DifferentialPackagePath, cwd)
 	return &PackageCreator{createOpts, cfg}
 }
 

--- a/src/pkg/packager/creator/normal_test.go
+++ b/src/pkg/packager/creator/normal_test.go
@@ -5,6 +5,7 @@
 package creator
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,35 +19,37 @@ func TestDifferentialPackagePathSetCorrectly(t *testing.T) {
 		expected string
 	}
 
+	absolutePackagePath, err := filepath.Abs(filepath.Join("home", "cool-guy", "zarf-package", "my-package.tar.zst"))
+	require.NoError(t, err)
+
 	testCases := []testCase{
 		{
 			name:     "relative path",
 			path:     "my-package.tar.zst",
-			cwd:      "/home/cool-guy/zarf-package",
-			expected: "/home/cool-guy/zarf-package/my-package.tar.zst",
+			cwd:      filepath.Join("home", "cool-guy", "zarf-package"),
+			expected: filepath.Join("home", "cool-guy", "zarf-package", "my-package.tar.zst"),
 		},
 		{
 			name:     "absolute path",
-			path:     "/home/cool-guy/zarf-package/my-package.tar.zst",
-			cwd:      "/home/cool-guy/zarf-package",
-			expected: "/home/cool-guy/zarf-package/my-package.tar.zst",
+			path:     absolutePackagePath,
+			cwd:      filepath.Join("home", "should-not-matter"),
+			expected: absolutePackagePath,
 		},
 		{
 			name:     "oci path",
 			path:     "oci://my-cool-registry.com:555/my-package.tar.zst",
-			cwd:      "/home/cool-guy/zarf-package",
+			cwd:      filepath.Join("home", "should-not-matter"),
 			expected: "oci://my-cool-registry.com:555/my-package.tar.zst",
 		},
 		{
 			name:     "https path",
 			path:     "https://neat-url.com/zarf-init-amd64-v1.0.0.tar.zst",
-			cwd:      "/home/cool-guy/zarf-package",
+			cwd:      filepath.Join("home", "should-not-matter"),
 			expected: "https://neat-url.com/zarf-init-amd64-v1.0.0.tar.zst",
 		},
 	}
 	for _, testCase := range testCases {
 		tc := testCase
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tc.expected, updateRelativeDifferentialPackagePath(tc.path, tc.cwd))

--- a/src/pkg/packager/creator/normal_test.go
+++ b/src/pkg/packager/creator/normal_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewImportChain(t *testing.T) {
+func TestDifferentialPackagePathSetCorrectly(t *testing.T) {
 	type testCase struct {
 		name     string
 		path     string
@@ -49,7 +49,7 @@ func TestNewImportChain(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tc.expected, localizeDifferentialPackagePath(tc.path, tc.cwd))
+			require.Equal(t, tc.expected, updateRelativeDifferentialPackagePath(tc.path, tc.cwd))
 		})
 	}
 }

--- a/src/pkg/packager/creator/normal_test.go
+++ b/src/pkg/packager/creator/normal_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+// Package creator contains functions for creating Zarf packages.
+package creator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewImportChain(t *testing.T) {
+	type testCase struct {
+		name     string
+		path     string
+		cwd      string
+		expected string
+	}
+
+	testCases := []testCase{
+		{
+			name:     "relative path",
+			path:     "my-package.tar.zst",
+			cwd:      "/home/cool-guy/zarf-package",
+			expected: "/home/cool-guy/zarf-package/my-package.tar.zst",
+		},
+		{
+			name:     "absolute path",
+			path:     "/home/cool-guy/zarf-package/my-package.tar.zst",
+			cwd:      "/home/cool-guy/zarf-package",
+			expected: "/home/cool-guy/zarf-package/my-package.tar.zst",
+		},
+		{
+			name:     "oci path",
+			path:     "oci://my-cool-registry.com:555/my-package.tar.zst",
+			cwd:      "/home/cool-guy/zarf-package",
+			expected: "oci://my-cool-registry.com:555/my-package.tar.zst",
+		},
+		{
+			name:     "https path",
+			path:     "https://neat-url.com/zarf-init-amd64-v1.0.0.tar.zst",
+			cwd:      "/home/cool-guy/zarf-package",
+			expected: "https://neat-url.com/zarf-init-amd64-v1.0.0.tar.zst",
+		},
+	}
+	for _, testCase := range testCases {
+		tc := testCase
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, localizeDifferentialPackagePath(tc.path, tc.cwd))
+		})
+	}
+}


### PR DESCRIPTION
## Description

Currently there is a bug wherein differential will only work if the source is a local file

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
