### PR TITLE
refactor: compile local cluster service format regexp just once

### DIFF
--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -38,6 +38,11 @@ import (
 	"github.com/defenseunicorns/zarf/src/types"
 )
 
+var (
+	// localClusterServiceRegex is used to match the local cluster service format:
+	localClusterServiceRegex = regexp.MustCompile(`^(?P<name>[^\.]+)\.(?P<namespace>[^\.]+)\.svc\.cluster\.local$`)
+)
+
 func (p *Packager) resetRegistryHPA(ctx context.Context) {
 	if p.isConnectedToCluster() && p.hpaModified {
 		if err := p.cluster.EnableRegHPAScaleDown(ctx); err != nil {
@@ -742,11 +747,7 @@ func serviceInfoFromServiceURL(serviceURL string) (string, string, int, error) {
 	}
 
 	// Match hostname against local cluster service format.
-	pattern, err := regexp.Compile(`^(?P<name>[^\.]+)\.(?P<namespace>[^\.]+)\.svc\.cluster\.local$`)
-	if err != nil {
-		return "", "", 0, err
-	}
-	get, err := helpers.MatchRegex(pattern, parsedURL.Hostname())
+	get, err := helpers.MatchRegex(localClusterServiceRegex, parsedURL.Hostname())
 
 	// If incomplete match, return an error.
 	if err != nil {


### PR DESCRIPTION
## Description

This change ensures the local cluster service format regexp is compiled just once on program's startup.

I believe similar cases might be found and improved across the codebase.

## Related Issue

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
