### PR TITLE
refactor: remove sbom view files property from packager

### DIFF
--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -37,7 +37,6 @@ type Packager struct {
 	layout         *layout.PackagePaths
 	hpaModified    bool
 	connectStrings types.ConnectStrings
-	sbomViewFiles  []string
 	source         sources.PackageSource
 	generation     int
 }

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -41,7 +41,7 @@ func (p *Packager) Create(ctx context.Context) error {
 	}
 	p.cfg.Pkg = pkg
 
-	if !p.confirmAction(config.ZarfCreateStage, warnings) {
+	if !p.confirmAction(config.ZarfCreateStage, warnings, nil) {
 		return fmt.Errorf("package creation canceled")
 	}
 

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -86,11 +86,10 @@ func (p *Packager) Deploy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	p.sbomViewFiles = sbomViewFiles
 	warnings = append(warnings, sbomWarnings...)
 
 	// Confirm the overall package deployment
-	if !p.confirmAction(config.ZarfDeployStage, warnings) {
+	if !p.confirmAction(config.ZarfDeployStage, warnings, sbomViewFiles) {
 		return fmt.Errorf("deployment cancelled")
 	}
 

--- a/src/pkg/packager/interactive.go
+++ b/src/pkg/packager/interactive.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pterm/pterm"
 )
 
-func (p *Packager) confirmAction(stage string, warnings []string) (confirm bool) {
+func (p *Packager) confirmAction(stage string, warnings []string, sbomViewFiles []string) (confirm bool) {
 	pterm.Println()
 	message.HeaderInfof("📦 PACKAGE DEFINITION")
 	utils.ColorPrintYAML(p.cfg.Pkg, p.getPackageYAMLHints(stage), true)
@@ -30,14 +30,14 @@ func (p *Packager) confirmAction(stage string, warnings []string) (confirm bool)
 			message.HorizontalRule()
 			message.Title("Software Bill of Materials", "an inventory of all software contained in this package")
 
-			if len(p.sbomViewFiles) > 0 {
+			if len(sbomViewFiles) > 0 {
 				cwd, _ := os.Getwd()
-				link := pterm.FgLightCyan.Sprint(pterm.Bold.Sprint(filepath.Join(cwd, layout.SBOMDir, filepath.Base(p.sbomViewFiles[0]))))
+				link := pterm.FgLightCyan.Sprint(pterm.Bold.Sprint(filepath.Join(cwd, layout.SBOMDir, filepath.Base(sbomViewFiles[0]))))
 				inspect := pterm.BgBlack.Sprint(pterm.FgWhite.Sprint(pterm.Bold.Sprintf("$ zarf package inspect %s", p.cfg.PkgOpts.PackageSource)))
 
-				artifactMsg := pterm.Bold.Sprintf("%d artifacts", len(p.sbomViewFiles)) + " to be reviewed. These are"
-				if len(p.sbomViewFiles) == 1 {
-					artifactMsg = pterm.Bold.Sprintf("%d artifact", len(p.sbomViewFiles)) + " to be reviewed. This is"
+				artifactMsg := pterm.Bold.Sprintf("%d artifacts", len(sbomViewFiles)) + " to be reviewed. These are"
+				if len(sbomViewFiles) == 1 {
+					artifactMsg = pterm.Bold.Sprintf("%d artifact", len(sbomViewFiles)) + " to be reviewed. This is"
 				}
 
 				msg := fmt.Sprintf("This package has %s available in a temporary '%s' folder in this directory and will be removed upon deployment.\n", artifactMsg, pterm.Bold.Sprint("zarf-sbom"))

--- a/src/pkg/packager/mirror.go
+++ b/src/pkg/packager/mirror.go
@@ -33,11 +33,10 @@ func (p *Packager) Mirror(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	p.sbomViewFiles = sbomViewFiles
 	warnings = append(warnings, sbomWarnings...)
 
 	// Confirm the overall package mirror
-	if !p.confirmAction(config.ZarfMirrorStage, warnings) {
+	if !p.confirmAction(config.ZarfMirrorStage, warnings, sbomViewFiles) {
 		return fmt.Errorf("mirror cancelled")
 	}
 


### PR DESCRIPTION
## Description

Removes the sbom view fiels struct property.

## Related Issue

Part of #2694 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
