### PR TITLE
fix: crane option argument parameters

### DIFF
--- a/src/cmd/tools/crane.go
+++ b/src/cmd/tools/crane.go
@@ -82,12 +82,12 @@ func init() {
 	craneCopy := craneCmd.NewCmdCopy(&craneOptions)
 
 	registryCmd.AddCommand(craneCopy)
-	registryCmd.AddCommand(zarfCraneCatalog(craneOptions))
-	registryCmd.AddCommand(zarfCraneInternalWrapper(craneCmd.NewCmdList, craneOptions, lang.CmdToolsRegistryListExample, 0))
-	registryCmd.AddCommand(zarfCraneInternalWrapper(craneCmd.NewCmdPush, craneOptions, lang.CmdToolsRegistryPushExample, 1))
-	registryCmd.AddCommand(zarfCraneInternalWrapper(craneCmd.NewCmdPull, craneOptions, lang.CmdToolsRegistryPullExample, 0))
-	registryCmd.AddCommand(zarfCraneInternalWrapper(craneCmd.NewCmdDelete, craneOptions, lang.CmdToolsRegistryDeleteExample, 0))
-	registryCmd.AddCommand(zarfCraneInternalWrapper(craneCmd.NewCmdDigest, craneOptions, lang.CmdToolsRegistryDigestExample, 0))
+	registryCmd.AddCommand(zarfCraneCatalog(&craneOptions))
+	registryCmd.AddCommand(zarfCraneInternalWrapper(craneCmd.NewCmdList, &craneOptions, lang.CmdToolsRegistryListExample, 0))
+	registryCmd.AddCommand(zarfCraneInternalWrapper(craneCmd.NewCmdPush, &craneOptions, lang.CmdToolsRegistryPushExample, 1))
+	registryCmd.AddCommand(zarfCraneInternalWrapper(craneCmd.NewCmdPull, &craneOptions, lang.CmdToolsRegistryPullExample, 0))
+	registryCmd.AddCommand(zarfCraneInternalWrapper(craneCmd.NewCmdDelete, &craneOptions, lang.CmdToolsRegistryDeleteExample, 0))
+	registryCmd.AddCommand(zarfCraneInternalWrapper(craneCmd.NewCmdDigest, &craneOptions, lang.CmdToolsRegistryDigestExample, 0))
 	registryCmd.AddCommand(pruneCmd)
 	registryCmd.AddCommand(craneCmd.NewCmdVersion())
 
@@ -100,8 +100,8 @@ func init() {
 }
 
 // Wrap the original crane catalog with a zarf specific version
-func zarfCraneCatalog(cranePlatformOptions []crane.Option) *cobra.Command {
-	craneCatalog := craneCmd.NewCmdCatalog(&cranePlatformOptions)
+func zarfCraneCatalog(cranePlatformOptions *[]crane.Option) *cobra.Command {
+	craneCatalog := craneCmd.NewCmdCatalog(cranePlatformOptions)
 
 	craneCatalog.Example = lang.CmdToolsRegistryCatalogExample
 	craneCatalog.Args = nil
@@ -134,7 +134,7 @@ func zarfCraneCatalog(cranePlatformOptions []crane.Option) *cobra.Command {
 
 		// Add the correct authentication to the crane command options
 		authOption := images.WithPullAuth(zarfState.RegistryInfo)
-		cranePlatformOptions = append(cranePlatformOptions, authOption)
+		*cranePlatformOptions = append(*cranePlatformOptions, authOption)
 
 		if tunnel != nil {
 			message.Notef(lang.CmdToolsRegistryTunnel, registryEndpoint, zarfState.RegistryInfo.Address)
@@ -149,8 +149,8 @@ func zarfCraneCatalog(cranePlatformOptions []crane.Option) *cobra.Command {
 }
 
 // Wrap the original crane list with a zarf specific version
-func zarfCraneInternalWrapper(commandToWrap func(*[]crane.Option) *cobra.Command, cranePlatformOptions []crane.Option, exampleText string, imageNameArgumentIndex int) *cobra.Command {
-	wrappedCommand := commandToWrap(&cranePlatformOptions)
+func zarfCraneInternalWrapper(commandToWrap func(*[]crane.Option) *cobra.Command, cranePlatformOptions *[]crane.Option, exampleText string, imageNameArgumentIndex int) *cobra.Command {
+	wrappedCommand := commandToWrap(cranePlatformOptions)
 
 	wrappedCommand.Example = exampleText
 	wrappedCommand.Args = nil
@@ -190,7 +190,7 @@ func zarfCraneInternalWrapper(commandToWrap func(*[]crane.Option) *cobra.Command
 
 		// Add the correct authentication to the crane command options
 		authOption := images.WithPushAuth(zarfState.RegistryInfo)
-		cranePlatformOptions = append(cranePlatformOptions, authOption)
+		*cranePlatformOptions = append(*cranePlatformOptions, authOption)
 
 		if tunnel != nil {
 			message.Notef(lang.CmdToolsRegistryTunnel, tunnel.Endpoint(), zarfState.RegistryInfo.Address)


### PR DESCRIPTION
## Description

During refactoring in #2460 we broke the option parameters for Crane. Honestly I am not surprised that this has happened. The way that these options are parsed and passed around are a threading mess. The issue is that this seems to also be the method in which Crane does it. This change reverts the specific pointer changes which caused the issue in the first place.

This is one the reasons why I do not like Cobra. The use of init functions and global variables are doomed to cause threading issues. Reminds me of writing Java programs with Spring Boot.

## Related Issue

Fixes #2571 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
