### PR TITLE
fix: update docker media type in registry

### DIFF
--- a/src/injector/src/main.rs
+++ b/src/injector/src/main.rs
@@ -17,7 +17,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use tar::Archive;
 
-const DOCKER_MIME_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
+const OCI_MIME_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
 
 // Reads the binary contents of a file
 fn get_file(path: &PathBuf) -> io::Result<Vec<u8>> {
@@ -140,7 +140,7 @@ fn handle_request(root: &Path, request: &Request) -> Response {
                 // on Content-Length, we respond the same as a GET
                 return accept!(
                     request,
-                    DOCKER_MIME_TYPE => {
+                    OCI_MIME_TYPE => {
                         handle_get_manifest(&root, &namespaced_name, &tag_or_digest)
                     },
                     "*/*" => Response::empty_406()
@@ -183,7 +183,7 @@ fn handle_get_manifest(root: &Path, name: &String, tag: &String) -> Response {
 
     if sha_manifest != "" {
         let file = File::open(&root.join("blobs").join("sha256").join(&sha_manifest)).unwrap();
-        Response::from_file(DOCKER_MIME_TYPE, file)
+        Response::from_file(OCI_MIME_TYPE, file)
             .with_additional_header(
                 "Docker-Content-Digest",
                 format!("sha256:{}", sha_manifest.to_owned()),

--- a/src/injector/src/main.rs
+++ b/src/injector/src/main.rs
@@ -17,7 +17,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use tar::Archive;
 
-const DOCKER_MIME_TYPE: &str = "application/vnd.docker.distribution.manifest.v2+json";
+const DOCKER_MIME_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
 
 // Reads the binary contents of a file
 fn get_file(path: &PathBuf) -> io::Result<Vec<u8>> {

--- a/zarf-config.toml
+++ b/zarf-config.toml
@@ -5,9 +5,9 @@ agent_image = 'defenseunicorns/zarf/agent'
 agent_image_tag = 'local'
 
 # Tag for the zarf injector binary to use
-injector_version = '2023-08-02'
-injector_amd64_shasum = '91de0768855ee2606a4f85a92bb480ff3a14ca205fd8d05eb397c18e15aa0247'
-injector_arm64_shasum = '663df681deea957b0ec53538eab221691a83de8e95d86b8a29008af711934bee'
+injector_version = '2024-05-03'
+injector_amd64_shasum = 'e5a3d380bac4bf6c68ba18275d6a92bb002e86c116eb364f960d393fd2f44da8'
+injector_arm64_shasum = 'f7f26e37a514f2ca36d795b7611d64491398a4bdc424e0045875af391dc28659'
 
 # The image reference to use for the registry that Zarf deploys into the cluster
 registry_image_domain = ''


### PR DESCRIPTION
## Description

Looks like the media type of the registry:2.8.3 has been changed from `application/vnd.docker.distribution.manifest.v2+json` to  `application/vnd.oci.image.manifest.v1+json`. This breaks minikube, hence the current pipeline fails, as it will do a check to make sure the mediatypes match, which they don't since they're hardcoded 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
