### PR TITLE
refactor: enable errcheck linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,7 @@ run:
 linters:
   disable-all: true
   enable:
+    - errcheck
     - gosimple
     - govet
     - ineffassign
@@ -54,6 +55,12 @@ linters-settings:
       - name: redefines-builtin-id
   testifylint:
     enable-all: true
+  errcheck:
+    exclude-functions:
+      - (*github.com/spf13/cobra.Command).Help
+      - (*github.com/spf13/cobra.Command).MarkFlagRequired
+      - (*github.com/spf13/pflag.FlagSet).MarkHidden
+      - (*github.com/spf13/pflag.FlagSet).MarkDeprecated
 issues:
   # Revive rules that are disabled by default.
   include:

--- a/src/internal/agent/http/admission/handler.go
+++ b/src/internal/agent/http/admission/handler.go
@@ -87,6 +87,7 @@ func (h *Handler) Serve(hook operations.Hook) http.HandlerFunc {
 				return
 			}
 			w.WriteHeader(http.StatusInternalServerError)
+			//nolint:errcheck // ignore
 			w.Write(jsonResponse)
 			return
 		}
@@ -124,6 +125,7 @@ func (h *Handler) Serve(hook operations.Hook) http.HandlerFunc {
 
 		message.Infof(lang.AgentInfoWebhookAllowed, r.URL.Path, review.Request.Operation, result.Allowed)
 		w.WriteHeader(http.StatusOK)
+		//nolint: errcheck // ignore
 		w.Write(jsonResponse)
 	}
 }

--- a/src/internal/agent/http/proxy.go
+++ b/src/internal/agent/http/proxy.go
@@ -27,6 +27,7 @@ func ProxyHandler() http.HandlerFunc {
 		if err != nil {
 			message.Debugf("%#v", err)
 			w.WriteHeader(http.StatusInternalServerError)
+			//nolint: errcheck // ignore
 			w.Write([]byte(lang.AgentErrUnableTransform))
 			return
 		}

--- a/src/internal/agent/http/server.go
+++ b/src/internal/agent/http/server.go
@@ -68,6 +68,7 @@ func NewProxyServer(port string) *http.Server {
 func healthz() http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
+		//nolint: errcheck // ignore
 		w.Write([]byte("ok"))
 	}
 }

--- a/src/pkg/cluster/state_test.go
+++ b/src/pkg/cluster/state_test.go
@@ -150,6 +150,7 @@ func TestInitZarfState(t *testing.T) {
 							Name:      "default",
 						},
 					}
+					//nolint:errcheck // ignore
 					cs.CoreV1().ServiceAccounts(ns.Name).Create(ctx, sa, metav1.CreateOptions{})
 					break
 				}

--- a/src/pkg/cluster/zarf_test.go
+++ b/src/pkg/cluster/zarf_test.go
@@ -227,7 +227,8 @@ func TestGetDeployedPackage(t *testing.T) {
 				"data": b,
 			},
 		}
-		c.Clientset.CoreV1().Secrets("zarf").Create(ctx, &secret, metav1.CreateOptions{})
+		_, err = c.Clientset.CoreV1().Secrets("zarf").Create(ctx, &secret, metav1.CreateOptions{})
+		require.NoError(t, err)
 		actual, err := c.GetDeployedPackage(ctx, p.Name)
 		require.NoError(t, err)
 		require.Equal(t, p, *actual)
@@ -242,7 +243,8 @@ func TestGetDeployedPackage(t *testing.T) {
 			},
 		},
 	}
-	c.Clientset.CoreV1().Secrets("zarf").Create(ctx, &nonPackageSecret, metav1.CreateOptions{})
+	_, err := c.Clientset.CoreV1().Secrets("zarf").Create(ctx, &nonPackageSecret, metav1.CreateOptions{})
+	require.NoError(t, err)
 
 	actualList, err := c.GetDeployedZarfPackages(ctx)
 	require.NoError(t, err)

--- a/src/pkg/message/message.go
+++ b/src/pkg/message/message.go
@@ -319,6 +319,7 @@ func Table(header []string, data [][]string) {
 		table = append(table, pterm.TableData{row}...)
 	}
 
+	//nolint:errcheck // never returns an error
 	pterm.DefaultTable.WithHasHeader().WithData(table).Render()
 }
 

--- a/src/pkg/packager/lint/lint.go
+++ b/src/pkg/packager/lint/lint.go
@@ -152,6 +152,7 @@ func fillComponentTemplate(validator *Validator, node *composer.Node, createOpts
 	// [DEPRECATION] Set the Package Variable syntax as well for backward compatibility
 	setVarsAndWarn(types.ZarfPackageVariablePrefix, true)
 
+	//nolint: errcheck // This error should bubble up
 	utils.ReloadYamlTemplate(node, templateMap)
 }
 

--- a/src/pkg/packager/sources/new_test.go
+++ b/src/pkg/packager/sources/new_test.go
@@ -129,6 +129,7 @@ func TestPackageSource(t *testing.T) {
 			return
 		}
 		defer f.Close()
+		//nolint:errcheck // ignore
 		io.Copy(rw, f)
 	}))
 	t.Cleanup(func() { ts.Close() })

--- a/src/pkg/utils/network_test.go
+++ b/src/pkg/utils/network_test.go
@@ -83,6 +83,7 @@ func TestDownloadToFile(t *testing.T) {
 			rw.WriteHeader(http.StatusNotFound)
 			return
 		}
+		//nolint:errcheck // ignore
 		rw.Write([]byte(content))
 	}))
 	t.Cleanup(func() { srv.Close() })

--- a/src/pkg/variables/templates_test.go
+++ b/src/pkg/variables/templates_test.go
@@ -135,7 +135,8 @@ func TestReplaceTextTemplate(t *testing.T) {
 			f, _ := os.Create(tc.path)
 			defer f.Close()
 
-			f.WriteString(start)
+			_, err := f.WriteString(start)
+			require.NoError(t, err)
 		}
 
 		gotErr := tc.vc.ReplaceTextTemplate(tc.path)

--- a/src/pkg/zoci/push.go
+++ b/src/pkg/zoci/push.go
@@ -53,7 +53,10 @@ func (r *Remote) PublishPackage(ctx context.Context, pkg *types.ZarfPackage, pat
 
 	// assumes referrers API is not supported since OCI artifact
 	// media type is not supported
-	r.Repo().SetReferrersCapability(false)
+	err = r.Repo().SetReferrersCapability(false)
+	if err != nil {
+		return err
+	}
 
 	// push the manifest config
 	manifestConfigDesc, err := r.CreateAndPushManifestConfig(ctx, annotations, ZarfConfigMediaType)

--- a/src/test/nightly/ecr_publish_test.go
+++ b/src/test/nightly/ecr_publish_test.go
@@ -30,7 +30,8 @@ func TestECRPublishing(t *testing.T) {
 	t.Log("E2E: Testing component actions")
 
 	// Work from the root directory of the project
-	os.Chdir("../../../")
+	err := os.Chdir("../../../")
+	require.NoError(t, err)
 
 	// Create a tmpDir for us to use during this test
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Description

This change enables the errcheck linter which requires all returned errors to be checked.

## Related Issue

Part of #2503
Depends on #2499 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
