### PR TITLE
refactor: use root ctx in agent

### DIFF
--- a/src/internal/agent/http/server.go
+++ b/src/internal/agent/http/server.go
@@ -18,15 +18,13 @@ import (
 )
 
 // NewAdmissionServer creates a http.Server for the mutating webhook admission handler.
-func NewAdmissionServer(port string) *http.Server {
+func NewAdmissionServer(ctx context.Context, port string) *http.Server {
 	message.Debugf("http.NewAdmissionServer(%s)", port)
 
 	c, err := cluster.NewCluster()
 	if err != nil {
 		message.Fatalf(err, err.Error())
 	}
-
-	ctx := context.Background()
 
 	// Instances hooks
 	podsMutation := hooks.NewPodMutationHook(ctx, c)

--- a/src/internal/agent/start.go
+++ b/src/internal/agent/start.go
@@ -30,7 +30,7 @@ const (
 // StartWebhook launches the Zarf agent mutating webhook in the cluster.
 func StartWebhook(ctx context.Context) error {
 	message.Debug("agent.StartWebhook()")
-	return startServer(ctx, agentHttp.NewAdmissionServer(httpPort))
+	return startServer(ctx, agentHttp.NewAdmissionServer(ctx, httpPort))
 }
 
 // StartHTTPProxy launches the zarf agent proxy in the cluster.


### PR DESCRIPTION
## Description
Updates the agent to use ctx from the root

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
