### PR TITLE
fix: remove ignore label when adopting resource

### DIFF
--- a/src/pkg/cluster/namespace.go
+++ b/src/pkg/cluster/namespace.go
@@ -67,5 +67,6 @@ func AdoptZarfManagedLabels(labels map[string]string) map[string]string {
 		labels = make(map[string]string)
 	}
 	labels[ZarfManagedByLabel] = "zarf"
+	delete(labels, AgentLabel)
 	return labels
 }

--- a/src/pkg/cluster/namespace_test.go
+++ b/src/pkg/cluster/namespace_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdoptZarfManagedLabels(t *testing.T) {
+	t.Parallel()
+
+	labels := map[string]string{
+		"foo":      "bar",
+		AgentLabel: "ignore",
+	}
+	adoptedLabels := AdoptZarfManagedLabels(labels)
+	expectedLabels := map[string]string{
+		"foo":              "bar",
+		ZarfManagedByLabel: "zarf",
+	}
+	require.Equal(t, expectedLabels, adoptedLabels)
+}


### PR DESCRIPTION
## Description

The changes in #2494 were added to keep existing labels when adopting resources. This however missed that an ignore label could exist on a namespace, which was never removed. This change fixes the adopting labels to remove any ignore label if it exists.

## Related Issue

Fixes #2693 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
