### PR TITLE
fix(release): do not delete testdata in release workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ destroy: ## Run `zarf destroy` on the current cluster
 	rm -fr build
 
 delete-packages: ## Delete all Zarf package tarballs in the project recursively
-	find . -type f -name 'zarf-package-*' -delete
+	find . -type f -name 'zarf-package-*' -not -path '*/testdata/*' -print -delete
 
 # Note: the path to the main.go file is not used due to https://github.com/golang/go/issues/51831#issuecomment-1074188363
 .PHONY: build


### PR DESCRIPTION
## Description
Fixes an issue where `make delete-packages` in the `cleanup-files` action of the release workflow deletes `src/pkg/packager/sources/testdata/zarf-package-wordpress-amd64-16.0.4.tar.zst`, causing `git` to be in a dirty state and the workflow to fail.

<img width="1322" alt="image" src="https://github.com/defenseunicorns/zarf/assets/87675701/c379fcb4-a299-4277-9075-d987355ea573">

https://github.com/defenseunicorns/zarf/actions/runs/9216112744/job/25356360304#step:11:92
