### PR TITLE
refactor: packager options to function arguments

### DIFF
--- a/src/pkg/packager/creator/creator_test.go
+++ b/src/pkg/packager/creator/creator_test.go
@@ -38,13 +38,13 @@ func TestLoadPackageDefinition(t *testing.T) {
 			name:        "valid package definition",
 			testDir:     "valid",
 			expectedErr: "",
-			creator:     NewSkeletonCreator(types.ZarfCreateOptions{}, types.ZarfPublishOptions{}),
+			creator:     NewSkeletonCreator(types.ZarfCreateOptions{}, "", ""),
 		},
 		{
 			name:        "invalid package definition",
 			testDir:     "invalid",
 			expectedErr: "package must have at least 1 component",
-			creator:     NewSkeletonCreator(types.ZarfCreateOptions{}, types.ZarfPublishOptions{}),
+			creator:     NewSkeletonCreator(types.ZarfCreateOptions{}, "", ""),
 		},
 	}
 

--- a/src/pkg/packager/creator/skeleton.go
+++ b/src/pkg/packager/creator/skeleton.go
@@ -33,13 +33,18 @@ var (
 
 // SkeletonCreator provides methods for creating skeleton Zarf packages.
 type SkeletonCreator struct {
-	createOpts  types.ZarfCreateOptions
-	publishOpts types.ZarfPublishOptions
+	createOpts         types.ZarfCreateOptions
+	signingKeyPath     string
+	signingKeyPassword string
 }
 
 // NewSkeletonCreator returns a new SkeletonCreator.
-func NewSkeletonCreator(createOpts types.ZarfCreateOptions, publishOpts types.ZarfPublishOptions) *SkeletonCreator {
-	return &SkeletonCreator{createOpts, publishOpts}
+func NewSkeletonCreator(createOpts types.ZarfCreateOptions, signingKeyPath, signingKeyPassword string) *SkeletonCreator {
+	return &SkeletonCreator{
+		createOpts:         createOpts,
+		signingKeyPath:     signingKeyPath,
+		signingKeyPassword: signingKeyPassword,
+	}
 }
 
 // LoadPackageDefinition loads and configure a zarf.yaml file when creating and publishing a skeleton package.
@@ -122,7 +127,7 @@ func (sc *SkeletonCreator) Output(_ context.Context, dst *layout.PackagePaths, p
 		return fmt.Errorf("unable to write zarf.yaml: %w", err)
 	}
 
-	return dst.SignPackage(sc.publishOpts.SigningKeyPath, sc.publishOpts.SigningKeyPassword, !config.CommonOptions.Confirm)
+	return dst.SignPackage(sc.signingKeyPath, sc.signingKeyPassword, !config.CommonOptions.Confirm)
 }
 
 func (sc *SkeletonCreator) processExtensions(components []types.ZarfComponent, layout *layout.PackagePaths) (processedComponents []types.ZarfComponent, err error) {

--- a/src/pkg/packager/inspect.go
+++ b/src/pkg/packager/inspect.go
@@ -15,15 +15,15 @@ import (
 )
 
 // Inspect list the contents of a package.
-func (p *Packager) Inspect(ctx context.Context) (err error) {
-	wantSBOM := p.cfg.InspectOpts.ViewSBOM || p.cfg.InspectOpts.SBOMOutputDir != ""
+func (p *Packager) Inspect(ctx context.Context, viewSBOM bool, sbomOutputDir string, listImages bool) (err error) {
+	wantSBOM := viewSBOM || sbomOutputDir != ""
 
 	p.cfg.Pkg, p.warnings, err = p.source.LoadPackageMetadata(ctx, p.layout, wantSBOM, true)
 	if err != nil {
 		return err
 	}
 
-	if p.cfg.InspectOpts.ListImages {
+	if listImages {
 		imageList := []string{}
 		for _, component := range p.cfg.Pkg.Components {
 			imageList = append(imageList, component.Images...)
@@ -38,15 +38,15 @@ func (p *Packager) Inspect(ctx context.Context) (err error) {
 
 	sbomDir := p.layout.SBOMs.Path
 
-	if p.cfg.InspectOpts.SBOMOutputDir != "" {
-		out, err := p.layout.SBOMs.OutputSBOMFiles(p.cfg.InspectOpts.SBOMOutputDir, p.cfg.Pkg.Metadata.Name)
+	if sbomOutputDir != "" {
+		out, err := p.layout.SBOMs.OutputSBOMFiles(sbomOutputDir, p.cfg.Pkg.Metadata.Name)
 		if err != nil {
 			return err
 		}
 		sbomDir = out
 	}
 
-	if p.cfg.InspectOpts.ViewSBOM {
+	if viewSBOM {
 		sbom.ViewSBOMFiles(sbomDir)
 	}
 

--- a/src/pkg/packager/mirror.go
+++ b/src/pkg/packager/mirror.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Mirror pulls resources from a package (images, git repositories, etc) and pushes them to remotes in the air gap without deploying them
-func (p *Packager) Mirror(ctx context.Context) (err error) {
+func (p *Packager) Mirror(ctx context.Context, noImgChecksum bool) (err error) {
 	filter := filters.Combine(
 		filters.ByLocalOS(runtime.GOOS),
 		filters.BySelectState(p.cfg.PkgOpts.OptionalComponents),
@@ -47,7 +47,7 @@ func (p *Packager) Mirror(ctx context.Context) (err error) {
 	}
 
 	for _, component := range p.cfg.Pkg.Components {
-		if err := p.mirrorComponent(ctx, component); err != nil {
+		if err := p.mirrorComponent(ctx, component, noImgChecksum); err != nil {
 			return err
 		}
 	}
@@ -55,7 +55,7 @@ func (p *Packager) Mirror(ctx context.Context) (err error) {
 }
 
 // mirrorComponent mirrors a Zarf Component.
-func (p *Packager) mirrorComponent(ctx context.Context, component types.ZarfComponent) error {
+func (p *Packager) mirrorComponent(ctx context.Context, component types.ZarfComponent, noImgChecksum bool) error {
 	componentPaths := p.layout.Components.Dirs[component.Name]
 
 	// All components now require a name
@@ -65,7 +65,7 @@ func (p *Packager) mirrorComponent(ctx context.Context, component types.ZarfComp
 	hasRepos := len(component.Repos) > 0
 
 	if hasImages {
-		if err := p.pushImagesToRegistry(ctx, component.Images, p.cfg.MirrorOpts.NoImgChecksum); err != nil {
+		if err := p.pushImagesToRegistry(ctx, component.Images, noImgChecksum); err != nil {
 			return fmt.Errorf("unable to push images to the registry: %w", err)
 		}
 	}

--- a/src/pkg/packager/pull.go
+++ b/src/pkg/packager/pull.go
@@ -6,19 +6,13 @@ package packager
 
 import (
 	"context"
-	"fmt"
 )
 
 // Pull pulls a Zarf package and saves it as a compressed tarball.
-func (p *Packager) Pull(ctx context.Context) (err error) {
-	if p.cfg.PkgOpts.OptionalComponents != "" {
-		return fmt.Errorf("pull does not support optional components")
-	}
-
-	_, err = p.source.Collect(ctx, p.cfg.PullOpts.OutputDirectory)
+func (p *Packager) Pull(ctx context.Context, outputDir string) (err error) {
+	_, err = p.source.Collect(ctx, outputDir)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }

--- a/src/types/packager.go
+++ b/src/types/packager.go
@@ -12,29 +12,8 @@ type PackagerConfig struct {
 	// PkgOpts tracks user-defined options
 	PkgOpts ZarfPackageOptions
 
-	// DeployOpts tracks user-defined values for the active deployment
-	DeployOpts ZarfDeployOptions
-
-	// MirrorOpts tracks user-defined values for the active mirror
-	MirrorOpts ZarfMirrorOptions
-
 	// InitOpts tracks user-defined values for the active Zarf initialization.
 	InitOpts ZarfInitOptions
-
-	// InspectOpts tracks user-defined options used to inspect the package
-	InspectOpts ZarfInspectOptions
-
-	// PublishOpts tracks user-defined options used to publish the package
-	PublishOpts ZarfPublishOptions
-
-	// PullOpts tracks user-defined options used to pull packages
-	PullOpts ZarfPullOptions
-
-	// FindImagesOpts tracks user-defined options used to find images
-	FindImagesOpts ZarfFindImagesOptions
-
-	// GenerateOpts tracks user-defined values for package generation.
-	GenerateOpts ZarfGenerateOptions
 
 	// The package data
 	Pkg ZarfPackage

--- a/src/types/runtime.go
+++ b/src/types/runtime.go
@@ -36,16 +36,6 @@ type ZarfPackageOptions struct {
 	Retries            int               `json:"retries" jsonschema:"description=The number of retries to perform for Zarf deploy operations like image pushes or Helm installs"`
 }
 
-// ZarfInspectOptions tracks the user-defined preferences during a package inspection.
-type ZarfInspectOptions struct {
-	// View SBOM contents while inspecting the package
-	ViewSBOM bool
-	// Location to output an SBOM into after package inspection
-	SBOMOutputDir string
-	// ListImages will list the images in the package
-	ListImages bool
-}
-
 // ZarfFindImagesOptions tracks the user-defined preferences during a prepare find-images search.
 type ZarfFindImagesOptions struct {
 	RepoHelmChartPath   string `json:"repoHelmChartPath" jsonschema:"description=Path to the helm chart directory"`
@@ -63,32 +53,6 @@ type ZarfDeployOptions struct {
 
 	// TODO (@WSTARR): This is a library only addition to Zarf and should be refactored in the future (potentially to utilize component composability). As is it should NOT be exposed directly on the CLI
 	ValuesOverridesMap map[string]map[string]map[string]interface{} `json:"valuesOverridesMap" jsonschema:"description=[Library Only] A map of component names to chart names containing Helm Chart values to override values on deploy"`
-}
-
-// ZarfMirrorOptions tracks the user-defined preferences during a package mirror.
-type ZarfMirrorOptions struct {
-	NoImgChecksum bool `json:"noImgChecksum" jsonschema:"description=Whether to skip adding a Zarf checksum to image references."`
-}
-
-// ZarfPublishOptions tracks the user-defined preferences during a package publish.
-type ZarfPublishOptions struct {
-	PackageDestination string `json:"packageDestination" jsonschema:"description=Location where the Zarf package will be published to"`
-	SigningKeyPassword string `json:"signingKeyPassword" jsonschema:"description=Password to the private key signature file that will be used to sign the published package"`
-	SigningKeyPath     string `json:"signingKeyPath" jsonschema:"description=Location where the private key component of a cosign key-pair can be found"`
-}
-
-// ZarfPullOptions tracks the user-defined preferences during a package pull.
-type ZarfPullOptions struct {
-	OutputDirectory string `json:"outputDirectory" jsonschema:"description=Location where the pulled Zarf package will be placed"`
-}
-
-// ZarfGenerateOptions tracks the user-defined options during package generation.
-type ZarfGenerateOptions struct {
-	Name    string `json:"name" jsonschema:"description=Name of the package being generated"`
-	URL     string `json:"url" jsonschema:"description=URL to the source git repository"`
-	Version string `json:"version" jsonschema:"description=Version of the chart to use"`
-	GitPath string `json:"gitPath" jsonschema:"description=Relative path to the chart in the git repository"`
-	Output  string `json:"output" jsonschema:"description=Location where the finalized zarf.yaml will be placed"`
 }
 
 // ZarfInitOptions tracks the user-defined options during cluster initialization.


### PR DESCRIPTION
## Description

This change refactors the pacakger to remove the use of struct properties instead of function arguments. This work is required to be able to easily remove the use of os.Chdir from packager.

## Related Issue

Relates to #2683
Part of #2694 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
