### PR TITLE
test: shutdown http test servers

### DIFF
--- a/src/pkg/packager/sources/new_test.go
+++ b/src/pkg/packager/sources/new_test.go
@@ -130,6 +130,7 @@ func TestPackageSource(t *testing.T) {
 		defer f.Close()
 		io.Copy(rw, f)
 	}))
+	defer ts.Close()
 
 	tests := []struct {
 		name   string

--- a/src/pkg/packager/sources/new_test.go
+++ b/src/pkg/packager/sources/new_test.go
@@ -130,7 +130,7 @@ func TestPackageSource(t *testing.T) {
 		defer f.Close()
 		io.Copy(rw, f)
 	}))
-	defer ts.Close()
+	t.Cleanup(func() { ts.Close() })
 
 	tests := []struct {
 		name   string

--- a/src/pkg/utils/network_test.go
+++ b/src/pkg/utils/network_test.go
@@ -85,6 +85,7 @@ func TestDownloadToFile(t *testing.T) {
 		}
 		rw.Write([]byte(content))
 	}))
+	defer srv.Close()
 
 	tests := []struct {
 		name        string

--- a/src/pkg/utils/network_test.go
+++ b/src/pkg/utils/network_test.go
@@ -85,7 +85,7 @@ func TestDownloadToFile(t *testing.T) {
 		}
 		rw.Write([]byte(content))
 	}))
-	defer srv.Close()
+	t.Cleanup(func() { srv.Close() })
 
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Description
Shutdown HTTP test servers with `Close()`

## Related Issue
Noticed we aren't shutting down HTTP test servers in a couple of our unit tests while working on #2558

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
