### PR TITLE
fix: pass image reference to syft sbom source object

### DIFF
--- a/src/internal/packager/sbom/catalog.go
+++ b/src/internal/packager/sbom/catalog.go
@@ -161,7 +161,7 @@ func (b *Builder) createImageSBOM(img v1.Image, src string) ([]byte, error) {
 		return nil, err
 	}
 
-	syftSource, err := source.NewFromStereoscopeImageObject(syftImage, "", nil)
+	syftSource, err := source.NewFromStereoscopeImageObject(syftImage, refInfo.Reference, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
When creating an image SBOM with syft, we currently pass an empty string `""` to `NewFromStereoscopeImageObject` when creating a new image source object.

```go
source.NewFromStereoscopeImageObject(syftImage, "", nil)
```
The second argument is the image reference. This data is ultimately used to populate the source metadata in the final SBOM, but since we pass an empty string, the `userInput` field is empty.

The fix is to pass in the image reference so that the `userInput` field is populated in the final SBOM.

```go
source.NewFromStereoscopeImageObject(syftImage, ref, nil)
```

Steps to reproduce:

1. Create this package

    ```yaml
    kind: ZarfPackageConfig
    metadata:
      name: sbom-test
      architecture: amd64
    components:
      - name: sbom-test
        required: true
        images:
          - quay.io/minio/minio:RELEASE.2024-03-21T23-13-43Z
    ```

1. Extract the package

    ```shell
    zarf tools archiver decompress zarf-package-sbom-test-amd64.tar.zst sbom
    ```

1. Extract the sbom tarball

    ```shell
    zarf tools archiver decompress sbom/sboms.tar sbom/syft 
    ```
1. Check the `.source.metadata.userInput` field in the image SBOM

    ```shell
    cat sbom/syft/quay.io_minio_minio_RELEASE.2024-03-21T23-13-43Z.json | jq .source.metadata.userInput
    ```
    
    With current Zarf, you will see that it returns an empty string. Re-run all of the above steps with Zarf built from this PR branch, and you will see it returns the image reference `quay.io/minio/minio:RELEASE.2024-03-21T23-13-43Z`
    
1. Generate a vulnerability scan report with `grype`

    ```shell
    cat sbom/syft/quay.io_minio_minio_RELEASE.2024-03-21T23-13-43Z.json | grype -o sarif > zarf-scan.json 
    ```
    
    You will see that the generated report is missing the image reference in the output
    
    `"text": "A medium vulnerability in go-module package: gopkg.in/square/go-jose.v2, version v2.6.0 was found in image  at: /usr/bin/minio"`
    
    Re-run all of the above steps with Zarf built from this PR branch, and you will see the image reference in the generated report:
    
    `"text": "A medium vulnerability in go-module package: gopkg.in/square/go-jose.v2, version v2.6.0 was found in image quay.io/minio/minio:RELEASE.2024-03-21T23-13-43Z at: /usr/bin/minio"`

## Related Issue

Fixes #2608

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
