### PR TITLE
ci: remove unused env var from codeql workflow

### DIFF
--- a/.github/workflows/scan-codeql.yml
+++ b/.github/workflows/scan-codeql.yml
@@ -44,8 +44,6 @@ jobs:
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@e8893c57a1f3a2b659b6b55564fdfdbbd2982911 # v3.24.0
-        env:
-          CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql.yaml


### PR DESCRIPTION
## Description
https://github.com/defenseunicorns/zarf/actions/runs/8792153868/job/24127764767#step:6:65

> Warning: The CODEQL_EXTRACTOR_GO_BUILD_TRACING environment variable has no effect on workflows with manual build steps, so we recommend that you remove it from your workflow.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
