### PR TITLE
test: cleanup e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ publish-init-package:
 	$(ZARF_BIN) package publish . oci://$(REPOSITORY_URL)
 
 build-examples: ## Build all of the example packages
-	@test -s $(ZARF_BIN) || $(MAKE) build-cli
+	@test -s $(ZARF_BIN) || $(MAKE)
 
 	@test -s ./build/zarf-package-dos-games-$(ARCH)-1.0.0.tar.zst || $(ZARF_BIN) package create examples/dos-games -o build -a $(ARCH) --confirm
 

--- a/src/test/e2e/main_test.go
+++ b/src/test/e2e/main_test.go
@@ -5,9 +5,9 @@
 package test
 
 import (
-	"fmt"
+	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/defenseunicorns/zarf/src/config"
@@ -25,53 +25,25 @@ const (
 	skipK8sEnvVar           = "SKIP_K8S"
 )
 
-// TestMain lets us customize the test run. See https://medium.com/goingogo/why-use-testmain-for-testing-in-go-dafb52b406bc.
 func TestMain(m *testing.M) {
-	// Work from the root directory of the project
-	err := os.Chdir("../../../")
+	rootDir, err := filepath.Abs("../../../")
 	if err != nil {
-		fmt.Println(err) //nolint:forbidigo
+		log.Fatal(err)
+	}
+	if err := os.Chdir(rootDir); err != nil {
+		log.Fatal(err)
 	}
 
-	// K3d use the intern package, which requires this to be set in go 1.19
-	os.Setenv("ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH", "go1.19")
-
-	// Set the log level to trace for when we call Zarf functions internally
-	message.SetLogLevel(message.TraceLevel)
-
-	retCode, err := doAllTheThings(m)
-	if err != nil {
-		fmt.Println(err) //nolint:forbidigo
-	}
-
-	os.Exit(retCode)
-}
-
-// doAllTheThings just wraps what should go in TestMain. It's in its own function so it can
-// [a] Not have a bunch of `os.Exit()` calls in it
-// [b] Do defers properly
-// [c] Handle errors cleanly
-//
-// It returns the return code passed from `m.Run()` and any error thrown.
-func doAllTheThings(m *testing.M) (int, error) {
-	var err error
-
-	// Set up constants in the global variable that all the tests are able to access
 	e2e.Arch = config.GetArch()
-	e2e.ZarfBinPath = path.Join("build", test.GetCLIName())
+	e2e.ZarfBinPath = filepath.Join("build", test.GetCLIName())
 	e2e.ApplianceMode = os.Getenv(applianceModeEnvVar) == "true"
 	e2e.ApplianceModeKeep = os.Getenv(applianceModeKeepEnvVar) == "true"
 	e2e.RunClusterTests = os.Getenv(skipK8sEnvVar) != "true"
 
-	// Validate that the Zarf binary exists. If it doesn't that means the dev hasn't built it, usually by running
-	// `make build-cli`
-	_, err = os.Stat(e2e.ZarfBinPath)
-	if err != nil {
-		return 1, fmt.Errorf("zarf binary %s not found", e2e.ZarfBinPath)
+	message.SetLogLevel(message.TraceLevel)
+
+	if _, err := os.Stat(e2e.ZarfBinPath); err != nil {
+		log.Fatalf("zarf binary %s not found: %v", e2e.ZarfBinPath, err)
 	}
-
-	// Run the tests, with the cluster cleanup being deferred to the end of the function call
-	returnCode := m.Run()
-
-	return returnCode, nil
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
## Description
Simplify `TestMain` and update the `build-examples` make target to build only the binary for the local system.

## Related Issue

Relates to #2562

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
