### PR TITLE
feat: inspect --list-images

### DIFF
--- a/site/src/content/docs/commands/zarf_package_inspect.md
+++ b/site/src/content/docs/commands/zarf_package_inspect.md
@@ -22,6 +22,7 @@ zarf package inspect [ PACKAGE_SOURCE ] [flags]
 
 ```
   -h, --help              help for inspect
+      --list-images       List images in the package (prints to stdout)
   -s, --sbom              View SBOM contents while inspecting the package
       --sbom-out string   Specify an output directory for the SBOMs from the inspected Zarf package
 ```

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -422,6 +422,7 @@ func bindInspectFlags(_ *viper.Viper) {
 	inspectFlags := packageInspectCmd.Flags()
 	inspectFlags.BoolVarP(&pkgConfig.InspectOpts.ViewSBOM, "sbom", "s", false, lang.CmdPackageInspectFlagSbom)
 	inspectFlags.StringVar(&pkgConfig.InspectOpts.SBOMOutputDir, "sbom-out", "", lang.CmdPackageInspectFlagSbomOut)
+	inspectFlags.BoolVar(&pkgConfig.InspectOpts.ListImages, "list-images", false, lang.CmdPackageInspectFlagListImages)
 }
 
 func bindRemoveFlags(v *viper.Viper) {

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -308,9 +308,10 @@ $ zarf package mirror-resources <your-package.tar.zst> \
 	CmdPackageMirrorFlagComponents = "Comma-separated list of components to mirror.  This list will be respected regardless of a component's 'required' or 'default' status.  Globbing component names with '*' and deselecting components with a leading '-' are also supported."
 	CmdPackageMirrorFlagNoChecksum = "Turns off the addition of a checksum to image tags (as would be used by the Zarf Agent) while mirroring images."
 
-	CmdPackageInspectFlagSbom    = "View SBOM contents while inspecting the package"
-	CmdPackageInspectFlagSbomOut = "Specify an output directory for the SBOMs from the inspected Zarf package"
-	CmdPackageInspectErr         = "Failed to inspect package: %s"
+	CmdPackageInspectFlagSbom       = "View SBOM contents while inspecting the package"
+	CmdPackageInspectFlagSbomOut    = "Specify an output directory for the SBOMs from the inspected Zarf package"
+	CmdPackageInspectFlagListImages = "List images in the package (prints to stdout)"
+	CmdPackageInspectErr            = "Failed to inspect package: %s"
 
 	CmdPackageRemoveShort          = "Removes a Zarf package that has been deployed already (runs offline)"
 	CmdPackageRemoveFlagConfirm    = "REQUIRED. Confirm the removal action to prevent accidental deletions"

--- a/src/pkg/packager/inspect.go
+++ b/src/pkg/packager/inspect.go
@@ -5,6 +5,10 @@
 package packager
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/defenseunicorns/pkg/helpers"
 	"github.com/defenseunicorns/zarf/src/internal/packager/sbom"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 )
@@ -18,7 +22,18 @@ func (p *Packager) Inspect() (err error) {
 		return err
 	}
 
-	utils.ColorPrintYAML(p.cfg.Pkg, nil, false)
+	if p.cfg.InspectOpts.ListImages {
+		imageList := []string{}
+		for _, component := range p.cfg.Pkg.Components {
+			imageList = append(imageList, component.Images...)
+		}
+		imageList = helpers.Unique(imageList)
+		for _, image := range imageList {
+			fmt.Fprintln(os.Stdout, "-", image)
+		}
+	} else {
+		utils.ColorPrintYAML(p.cfg.Pkg, nil, false)
+	}
 
 	sbomDir := p.layout.SBOMs.Path
 

--- a/src/test/e2e/06_create_sbom_test.go
+++ b/src/test/e2e/06_create_sbom_test.go
@@ -41,6 +41,10 @@ func TestCreateSBOM(t *testing.T) {
 	_, err = os.ReadFile(filepath.Join(sbomPath, "dos-games", "docker.io_defenseunicorns_zarf-game_multi-tile-dark.json"))
 	require.NoError(t, err)
 
+	stdOut, _, err = e2e.Zarf("package", "inspect", pkgName, "--list-images")
+	require.NoError(t, err)
+	require.Equal(t, "- defenseunicorns/zarf-game:multi-tile-dark\n", stdOut)
+
 	// Pull the current zarf binary version to find the corresponding init package
 	version, stdErr, err := e2e.Zarf("version")
 	require.NoError(t, err, version, stdErr)

--- a/src/types/runtime.go
+++ b/src/types/runtime.go
@@ -38,8 +38,12 @@ type ZarfPackageOptions struct {
 
 // ZarfInspectOptions tracks the user-defined preferences during a package inspection.
 type ZarfInspectOptions struct {
-	ViewSBOM      bool   `json:"sbom" jsonschema:"description=View SBOM contents while inspecting the package"`
-	SBOMOutputDir string `json:"sbomOutput" jsonschema:"description=Location to output an SBOM into after package inspection"`
+	// View SBOM contents while inspecting the package
+	ViewSBOM bool
+	// Location to output an SBOM into after package inspection
+	SBOMOutputDir string
+	// ListImages will list the images in the package
+	ListImages bool
 }
 
 // ZarfFindImagesOptions tracks the user-defined preferences during a prepare find-images search.


### PR DESCRIPTION
## Description

Adds `--list-images` to `zarf package inspect`.  Output is a YAML style list printed to STDOUT so it can be used with scripting.

## Related Issue

Fixes https://github.com/defenseunicorns/zarf/issues/2479

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
