### PR TITLE
fix: adds GetVariableConfig function for packager

### DIFF
--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -153,6 +153,11 @@ func (p *Packager) ClearTempPaths() {
 	_ = os.RemoveAll(layout.SBOMDir)
 }
 
+// GetVariableConfig returns the variable configuration for the packager.
+func (p *Packager) GetVariableConfig() *variables.VariableConfig {
+	return p.variableConfig
+}
+
 // connectToCluster attempts to connect to a cluster if a connection is not already established
 func (p *Packager) connectToCluster(timeout time.Duration) (err error) {
 	if p.isConnectedToCluster() {


### PR DESCRIPTION
## Description

Makes Packager's variableConfig publicly accessible which in turns allows access to VariableConfig's setVariableMap which is currently being used by uds-cli for bundle deployment processing.

## Related Issue

Fixes #2472

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
