### PR TITLE
fix: remove unpinned image warning in lint for cosign signatures

### DIFF
--- a/src/pkg/packager/lint/lint.go
+++ b/src/pkg/packager/lint/lint.go
@@ -64,7 +64,6 @@ func lintComponents(ctx context.Context, pkg types.ZarfPackage, createOpts types
 		}
 
 		chain, err := composer.NewImportChain(ctx, component, i, pkg.Metadata.Name, arch, createOpts.Flavor)
-
 		if err != nil {
 			return nil, err
 		}
@@ -144,7 +143,7 @@ func isPinnedImage(image string) (bool, error) {
 		}
 		return false, err
 	}
-	if isCosignSignature(transformedImage.Tag) {
+	if isCosignSignature(transformedImage.Tag) || isCosignAttestation(transformedImage.Tag) {
 		return true, nil
 	}
 	return (transformedImage.Digest != ""), err
@@ -152,6 +151,10 @@ func isPinnedImage(image string) (bool, error) {
 
 func isCosignSignature(image string) bool {
 	return (strings.HasSuffix(image, ".sig"))
+}
+
+func isCosignAttestation(image string) bool {
+	return (strings.HasSuffix(image, ".att"))
 }
 
 func isPinnedRepo(repo string) bool {

--- a/src/pkg/packager/lint/lint.go
+++ b/src/pkg/packager/lint/lint.go
@@ -150,11 +150,11 @@ func isPinnedImage(image string) (bool, error) {
 }
 
 func isCosignSignature(image string) bool {
-	return (strings.HasSuffix(image, ".sig"))
+	return strings.HasSuffix(image, ".sig")
 }
 
 func isCosignAttestation(image string) bool {
-	return (strings.HasSuffix(image, ".att"))
+	return strings.HasSuffix(image, ".att")
 }
 
 func isPinnedRepo(repo string) bool {

--- a/src/pkg/packager/lint/lint.go
+++ b/src/pkg/packager/lint/lint.go
@@ -144,7 +144,14 @@ func isPinnedImage(image string) (bool, error) {
 		}
 		return false, err
 	}
+	if isCosignSignature(transformedImage.Tag) {
+		return true, nil
+	}
 	return (transformedImage.Digest != ""), err
+}
+
+func isCosignSignature(image string) bool {
+	return (strings.HasSuffix(image, ".sig"))
 }
 
 func isPinnedRepo(repo string) bool {

--- a/src/pkg/packager/lint/lint_test.go
+++ b/src/pkg/packager/lint/lint_test.go
@@ -217,12 +217,12 @@ func TestValidateComponent(t *testing.T) {
 		t.Parallel()
 		unpinnedImage := "registry.com:9001/whatever/image:1.0.0"
 		badImage := "badimage:badimage@@sha256:3fbc632167424a6d997e74f5"
-		cosignedImage := "ghcr.io/stefanprodan/podinfo:sha256-57a654ace69ec02ba8973093b6a786faa15640575fbf0dbb603db55aca2ccec8.sig"
+		cosignSignature := "ghcr.io/stefanprodan/podinfo:sha256-57a654ace69ec02ba8973093b6a786faa15640575fbf0dbb603db55aca2ccec8.sig"
 		component := types.ZarfComponent{Images: []string{
 			unpinnedImage,
 			"busybox:latest@sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79",
 			badImage,
-			cosignedImage,
+			cosignSignature,
 		}}
 		findings := checkForUnpinnedImages(component, 0)
 		expected := []types.PackageFinding{

--- a/src/pkg/packager/lint/lint_test.go
+++ b/src/pkg/packager/lint/lint_test.go
@@ -218,11 +218,13 @@ func TestValidateComponent(t *testing.T) {
 		unpinnedImage := "registry.com:9001/whatever/image:1.0.0"
 		badImage := "badimage:badimage@@sha256:3fbc632167424a6d997e74f5"
 		cosignSignature := "ghcr.io/stefanprodan/podinfo:sha256-57a654ace69ec02ba8973093b6a786faa15640575fbf0dbb603db55aca2ccec8.sig"
+		cosignAttestation := "ghcr.io/stefanprodan/podinfo:sha256-57a654ace69ec02ba8973093b6a786faa15640575fbf0dbb603db55aca2ccec8.att"
 		component := types.ZarfComponent{Images: []string{
 			unpinnedImage,
 			"busybox:latest@sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79",
 			badImage,
 			cosignSignature,
+			cosignAttestation,
 		}}
 		findings := checkForUnpinnedImages(component, 0)
 		expected := []types.PackageFinding{
@@ -337,6 +339,11 @@ func TestValidateComponent(t *testing.T) {
 			},
 			{
 				input:    "ghcr.io/stefanprodan/podinfo:sha256-57a654ace69ec02ba8973093b6a786faa15640575fbf0dbb603db55aca2ccec8.sig",
+				expected: true,
+				err:      nil,
+			},
+			{
+				input:    "ghcr.io/stefanprodan/podinfo:sha256-57a654ace69ec02ba8973093b6a786faa15640575fbf0dbb603db55aca2ccec8.att",
 				expected: true,
 				err:      nil,
 			},

--- a/src/pkg/packager/lint/lint_test.go
+++ b/src/pkg/packager/lint/lint_test.go
@@ -217,10 +217,12 @@ func TestValidateComponent(t *testing.T) {
 		t.Parallel()
 		unpinnedImage := "registry.com:9001/whatever/image:1.0.0"
 		badImage := "badimage:badimage@@sha256:3fbc632167424a6d997e74f5"
+		cosignedImage := "ghcr.io/stefanprodan/podinfo:sha256-57a654ace69ec02ba8973093b6a786faa15640575fbf0dbb603db55aca2ccec8.sig"
 		component := types.ZarfComponent{Images: []string{
 			unpinnedImage,
 			"busybox:latest@sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79",
 			badImage,
+			cosignedImage,
 		}}
 		findings := checkForUnpinnedImages(component, 0)
 		expected := []types.PackageFinding{
@@ -330,6 +332,11 @@ func TestValidateComponent(t *testing.T) {
 			},
 			{
 				input:    "busybox:###ZARF_PKG_TMPL_BUSYBOX_IMAGE###",
+				expected: true,
+				err:      nil,
+			},
+			{
+				input:    "ghcr.io/stefanprodan/podinfo:sha256-57a654ace69ec02ba8973093b6a786faa15640575fbf0dbb603db55aca2ccec8.sig",
 				expected: true,
 				err:      nil,
 			},


### PR DESCRIPTION
## Description
Removes unpinned image warning generated by `zarf dev lint` for cosign signatures.
...

## Related Issue

Fixes #2577 

## Checklist before merging

- [ x ] Test, docs, adr added or updated as needed
- [ x ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
