### PR TITLE
refactor: enable ineffassign linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,7 @@ linters:
   enable:
     - gosimple
     - govet
+    - ineffassign
     - staticcheck
     - unused
     - revive

--- a/src/pkg/packager/filters/select.go
+++ b/src/pkg/packager/filters/select.go
@@ -26,26 +26,16 @@ type selectStateFilter struct {
 // Apply applies the filter.
 func (f *selectStateFilter) Apply(pkg types.ZarfPackage) ([]types.ZarfComponent, error) {
 	isPartial := len(f.requestedComponents) > 0 && f.requestedComponents[0] != ""
-
 	result := []types.ZarfComponent{}
-
 	for _, component := range pkg.Components {
-		selectState := unknown
-
+		selectState := included
 		if isPartial {
 			selectState, _ = includedOrExcluded(component.Name, f.requestedComponents)
-
-			if selectState == excluded {
-				continue
-			}
-		} else {
-			selectState = included
 		}
-
-		if selectState == included {
-			result = append(result, component)
+		if selectState != included {
+			continue
 		}
+		result = append(result, component)
 	}
-
 	return result, nil
 }


### PR DESCRIPTION
## Description

This change enables the ineffassign linter and fixes the only complaint by refactoring the select state filter.

## Related Issue

Part of #2503 
Depends on #2499 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
