### PR TITLE
refactor: move lint logic from pacakger to command

### DIFF
--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -6,10 +6,8 @@ package packager
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
@@ -18,10 +16,7 @@ import (
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/packager/creator"
 	"github.com/defenseunicorns/zarf/src/pkg/packager/filters"
-	"github.com/defenseunicorns/zarf/src/pkg/packager/lint"
-	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/defenseunicorns/zarf/src/types"
-	"github.com/fatih/color"
 )
 
 // DevDeploy creates + deploys a package in one shot
@@ -109,70 +104,4 @@ func (p *Packager) DevDeploy(ctx context.Context) error {
 
 	// cd back
 	return os.Chdir(cwd)
-}
-
-// Lint ensures a package is valid & follows suggested conventions
-func (p *Packager) Lint(ctx context.Context) error {
-	if err := os.Chdir(p.cfg.CreateOpts.BaseDir); err != nil {
-		return fmt.Errorf("unable to access directory %q: %w", p.cfg.CreateOpts.BaseDir, err)
-	}
-
-	if err := utils.ReadYaml(layout.ZarfYAML, &p.cfg.Pkg); err != nil {
-		return err
-	}
-
-	findings, err := lint.Validate(ctx, p.cfg.Pkg, p.cfg.CreateOpts)
-	if err != nil {
-		return fmt.Errorf("linting failed: %w", err)
-	}
-
-	if len(findings) == 0 {
-		message.Successf("0 findings for %q", p.cfg.Pkg.Metadata.Name)
-		return nil
-	}
-
-	mapOfFindingsByPath := lint.GroupFindingsByPath(findings, types.SevWarn, p.cfg.Pkg.Metadata.Name)
-
-	header := []string{"Type", "Path", "Message"}
-
-	for _, findings := range mapOfFindingsByPath {
-		lintData := [][]string{}
-		for _, finding := range findings {
-			lintData = append(lintData, []string{
-				colorWrapSev(finding.Severity),
-				message.ColorWrap(finding.YqPath, color.FgCyan),
-				itemizedDescription(finding.Description, finding.Item),
-			})
-		}
-		var packagePathFromUser string
-		if helpers.IsOCIURL(findings[0].PackagePathOverride) {
-			packagePathFromUser = findings[0].PackagePathOverride
-		} else {
-			packagePathFromUser = filepath.Join(p.cfg.CreateOpts.BaseDir, findings[0].PackagePathOverride)
-		}
-		message.Notef("Linting package %q at %s", findings[0].PackageNameOverride, packagePathFromUser)
-		message.Table(header, lintData)
-	}
-
-	if lint.HasSeverity(findings, types.SevErr) {
-		return errors.New("errors during lint")
-	}
-
-	return nil
-}
-
-func itemizedDescription(description string, item string) string {
-	if item == "" {
-		return description
-	}
-	return fmt.Sprintf("%s - %s", description, item)
-}
-
-func colorWrapSev(s types.Severity) string {
-	if s == types.SevErr {
-		return message.ColorWrap("Error", color.FgRed)
-	} else if s == types.SevWarn {
-		return message.ColorWrap("Warning", color.FgYellow)
-	}
-	return "unknown"
 }

--- a/src/pkg/packager/lint/lint_test.go
+++ b/src/pkg/packager/lint/lint_test.go
@@ -11,10 +11,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/defenseunicorns/zarf/src/pkg/variables"
-	"github.com/defenseunicorns/zarf/src/types"
 	goyaml "github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/require"
+
+	"github.com/defenseunicorns/zarf/src/pkg/variables"
+	"github.com/defenseunicorns/zarf/src/types"
 )
 
 func TestZarfSchema(t *testing.T) {
@@ -296,8 +297,7 @@ func TestValidateComponent(t *testing.T) {
 			Metadata: types.ZarfMetadata{Name: "test-zarf-package"},
 		}
 
-		createOpts := types.ZarfCreateOptions{Flavor: "", BaseDir: "."}
-		_, err := lintComponents(context.Background(), zarfPackage, createOpts)
+		_, err := lintComponents(context.Background(), zarfPackage, nil, "")
 		require.Error(t, err)
 	})
 


### PR DESCRIPTION
## Description

This moves the CLI specific lint logic out of the packager and into the command instead. This means that you do not need a packager instance to do the linting. Additionally this removes the use of os.Chdir for the linter.

Doing this reduces the complexity as the linter logic does not need to know about all other packager related logic which currently exists.

## Related Issue

Relates to #2694

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
