### PR TITLE
chore: add a check for go mod tidy

### DIFF
--- a/.github/workflows/scan-go-mod-tidy.yml
+++ b/.github/workflows/scan-go-mod-tidy.yml
@@ -1,0 +1,26 @@
+name: Validate Go Mod Tidy
+on:
+  pull_request:
+    paths:
+      - "go.mod"
+      - "go.sum"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Setup golang
+        uses: ./.github/actions/golang
+
+      - name: Check go mod tidy
+        run: make test-go-mod-tidy
+
+      - name: Save logs
+        if: always()
+        uses: ./.github/actions/save-logs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,10 @@ repos:
         files: .go$
         language: system
         pass_filenames: true
+      - id: check-go-mod-tidy
+        name: Check for out of sync Go module dependencies
+        entry: make test-go-mod-tidy
+        language: system
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.14.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,10 @@ test-docs-and-schema:
 test-cves:
 	go run main.go tools sbom scan . -o json --exclude './site' --exclude './examples' | grype --fail-on low
 
+# INTERNAL: used to test that a dev has ran `go mod tidy` in their PR
+test-go-mod-tidy:
+	./hack/check-go-mod-tidy.sh
+
 cve-report: ## Create a CVE report for the current project (must `brew install grype` first)
 	@test -d ./build || mkdir ./build
 	go run main.go tools sbom scan . -o json --exclude './site' --exclude './examples' | grype -o template -t hack/grype.tmpl > build/zarf-known-cves.csv

--- a/hack/check-go-mod-tidy.sh
+++ b/hack/check-go-mod-tidy.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+go mod tidy
+if ! git diff --quiet go.mod go.sum; then
+  echo "ERROR: Changes detected after running 'go mod tidy'. Please run 'go mod tidy' and commit the changes."
+  exit 1
+fi


### PR DESCRIPTION
## Description
Adds a check in CI and `pre-commit` hooks to check if `go mod tidy` needs to be ran in a PR

This PR adds:
- shell script to check if `go mod tidy` needs to be ran in a PR
- `make` target to call the script
- workflow to run in CI
- `pre-commit` hook

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
