### PR TITLE
fix: delete injector pod immediately

### DIFF
--- a/src/pkg/cluster/injector.go
+++ b/src/pkg/cluster/injector.go
@@ -153,7 +153,13 @@ func (c *Cluster) StartInjectionMadness(ctx context.Context, tmpDir string, imag
 // StopInjectionMadness handles cleanup once the seed registry is up.
 func (c *Cluster) StopInjectionMadness(ctx context.Context) error {
 	// Try to kill the injector pod now
-	err := c.Clientset.CoreV1().Pods(ZarfNamespaceName).Delete(ctx, "injector", metav1.DeleteOptions{})
+	deleteGracePeriod := int64(0)
+	deletePolicy := metav1.DeletePropagationForeground
+	deleteOpts := metav1.DeleteOptions{
+		GracePeriodSeconds: &deleteGracePeriod,
+		PropagationPolicy:  &deletePolicy,
+	}
+	err := c.Clientset.CoreV1().Pods(ZarfNamespaceName).Delete(ctx, "injector", deleteOpts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
This PR adds back the behavior of deleting the injector pod immediately in `StopInjectionMadness` with no grace period before deletion. This was removed in [2553](https://github.com/defenseunicorns/zarf/pull/2553/files#diff-ce8c8d39489a071f6e62ecb731b08598f9a180bf773d2c216f67cb55a01497abL149) but it has lead to failures in our upgrade test because there are times when the injector pod from the initial `zarf init` in the test still exists in a `terminating` state, and it fails when we try to create the injector pod on the second "upgrade" `zarf init` because the pod already exists.

https://github.com/defenseunicorns/zarf/actions/runs/9470798079/job/26092606648?pr=2612#step:10:2776
