### PR TITLE
chore: exclude autogened files from pre-commit end of file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
           - "--allow-missing-credentials"
       - id: detect-private-key
       - id: end-of-file-fixer
+        exclude: site/src/content/docs/commands/.*
       - id: fix-byte-order-marker
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]


### PR DESCRIPTION
## Description

The auto generator we use adds an extra line to the end of the docs files which triggers pre-commit, lets exclude it