### PR TITLE
refactor: remove unused message functions and verbose logging

### DIFF
--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -23,6 +23,8 @@ import (
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/defenseunicorns/zarf/src/types"
 	"github.com/mholt/archiver/v3"
+	"github.com/pterm/pterm"
+	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -110,7 +112,10 @@ var devTransformGitLinksCmd = &cobra.Command{
 		processedText := transform.MutateGitURLsInText(message.Warnf, pkgConfig.InitOpts.GitServer.Address, text, pkgConfig.InitOpts.GitServer.PushUsername)
 
 		// Print the differences
-		message.PrintDiff(text, processedText)
+		dmp := diffmatchpatch.New()
+		diffs := dmp.DiffMain(text, processedText, true)
+		diffs = dmp.DiffCleanupSemantic(diffs)
+		pterm.Println(dmp.DiffPrettyText(diffs))
 
 		// Ask the user before this destructive action
 		confirm := false

--- a/src/internal/agent/hooks/argocd-application.go
+++ b/src/internal/agent/hooks/argocd-application.go
@@ -48,7 +48,6 @@ type ApplicationSource struct {
 
 // NewApplicationMutationHook creates a new instance of the ArgoCD Application mutation hook.
 func NewApplicationMutationHook(ctx context.Context, cluster *cluster.Cluster) operations.Hook {
-	message.Debug("hooks.NewApplicationMutationHook()")
 	return operations.Hook{
 		Create: func(r *v1.AdmissionRequest) (*operations.Result, error) {
 			return mutateApplication(ctx, r, cluster)

--- a/src/internal/agent/hooks/argocd-repository.go
+++ b/src/internal/agent/hooks/argocd-repository.go
@@ -36,7 +36,6 @@ type RepoCreds struct {
 
 // NewRepositorySecretMutationHook creates a new instance of the ArgoCD repository secret mutation hook.
 func NewRepositorySecretMutationHook(ctx context.Context, cluster *cluster.Cluster) operations.Hook {
-	message.Debug("hooks.NewRepositoryMutationHook()")
 	return operations.Hook{
 		Create: func(r *v1.AdmissionRequest) (*operations.Result, error) {
 			return mutateRepositorySecret(ctx, r, cluster)

--- a/src/internal/agent/hooks/flux-gitrepo.go
+++ b/src/internal/agent/hooks/flux-gitrepo.go
@@ -26,7 +26,6 @@ const AgentErrTransformGitURL = "unable to transform the git url"
 
 // NewGitRepositoryMutationHook creates a new instance of the git repo mutation hook.
 func NewGitRepositoryMutationHook(ctx context.Context, cluster *cluster.Cluster) operations.Hook {
-	message.Debug("hooks.NewGitRepositoryMutationHook()")
 	return operations.Hook{
 		Create: func(r *v1.AdmissionRequest) (*operations.Result, error) {
 			return mutateGitRepo(ctx, r, cluster)

--- a/src/internal/agent/hooks/flux-helmrepo.go
+++ b/src/internal/agent/hooks/flux-helmrepo.go
@@ -24,7 +24,6 @@ import (
 
 // NewHelmRepositoryMutationHook creates a new instance of the helm repo mutation hook.
 func NewHelmRepositoryMutationHook(ctx context.Context, cluster *cluster.Cluster) operations.Hook {
-	message.Debug("hooks.NewHelmRepositoryMutationHook()")
 	return operations.Hook{
 		Create: func(r *v1.AdmissionRequest) (*operations.Result, error) {
 			return mutateHelmRepo(ctx, r, cluster)

--- a/src/internal/agent/hooks/flux-ocirepo.go
+++ b/src/internal/agent/hooks/flux-ocirepo.go
@@ -23,7 +23,6 @@ import (
 
 // NewOCIRepositoryMutationHook creates a new instance of the oci repo mutation hook.
 func NewOCIRepositoryMutationHook(ctx context.Context, cluster *cluster.Cluster) operations.Hook {
-	message.Debug("hooks.NewOCIRepositoryMutationHook()")
 	return operations.Hook{
 		Create: func(r *v1.AdmissionRequest) (*operations.Result, error) {
 			return mutateOCIRepo(ctx, r, cluster)

--- a/src/internal/agent/hooks/pods.go
+++ b/src/internal/agent/hooks/pods.go
@@ -22,7 +22,6 @@ import (
 
 // NewPodMutationHook creates a new instance of pods mutation hook.
 func NewPodMutationHook(ctx context.Context, cluster *cluster.Cluster) operations.Hook {
-	message.Debug("hooks.NewMutationHook()")
 	return operations.Hook{
 		Create: func(r *v1.AdmissionRequest) (*operations.Result, error) {
 			return mutatePod(ctx, r, cluster)
@@ -34,7 +33,6 @@ func NewPodMutationHook(ctx context.Context, cluster *cluster.Cluster) operation
 }
 
 func parsePod(object []byte) (*corev1.Pod, error) {
-	message.Debugf("pods.parsePod(%s)", string(object))
 	var pod corev1.Pod
 	if err := json.Unmarshal(object, &pod); err != nil {
 		return nil, err
@@ -43,8 +41,6 @@ func parsePod(object []byte) (*corev1.Pod, error) {
 }
 
 func mutatePod(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster.Cluster) (*operations.Result, error) {
-	message.Debugf("hooks.mutatePod()(*v1.AdmissionRequest) - %#v , %s/%s: %#v", r.Kind, r.Namespace, r.Name, r.Operation)
-
 	pod, err := parsePod(r.Object.Raw)
 	if err != nil {
 		return nil, fmt.Errorf(lang.AgentErrParsePod, err)

--- a/src/internal/agent/http/admission/handler.go
+++ b/src/internal/agent/http/admission/handler.go
@@ -35,10 +35,7 @@ func NewHandler() *Handler {
 
 // Serve returns an http.HandlerFunc for an admission webhook.
 func (h *Handler) Serve(hook operations.Hook) http.HandlerFunc {
-	message.Debugf("http.Serve(%#v)", hook)
 	return func(w http.ResponseWriter, r *http.Request) {
-		message.Debugf("http.Serve()(writer, %#v)", r.URL)
-
 		w.Header().Set("Content-Type", "application/json")
 		if r.Method != http.MethodPost {
 			http.Error(w, lang.AgentErrInvalidMethod, http.StatusMethodNotAllowed)

--- a/src/internal/agent/start.go
+++ b/src/internal/agent/start.go
@@ -29,7 +29,6 @@ const (
 
 // StartWebhook launches the Zarf agent mutating webhook in the cluster.
 func StartWebhook(ctx context.Context) error {
-	message.Debug("agent.StartWebhook()")
 	srv, err := agentHttp.NewAdmissionServer(ctx, httpPort)
 	if err != nil {
 		return err
@@ -39,7 +38,6 @@ func StartWebhook(ctx context.Context) error {
 
 // StartHTTPProxy launches the zarf agent proxy in the cluster.
 func StartHTTPProxy(ctx context.Context) error {
-	message.Debug("agent.StartHttpProxy()")
 	return startServer(ctx, agentHttp.NewProxyServer(httpPort))
 }
 

--- a/src/pkg/cluster/data.go
+++ b/src/pkg/cluster/data.go
@@ -6,6 +6,7 @@ package cluster
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,8 +47,12 @@ func (c *Cluster) HandleDataInjection(ctx context.Context, wg *sync.WaitGroup, d
 
 	// Pod filter to ensure we only use the current deployment's pods
 	podFilterByInitContainer := func(pod corev1.Pod) bool {
+		b, err := json.Marshal(pod)
+		if err != nil {
+			return false
+		}
 		// Look everywhere in the pod for a matching data injection marker
-		return strings.Contains(message.JSONValue(pod), config.GetDataInjectionMarker())
+		return strings.Contains(string(b), config.GetDataInjectionMarker())
 	}
 
 	// Get the OS shell to execute commands in

--- a/src/pkg/cluster/secrets.go
+++ b/src/pkg/cluster/secrets.go
@@ -89,8 +89,6 @@ func (c *Cluster) GenerateRegistryPullCreds(ctx context.Context, namespace, name
 
 // GenerateGitPullCreds generates a secret containing the git credentials.
 func (c *Cluster) GenerateGitPullCreds(namespace, name string, gitServerInfo types.GitServerInfo) *corev1.Secret {
-	message.Debugf("k8s.GenerateGitPullCreds(%s, %s, gitServerInfo)", namespace, name)
-
 	gitServerSecret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),

--- a/src/pkg/cluster/state.go
+++ b/src/pkg/cluster/state.go
@@ -250,7 +250,11 @@ func (c *Cluster) debugPrintZarfState(state *types.ZarfState) {
 	// this is a shallow copy, nested pointers WILL NOT be copied
 	oldState := *state
 	sanitized := c.sanitizeZarfState(&oldState)
-	message.Debugf("ZarfState - %s", message.JSONValue(sanitized))
+	b, err := json.MarshalIndent(sanitized, "", "  ")
+	if err != nil {
+		return
+	}
+	message.Debugf("ZarfState - %s", string(b))
 }
 
 // SaveZarfState takes a given state and persists it to the Zarf/zarf-state secret.

--- a/src/pkg/message/connect.go
+++ b/src/pkg/message/connect.go
@@ -12,8 +12,6 @@ import (
 
 // PrintConnectStringTable prints a table of connect strings.
 func PrintConnectStringTable(connectStrings types.ConnectStrings) {
-	Debugf("message.PrintConnectStringTable(%#v)", connectStrings)
-
 	if len(connectStrings) > 0 {
 		connectData := [][]string{}
 		// Loop over each connectStrings and convert to a string matrix

--- a/src/pkg/message/message.go
+++ b/src/pkg/message/message.go
@@ -5,10 +5,8 @@
 package message
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -17,7 +15,6 @@ import (
 	"github.com/defenseunicorns/zarf/src/config"
 	"github.com/fatih/color"
 	"github.com/pterm/pterm"
-	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
 // LogLevel is the level of logging to display.
@@ -97,11 +94,6 @@ func SetLogLevel(lvl LogLevel) {
 	}
 }
 
-// GetLogLevel returns the current log level.
-func GetLogLevel() LogLevel {
-	return logLevel
-}
-
 // DisableColor disables color in output
 func DisableColor() {
 	pterm.DisableColor()
@@ -127,14 +119,6 @@ func Debug(payload ...any) {
 func Debugf(format string, a ...any) {
 	message := fmt.Sprintf(format, a...)
 	debugPrinter(2, message)
-}
-
-// ErrorWebf prints an error message and returns a web response.
-func ErrorWebf(err any, w http.ResponseWriter, format string, a ...any) {
-	debugPrinter(2, err)
-	message := fmt.Sprintf(format, a...)
-	Warn(message)
-	http.Error(w, message, http.StatusInternalServerError)
 }
 
 // Warn prints a warning message.
@@ -242,15 +226,6 @@ func HorizontalRule() {
 	pterm.Println(RuleLine)
 }
 
-// JSONValue prints any value as JSON.
-func JSONValue(value any) string {
-	bytes, err := json.MarshalIndent(value, "", "  ")
-	if err != nil {
-		debugPrinter(2, fmt.Sprintf("ERROR marshalling json: %s", err.Error()))
-	}
-	return string(bytes)
-}
-
 // Paragraph formats text into a paragraph matching the TermWidth
 func Paragraph(format string, a ...any) string {
 	return Paragraphn(TermWidth, format, a...)
@@ -267,17 +242,6 @@ func Paragraphn(n int, format string, a ...any) string {
 	}
 
 	return strings.Join(formattedLines, "\n")
-}
-
-// PrintDiff prints the differences between a and b with a as original and b as new
-func PrintDiff(textA, textB string) {
-	dmp := diffmatchpatch.New()
-
-	diffs := dmp.DiffMain(textA, textB, true)
-
-	diffs = dmp.DiffCleanupSemantic(diffs)
-
-	pterm.Println(dmp.DiffPrettyText(diffs))
 }
 
 // Table prints a padded table containing the specified header and data

--- a/src/pkg/utils/cosign.go
+++ b/src/pkg/utils/cosign.go
@@ -50,8 +50,6 @@ func Sget(ctx context.Context, image, key string, out io.Writer) error {
 	// Remove the custom protocol header from the url
 	image = strings.TrimPrefix(image, helpers.SGETURLPrefix)
 
-	message.Debugf("utils.Sget: image=%s, key=%s", image, key)
-
 	spinner := message.NewProgressSpinner("Loading signed file %s", image)
 	defer spinner.Stop()
 

--- a/src/pkg/utils/io.go
+++ b/src/pkg/utils/io.go
@@ -42,8 +42,6 @@ func MakeTempDir(basePath string) (string, error) {
 
 // GetFinalExecutablePath returns the absolute path to the current executable, following any symlinks along the way.
 func GetFinalExecutablePath() (string, error) {
-	message.Debug("utils.GetExecutablePath()")
-
 	binaryPath, err := os.Executable()
 	if err != nil {
 		return "", err

--- a/src/pkg/utils/yaml.go
+++ b/src/pkg/utils/yaml.go
@@ -124,8 +124,6 @@ func AddRootHint(hints map[string]string, rootKey string, hintText string) map[s
 
 // ReadYaml reads a yaml file and unmarshals it into a given config.
 func ReadYaml(path string, destConfig any) error {
-	message.Debugf("Reading YAML at %s", path)
-
 	file, err := os.ReadFile(path)
 	if err != nil {
 		return err

--- a/src/test/e2e/05_tarball_test.go
+++ b/src/test/e2e/05_tarball_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/zarf/src/pkg/layout"
-	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/defenseunicorns/zarf/src/types"
 	"github.com/stretchr/testify/require"
@@ -98,10 +97,6 @@ func TestReproducibleTarballs(t *testing.T) {
 	err = utils.ReadYaml(filepath.Join(unpack1, layout.ZarfYAML), &pkg1)
 	require.NoError(t, err)
 
-	b, err := os.ReadFile(filepath.Join(unpack1, layout.Checksums))
-	require.NoError(t, err)
-	checksums1 := string(b)
-
 	e2e.CleanFiles(unpack1, tb)
 
 	stdOut, stdErr, err = e2e.Zarf("package", "create", createPath, "--confirm", "--output", tmp)
@@ -113,12 +108,6 @@ func TestReproducibleTarballs(t *testing.T) {
 	var pkg2 types.ZarfPackage
 	err = utils.ReadYaml(filepath.Join(unpack2, layout.ZarfYAML), &pkg2)
 	require.NoError(t, err)
-
-	b, err = os.ReadFile(filepath.Join(unpack2, layout.Checksums))
-	require.NoError(t, err)
-	checksums2 := string(b)
-
-	message.PrintDiff(checksums1, checksums2)
 
 	require.Equal(t, pkg1.Metadata.AggregateChecksum, pkg2.Metadata.AggregateChecksum)
 }


### PR DESCRIPTION
## Description

This change removes unused functions in message. It also moves some of the logic out of message because it is the wrong place to live. Additionally I have removed some debug logs which are basically used as tracing. 

## Related Issue

Relates to #2588 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
