### PR TITLE
docs: add google analytics for docs pages

### DIFF
--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -28,7 +28,11 @@ export default defineConfig({
       head: [
         {
           tag: "script",
-          content: "(function(w,d,s,l,i){ ... })(window,document,'script','dataLayer','G-N1XZ8ZXCWL');",
+          content: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+          new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+          })(window,document,'script','dataLayer','G-N1XZ8ZXCWL');`,
         },
       ],
       components: {

--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -25,6 +25,15 @@ export default defineConfig({
   integrations: [
     starlight({
       title: "Zarf",
+      head: [
+        {
+          tag: "script",
+          content: "(function(w,d,s,l,i){ ... })(window,document,'script','dataLayer','G-N1XZ8ZXCWL');",
+        },
+      ],
+      components: {
+        SkipLink: "./src/components/SkipLink.astro",
+      },
       social: {
         github: "https://github.com/defenseunicorns/zarf",
         slack: "https://kubernetes.slack.com/archives/C03B6BJAUJ3",

--- a/site/src/components/SkipLink.astro
+++ b/site/src/components/SkipLink.astro
@@ -1,0 +1,18 @@
+---
+import type { Props } from '@astrojs/starlight/props'
+import Default from '@astrojs/starlight/components/SkipLink.astro'
+---
+
+<!-- Add the noscript tag for Google Tag Manager. -->
+<noscript>
+  <iframe
+    src="https://www.googletagmanager.com/gtag/js?id=G-N1XZ8ZXCWL"
+    height="0"
+    width="0"
+    style="display:none;visibility:hidden"
+  >
+  </iframe>
+</noscript>
+
+<!-- Render the default <SkipLink/> component. -->
+<Default {...Astro.props}><slot /></Default>


### PR DESCRIPTION
## Description

Add Google Analytics for docs pages

## Related Issue

Fixes n/a

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
