### PR TITLE
chore: update go version to 1.22.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/defenseunicorns/zarf
 
-go 1.21.8
+go 1.22.4
 
 // TODO (@AABRO): Pending merge into github.com/gojsonschema/gojsonschema (https://github.com/gojsonschema/gojsonschema/pull/5)
 replace github.com/xeipuuv/gojsonschema => github.com/defenseunicorns/gojsonschema v0.0.0-20231116163348-e00f069122d6


### PR DESCRIPTION
## Description
Updates Go version to the latest stable version of `1.22`

https://go.dev/dl/