### PR TITLE
fix: use correct sha256 checksum for arm64 injector binary

### DIFF
--- a/zarf-config.toml
+++ b/zarf-config.toml
@@ -7,7 +7,7 @@ agent_image_tag = 'local'
 # Tag for the zarf injector binary to use
 injector_version = '2024-05-03'
 injector_amd64_shasum = 'e5a3d380bac4bf6c68ba18275d6a92bb002e86c116eb364f960d393fd2f44da8'
-injector_arm64_shasum = 'f7f26e37a514f2ca36d795b7611d64491398a4bdc424e0045875af391dc28659'
+injector_arm64_shasum = '866b5b1911dd920618be55164c4f95abe05753932ac6d0f2270d26e569d797a2'
 
 # The image reference to use for the registry that Zarf deploys into the cluster
 registry_image_domain = ''


### PR DESCRIPTION
## Description
From `main`:

```shell
zarf p create . -a arm64 --confirm
```

Output:
![injector-checksum](https://github.com/defenseunicorns/zarf/assets/87675701/b34e2398-f2fc-434f-a8e6-5614b6335258)

or

```shell
curl -sLO https://zarf-public.s3-us-gov-west-1.amazonaws.com/injector/2024-05-03/zarf-injector-arm64

sha256sum ./zarf-injector-arm64 
```

Output:

```shell
866b5b1911dd920618be55164c4f95abe05753932ac6d0f2270d26e569d797a2  ./zarf-injector-arm64
```

The checksum does not match what is in our `zarf-config.toml`:

https://github.com/defenseunicorns/zarf/blob/e69f3ab70aa248d7cb43eda1b920d196b79188b1/zarf-config.toml#L10

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
